### PR TITLE
Add DAO configuration step after setting canister references

### DIFF
--- a/src/dao_frontend/src/hooks/useDAOOperations.js
+++ b/src/dao_frontend/src/hooks/useDAOOperations.js
@@ -80,8 +80,41 @@ export const useDAOOperations = () => {
                 throw new Error(canisterRefResult.err);
             }
 
+            // Step 3: Configure DAO settings
+            const moduleFeatures = Object.entries(daoConfig.selectedFeatures || {})
+                .map(([moduleId, features]) => ({
+                    moduleId,
+                    features: Object.entries(features)
+                        .filter(([_, selected]) => selected)
+                        .map(([featureId]) => featureId)
+                }))
+                .filter(mf => mf.features.length > 0);
 
-            // Step 3: Register initial users via admin method
+            const configResult = await actors.daoBackend.setDAOConfig({
+                category: daoConfig.category,
+                website: daoConfig.website,
+                selectedModules: daoConfig.selectedModules,
+                moduleFeatures,
+                tokenName: daoConfig.tokenName,
+                tokenSymbol: daoConfig.tokenSymbol,
+                totalSupply: BigInt(daoConfig.totalSupply || 0),
+                initialPrice: BigInt(daoConfig.initialPrice || 0),
+                votingPeriod: BigInt(daoConfig.votingPeriod || 0),
+                quorumThreshold: BigInt(daoConfig.quorumThreshold || 0),
+                proposalThreshold: BigInt(daoConfig.proposalThreshold || 0),
+                fundingGoal: BigInt(daoConfig.fundingGoal || 0),
+                fundingDuration: BigInt(daoConfig.fundingDuration || 0),
+                minInvestment: BigInt(daoConfig.minInvestment || 0),
+                termsAccepted: daoConfig.termsAccepted,
+                kycRequired: daoConfig.kycRequired
+            });
+
+            if ('err' in configResult) {
+                throw new Error(configResult.err);
+            }
+
+
+            // Step 4: Register initial users via admin method
             if (creatorPrincipal) {
                 const registerCreator = await actors.daoBackend.adminRegisterUser(
                     creatorPrincipal,
@@ -113,7 +146,7 @@ export const useDAOOperations = () => {
                     }
                 }
             }
-            // Step 4: Return the DAO info
+            // Step 5: Return the DAO info
             const daoInfo = await actors.daoBackend.getDAOInfo();
             return daoInfo;
 


### PR DESCRIPTION
## Summary
- After establishing canister references, configure the DAO via `setDAOConfig`
- Map frontend DAO settings to backend `DAOConfig` structure and handle backend errors

## Testing
- `npm test` *(fails: dfx: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ecc5a6eec8320bd0f19e4e5deaa8f