### PR TITLE
Use Array.size for proposal limit checks

### DIFF
--- a/src/dao_backend/governance/main.mo
+++ b/src/dao_backend/governance/main.mo
@@ -1,5 +1,5 @@
 import HashMap "mo:base/HashMap";
-// import Array "mo:base/Array";
+import Array "mo:base/Array";
 import Iter "mo:base/Iter";
 import Time "mo:base/Time";
 import Result "mo:base/Result";
@@ -99,7 +99,7 @@ actor GovernanceCanister {
             case null return #err("Configuration not found");
         };
         
-        if (activeProposals.size() >= currentConfig.maxProposalsPerUser) {
+        if (Array.size(activeProposals) >= currentConfig.maxProposalsPerUser) {
             return #err("Maximum active proposals limit reached");
         };
 

--- a/src/dao_backend/proposals/main.mo
+++ b/src/dao_backend/proposals/main.mo
@@ -182,7 +182,7 @@ actor ProposalsCanister {
             case null return #err("Configuration not found");
         };
         
-        if (activeProposals.size() >= currentConfig.maxProposalsPerUser) {
+        if (Array.size(activeProposals) >= currentConfig.maxProposalsPerUser) {
             return #err("Maximum active proposals limit reached");
         };
 


### PR DESCRIPTION
## Summary
- Replace uses of `activeProposals.size()` with `Array.size(activeProposals)` in governance and proposals canisters
- Import `Array` module where needed

## Testing
- `npm test` *(fails: dfx not found)*
- `dfx build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ebe9d4d488320b5d0a4fbadab2bdd