### PR TITLE
feat: use generated DAO declarations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 
 # generated files
 **/declarations/
+!src/dao_frontend/src/declarations/
+!src/dao_frontend/src/declarations/**
 
 # rust
 target/

--- a/src/dao_frontend/src/declarations/dao_backend/dao_backend.did.js
+++ b/src/dao_frontend/src/declarations/dao_backend/dao_backend.did.js
@@ -1,0 +1,28 @@
+export const idlFactory = ({ IDL }) => {
+  const Result = IDL.Variant({ ok: IDL.Null, err: IDL.Text });
+  const DAOInfo = IDL.Record({
+    name: IDL.Text,
+    description: IDL.Text,
+    totalMembers: IDL.Nat,
+    initialized: IDL.Bool,
+  });
+  return IDL.Service({
+    initialize: IDL.Func(
+      [IDL.Text, IDL.Text, IDL.Vec(IDL.Principal)],
+      [Result],
+      []
+    ),
+    setCanisterReferences: IDL.Func(
+      [IDL.Principal, IDL.Principal, IDL.Principal, IDL.Principal],
+      [Result],
+      []
+    ),
+    registerUser: IDL.Func([IDL.Text, IDL.Text], [Result], []),
+    getDAOInfo: IDL.Func([], [DAOInfo], ['query']),
+  });
+};
+
+export const init = ({ IDL }) => {
+  return [];
+};
+

--- a/src/dao_frontend/src/declarations/dao_backend/index.js
+++ b/src/dao_frontend/src/declarations/dao_backend/index.js
@@ -1,0 +1,2 @@
+export { idlFactory } from './dao_backend.did.js';
+

--- a/src/dao_frontend/src/declarations/governance/governance.did.js
+++ b/src/dao_frontend/src/declarations/governance/governance.did.js
@@ -1,0 +1,8 @@
+export const idlFactory = ({ IDL }) => {
+  return IDL.Service({});
+};
+
+export const init = ({ IDL }) => {
+  return [];
+};
+

--- a/src/dao_frontend/src/declarations/governance/index.js
+++ b/src/dao_frontend/src/declarations/governance/index.js
@@ -1,0 +1,2 @@
+export { idlFactory } from './governance.did.js';
+


### PR DESCRIPTION
## Summary
- import IDL factories from generated declarations
- add minimal candid IDL for DAO backend and governance canisters
- allow committing generated declarations

## Testing
- `npm test` *(fails: sh: 1: dfx: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ebdcd7a088320a7bb9dd21b6a760a