### PR TITLE
feat: add governance hook and page

### DIFF
--- a/src/dao_frontend/src/App.jsx
+++ b/src/dao_frontend/src/App.jsx
@@ -1,6 +1,3 @@
-// import { dao_backend } from 'declarations/dao_backend';
-
-
 import React, { useState, useEffect } from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { AuthClient } from '@dfinity/auth-client';
@@ -12,12 +9,13 @@ import Settings from './components/Settings';
 import Proposals from './components/Proposals';
 import Staking from './components/Staking';
 import Treasury from './components/Treasury';
+import Governance from './components/Governance';
 import Navbar from './components/Navbar';
 import { AuthProvider } from './context/AuthContext';
 import './app.css';
 
 function App() {
-  
+
   return (
     <AuthProvider>
       <Router>
@@ -32,6 +30,7 @@ function App() {
             <Route path="/proposals" element={<Proposals />} />
             <Route path="/staking" element={<Staking />} />
             <Route path="/treasury" element={<Treasury />} />
+            <Route path="/governance" element={<Governance />} />
           </Routes>
         </div>
       </Router>

--- a/src/dao_frontend/src/components/Governance.jsx
+++ b/src/dao_frontend/src/components/Governance.jsx
@@ -1,0 +1,121 @@
+import React, { useState, useEffect } from 'react';
+import { useGovernance } from '../hooks/useGovernance';
+
+const Governance = () => {
+  const { createProposal, vote, getConfig, getStats, loading, error } = useGovernance();
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [proposalId, setProposalId] = useState('');
+  const [choice, setChoice] = useState('inFavor');
+  const [votingPower, setVotingPower] = useState('');
+  const [reason, setReason] = useState('');
+  const [config, setConfig] = useState(null);
+  const [stats, setStats] = useState(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const cfg = await getConfig();
+        setConfig(cfg);
+        const st = await getStats();
+        setStats(st);
+      } catch (e) {
+        // error handled in hook
+      }
+    };
+    fetchData();
+  }, []);
+
+  const handleCreate = async (e) => {
+    e.preventDefault();
+    await createProposal(title, description);
+    setTitle('');
+    setDescription('');
+  };
+
+  const handleVote = async (e) => {
+    e.preventDefault();
+    await vote(proposalId, choice, votingPower, reason);
+    setProposalId('');
+    setVotingPower('');
+    setReason('');
+  };
+
+  return (
+    <div className="p-4 space-y-8">
+      <h1 className="text-2xl font-bold">Governance</h1>
+      {error && <p className="text-red-500">{error}</p>}
+      <form onSubmit={handleCreate} className="space-y-2">
+        <h2 className="text-xl font-semibold">Create Proposal</h2>
+        <input
+          className="border p-2 w-full"
+          placeholder="Title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+        <textarea
+          className="border p-2 w-full"
+          placeholder="Description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+        <button
+          type="submit"
+          className="bg-blue-500 text-white px-4 py-2 rounded"
+          disabled={loading}
+        >
+          Create
+        </button>
+      </form>
+
+      <form onSubmit={handleVote} className="space-y-2">
+        <h2 className="text-xl font-semibold">Vote on Proposal</h2>
+        <input
+          className="border p-2 w-full"
+          placeholder="Proposal ID"
+          value={proposalId}
+          onChange={(e) => setProposalId(e.target.value)}
+        />
+        <select
+          className="border p-2 w-full"
+          value={choice}
+          onChange={(e) => setChoice(e.target.value)}
+        >
+          <option value="inFavor">In Favor</option>
+          <option value="against">Against</option>
+          <option value="abstain">Abstain</option>
+        </select>
+        <input
+          className="border p-2 w-full"
+          placeholder="Voting Power"
+          value={votingPower}
+          onChange={(e) => setVotingPower(e.target.value)}
+        />
+        <input
+          className="border p-2 w-full"
+          placeholder="Reason (optional)"
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+        />
+        <button
+          type="submit"
+          className="bg-green-500 text-white px-4 py-2 rounded"
+          disabled={loading}
+        >
+          Vote
+        </button>
+      </form>
+
+      <div>
+        <h2 className="text-xl font-semibold">Configuration</h2>
+        <pre className="bg-gray-100 p-2 overflow-auto">{config ? JSON.stringify(config, null, 2) : 'No config'}</pre>
+      </div>
+      <div>
+        <h2 className="text-xl font-semibold">Stats</h2>
+        <pre className="bg-gray-100 p-2 overflow-auto">{stats ? JSON.stringify(stats, null, 2) : 'No stats'}</pre>
+      </div>
+    </div>
+  );
+};
+
+export default Governance;

--- a/src/dao_frontend/src/components/Navbar.jsx
+++ b/src/dao_frontend/src/components/Navbar.jsx
@@ -39,6 +39,7 @@ const Navbar = () => {
     { name: 'Proposals', href: '/proposals', icon: Star },
     { name: 'Staking', href: '/staking', icon: Award },
     { name: 'Treasury', href: '/treasury', icon: DollarSign },
+    { name: 'Governance', href: '/governance', icon: Shield },
   ];
 
   const isActive = (path) => location.pathname === path;

--- a/src/dao_frontend/src/hooks/useGovernance.js
+++ b/src/dao_frontend/src/hooks/useGovernance.js
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+import { useActors } from '../context/ActorContext';
+
+export const useGovernance = () => {
+  const actors = useActors();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const createProposal = async (title, description) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await actors.governance.createProposal(title, description);
+      return result;
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const vote = async (proposalId, choice, votingPower, reason) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const choiceVariant = { [choice]: null };
+      const res = await actors.governance.vote(
+        BigInt(proposalId),
+        choiceVariant,
+        BigInt(votingPower),
+        reason ? [reason] : []
+      );
+      return res;
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getConfig = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const cfg = await actors.governance.getConfig();
+      return cfg;
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getStats = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const stats = await actors.governance.getStats();
+      return stats;
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { createProposal, vote, getConfig, getStats, loading, error };
+};


### PR DESCRIPTION
## Summary
- add `useGovernance` hook for proposal, vote, config, and stat actions
- introduce `Governance` component and route to interact with governance features
- expose Governance navigation link in the navbar

## Testing
- `npm test` *(fails: dfx: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ec8c1ea288320b48328be93746f93