### PR TITLE
Use Vite env vars for canister IDs and drop process polyfill

### DIFF
--- a/src/dao_frontend/src/main.jsx
+++ b/src/dao_frontend/src/main.jsx
@@ -1,4 +1,3 @@
-import './polyfills'
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'

--- a/src/dao_frontend/src/polyfills.js
+++ b/src/dao_frontend/src/polyfills.js
@@ -1,6 +1,0 @@
-if (typeof window !== 'undefined') {
-    window.global = window;
-    window.process = {
-        env: { NODE_ENV: process.env.NODE_ENV }
-    };
-}


### PR DESCRIPTION
## Summary
- validate canister IDs from Vite env vars before converting to `Principal`
- deduplicate creator principal when launching DAO
- remove unused process env polyfill

## Testing
- `npm test` *(fails: dfx: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ec06c13188320b950485ddcebf76b