### PR TITLE
Fix team member registration loop in useDAOOperations hook

### DIFF
--- a/src/dao_frontend/src/hooks/useDAOOperations.js
+++ b/src/dao_frontend/src/hooks/useDAOOperations.js
@@ -98,17 +98,20 @@ export const useDAOOperations = () => {
             for (const member of daoConfig.teamMembers) {
                 if (member.wallet) {
                     try {
-
                         const memberPrincipal = Principal.fromText(member.wallet);
-                        await actors.daoBackend.adminRegisterUser(
+                        const registerMember = await actors.daoBackend.adminRegisterUser(
                             memberPrincipal,
-
-                        // Use principal.toString() as wallet address might be already a Principal
-                        const memberPrincipal = Principal.fromText(member.wallet);
-                        await actors.daoBackend.registerUser(
-
-
-
+                            member.name,
+                            member.role
+                        );
+                        if ('err' in registerMember) {
+                            console.warn(`Failed to register team member ${member.name}:`, registerMember.err);
+                        }
+                    } catch (err) {
+                        console.warn(`Invalid principal for team member ${member.name}:`, err);
+                    }
+                }
+            }
             // Step 4: Return the DAO info
             const daoInfo = await actors.daoBackend.getDAOInfo();
             return daoInfo;


### PR DESCRIPTION
## Summary
- complete team member registration loop, registering each wallet-holder once via `adminRegisterUser`
- clean up stray `registerUser` call and close all blocks

## Testing
- `npx eslint src/dao_frontend/src/hooks/useDAOOperations.js` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: dfx not found)*
- `npm run build` *(fails: dfx not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ec92a4ccc832083f674bc16367cd7