### PR TITLE
Pass identity to HttpAgent via context

### DIFF
--- a/src/dao_frontend/src/config/agent.ts
+++ b/src/dao_frontend/src/config/agent.ts
@@ -1,4 +1,5 @@
 import { Actor, ActorSubclass, HttpAgent } from "@dfinity/agent";
+import type { Identity } from "@dfinity/agent";
 import type { IDL } from "@dfinity/candid";
 import {
   idlFactory as daoBackendIdl,
@@ -44,13 +45,20 @@ if (typeof window !== "undefined") {
 
 const createActor = async <T>(
   canisterId: string,
-  idlFactory: IDL.InterfaceFactory
+  idlFactory: IDL.InterfaceFactory,
+  identity?: Identity
 ): Promise<ActorSubclass<T>> => {
   try {
     const agent = new HttpAgent({
       host: import.meta.env.VITE_HOST || "http://localhost:4943",
-      verifyQuerySignatures: false
+      verifyQuerySignatures: false,
+      identity,
     });
+
+    if (identity) {
+      const principal = await agent.getPrincipal();
+      console.log("HttpAgent principal:", principal.toString());
+    }
 
     // Only fetch the root key when we're in development
     if (import.meta.env.VITE_DFX_NETWORK !== "ic") {
@@ -70,27 +78,32 @@ const createActor = async <T>(
   }
 };
 
-export const initializeAgents = async () => {
+export const initializeAgents = async (identity?: Identity) => {
   try {
     const daoBackend = await createActor<DaoBackendService>(
       import.meta.env.VITE_CANISTER_ID_DAO_BACKEND,
-      daoBackendIdl
+      daoBackendIdl,
+      identity
     );
     const governance = await createActor<GovernanceService>(
       import.meta.env.VITE_CANISTER_ID_GOVERNANCE,
-      governanceIdl
+      governanceIdl,
+      identity
     );
     const proposals = await createActor<ProposalsService>(
       import.meta.env.VITE_CANISTER_ID_PROPOSALS,
-      proposalsIdl
+      proposalsIdl,
+      identity
     );
     const staking = await createActor<StakingService>(
       import.meta.env.VITE_CANISTER_ID_STAKING,
-      stakingIdl
+      stakingIdl,
+      identity
     );
     const treasury = await createActor<TreasuryService>(
       import.meta.env.VITE_CANISTER_ID_TREASURY,
-      treasuryIdl
+      treasuryIdl,
+      identity
     );
 
     return {

--- a/src/dao_frontend/src/context/ActorContext.tsx
+++ b/src/dao_frontend/src/context/ActorContext.tsx
@@ -6,6 +6,7 @@ import {
   ReactNode,
 } from "react";
 import { initializeAgents } from "../config/agent";
+import { useAuth } from "./AuthContext";
 
 type Actors = Awaited<ReturnType<typeof initializeAgents>>;
 
@@ -19,11 +20,13 @@ export const ActorProvider = ({ children }: ActorProviderProps) => {
   const [actors, setActors] = useState<Actors | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const { identity } = useAuth();
 
   useEffect(() => {
     const setup = async () => {
+      setLoading(true);
       try {
-        const initializedActors = await initializeAgents();
+        const initializedActors = await initializeAgents(identity ?? undefined);
         setActors(initializedActors);
       } catch (err) {
         console.error("Failed to initialize actors:", err);
@@ -33,7 +36,7 @@ export const ActorProvider = ({ children }: ActorProviderProps) => {
       }
     };
     setup();
-  }, []);
+  }, [identity]);
 
   if (loading) {
     return (
@@ -63,3 +66,4 @@ export const useActors = (): Actors => {
   }
   return context;
 };
+

--- a/src/dao_frontend/src/context/AuthContext.jsx
+++ b/src/dao_frontend/src/context/AuthContext.jsx
@@ -8,6 +8,7 @@ const AuthContext = createContext();
 export const AuthProvider = ({ children }) => {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [principal, setPrincipal] = useState(null);
+  const [identity, setIdentity] = useState(null);
   const [userSettings, setUserSettings] = useState({
     displayName: 'Anonymous User'
   });
@@ -27,9 +28,10 @@ export const AuthProvider = ({ children }) => {
         if (isAuthenticated) {
           const identity = client.getIdentity();
           const principalId = identity.getPrincipal().toString();
-          
+
           setIsAuthenticated(true);
           setPrincipal(principalId);
+          setIdentity(identity);
           setUserSettings({
             displayName: `User ${principalId.slice(0, 8)}`
           });
@@ -63,9 +65,10 @@ export const AuthProvider = ({ children }) => {
           const identity = authClient.getIdentity();
           const principal = identity.getPrincipal();
           const principalId = principal.toString();
-          
+
           setIsAuthenticated(true);
           setPrincipal(principalId);
+          setIdentity(identity);
           setUserSettings({
             displayName: `User ${principalId.slice(0, 8)}`
           });
@@ -98,6 +101,7 @@ export const AuthProvider = ({ children }) => {
       
       setIsAuthenticated(false);
       setPrincipal(null);
+      setIdentity(null);
       setUserSettings({
         displayName: 'Anonymous User'
       });
@@ -117,7 +121,8 @@ export const AuthProvider = ({ children }) => {
     loading,
     login,
     logout,
-    authClient
+    authClient,
+    identity
   };
 
   return (


### PR DESCRIPTION
## Summary
- expose authenticated identity through AuthContext
- use current identity when creating HttpAgent and actors
- recreate actors whenever identity changes

## Testing
- `npm test` *(fails: sh: 1: dfx: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ecc633dcc8320ac671ee9c23c7be8