### PR TITLE
Persist launch form configuration

### DIFF
--- a/src/dao_backend/main.mo
+++ b/src/dao_backend/main.mo
@@ -19,6 +19,7 @@ actor DAOMain {
     type TokenAmount = Types.TokenAmount;
     type UserProfile = Types.UserProfile;
     type DAOStats = Types.DAOStats;
+    type DAOConfig = Types.DAOConfig;
 
     // Stable storage for upgrades
     private stable var initialized : Bool = false;
@@ -27,6 +28,7 @@ actor DAOMain {
     private stable var totalMembers : Nat = 0;
     private stable var userProfilesEntries : [(Principal, UserProfile)] = [];
     private stable var adminPrincipalsEntries : [Principal] = [];
+    private stable var daoConfig : ?DAOConfig = null;
 
     // Runtime storage
     private var userProfiles = HashMap.HashMap<Principal, UserProfile>(100, Principal.equal, Principal.hash);
@@ -103,6 +105,16 @@ actor DAOMain {
         #ok()
     };
 
+    // DAO configuration
+    public shared(msg) func setDAOConfig(config: DAOConfig) : async Result<(), Text> {
+        if (not isAdmin(msg.caller)) {
+            return #err("Only admins can set DAO configuration");
+        };
+        daoConfig := ?config;
+        Debug.print("DAO configuration saved");
+        #ok()
+    };
+
     // User management
     public shared(msg) func registerUser(displayName: Text, bio: Text) : async Result<(), Text> {
         let caller = msg.caller;
@@ -163,6 +175,10 @@ actor DAOMain {
             totalMembers = totalMembers;
             initialized = initialized;
         }
+    };
+
+    public query func getDAOConfig() : async ?DAOConfig {
+        daoConfig
     };
 
     public query func getUserProfile(userId: Principal) : async ?UserProfile {

--- a/src/dao_backend/shared/types.mo
+++ b/src/dao_backend/shared/types.mo
@@ -23,6 +23,31 @@ module {
         votingPower: Nat;
     };
 
+    // DAO configuration types
+    public type ModuleFeature = {
+        moduleId: Text;
+        features: [Text];
+    };
+
+    public type DAOConfig = {
+        category: Text;
+        website: Text;
+        selectedModules: [Text];
+        moduleFeatures: [ModuleFeature];
+        tokenName: Text;
+        tokenSymbol: Text;
+        totalSupply: Nat;
+        initialPrice: Nat;
+        votingPeriod: Nat;
+        quorumThreshold: Nat;
+        proposalThreshold: Nat;
+        fundingGoal: Nat;
+        fundingDuration: Nat;
+        minInvestment: Nat;
+        termsAccepted: Bool;
+        kycRequired: Bool;
+    };
+
     // Token and Balance types
     public type TokenAmount = Nat;
     public type Balance = Nat;

--- a/src/dao_frontend/src/declarations/dao_backend/dao_backend.did.js
+++ b/src/dao_frontend/src/declarations/dao_backend/dao_backend.did.js
@@ -1,5 +1,27 @@
 export const idlFactory = ({ IDL }) => {
   const Result = IDL.Variant({ ok: IDL.Null, err: IDL.Text });
+  const ModuleFeature = IDL.Record({
+    moduleId: IDL.Text,
+    features: IDL.Vec(IDL.Text),
+  });
+  const DAOConfig = IDL.Record({
+    category: IDL.Text,
+    website: IDL.Text,
+    selectedModules: IDL.Vec(IDL.Text),
+    moduleFeatures: IDL.Vec(ModuleFeature),
+    tokenName: IDL.Text,
+    tokenSymbol: IDL.Text,
+    totalSupply: IDL.Nat,
+    initialPrice: IDL.Nat,
+    votingPeriod: IDL.Nat,
+    quorumThreshold: IDL.Nat,
+    proposalThreshold: IDL.Nat,
+    fundingGoal: IDL.Nat,
+    fundingDuration: IDL.Nat,
+    minInvestment: IDL.Nat,
+    termsAccepted: IDL.Bool,
+    kycRequired: IDL.Bool,
+  });
   const DAOInfo = IDL.Record({
     name: IDL.Text,
     description: IDL.Text,
@@ -18,7 +40,9 @@ export const idlFactory = ({ IDL }) => {
       []
     ),
     registerUser: IDL.Func([IDL.Text, IDL.Text], [Result], []),
+    setDAOConfig: IDL.Func([DAOConfig], [Result], []),
     getDAOInfo: IDL.Func([], [DAOInfo], ['query']),
+    getDAOConfig: IDL.Func([], [IDL.Opt(DAOConfig)], ['query']),
   });
 };
 

--- a/src/dao_frontend/src/hooks/useDAOOperations.js
+++ b/src/dao_frontend/src/hooks/useDAOOperations.js
@@ -104,7 +104,34 @@ export const useDAOOperations = () => {
                 }
             }
 
-            // Step 4: Return the DAO info
+            // Step 4: Save DAO configuration
+            const configPayload = {
+                category: daoConfig.category,
+                website: daoConfig.website,
+                selectedModules: daoConfig.selectedModules,
+                moduleFeatures: Object.entries(daoConfig.selectedFeatures || {}).map(
+                    ([moduleId, features]) => ({ moduleId, features })
+                ),
+                tokenName: daoConfig.tokenName,
+                tokenSymbol: daoConfig.tokenSymbol,
+                totalSupply: BigInt(daoConfig.totalSupply || 0),
+                initialPrice: BigInt(daoConfig.initialPrice || 0),
+                votingPeriod: BigInt(daoConfig.votingPeriod || 0),
+                quorumThreshold: BigInt(daoConfig.quorumThreshold || 0),
+                proposalThreshold: BigInt(daoConfig.proposalThreshold || 0),
+                fundingGoal: BigInt(daoConfig.fundingGoal || 0),
+                fundingDuration: BigInt(daoConfig.fundingDuration || 0),
+                minInvestment: BigInt(daoConfig.minInvestment || 0),
+                termsAccepted: daoConfig.termsAccepted,
+                kycRequired: daoConfig.kycRequired
+            };
+
+            const configResult = await actors.daoBackend.setDAOConfig(configPayload);
+            if ('err' in configResult) {
+                throw new Error(configResult.err);
+            }
+
+            // Step 5: Return the DAO info
             const daoInfo = await actors.daoBackend.getDAOInfo();
             return daoInfo;
 


### PR DESCRIPTION
## Summary
- Store comprehensive DAO configuration in backend via new `setDAOConfig` and `getDAOConfig` APIs
- Send all launch form fields from `useDAOOperations.launchDAO` to backend
- Describe DAO config structures for generated actor declarations

## Testing
- `npm test` *(fails: dfx not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ec378f014832086ff341d3dbea23f