### PR TITLE
Add unstake and reward claim options to staking UI

### DIFF
--- a/src/dao_frontend/src/components/Staking.jsx
+++ b/src/dao_frontend/src/components/Staking.jsx
@@ -2,14 +2,28 @@ import React, { useState } from 'react';
 import { useStaking } from '../hooks/useStaking';
 
 const Staking = () => {
-  const { stake, loading, error } = useStaking();
+  const { stake, unstake, claimRewards, loading, error } = useStaking();
   const [amount, setAmount] = useState('');
   const [period, setPeriod] = useState('instant');
+  const [unstakeId, setUnstakeId] = useState('');
+  const [claimId, setClaimId] = useState('');
 
   const handleStake = async (e) => {
     e.preventDefault();
     await stake(amount, period);
     setAmount('');
+  };
+
+  const handleUnstake = async (e) => {
+    e.preventDefault();
+    await unstake(unstakeId);
+    setUnstakeId('');
+  };
+
+  const handleClaim = async (e) => {
+    e.preventDefault();
+    await claimRewards(claimId);
+    setClaimId('');
   };
 
   return (
@@ -40,6 +54,38 @@ const Staking = () => {
           disabled={loading}
         >
           Stake
+        </button>
+      </form>
+
+      <form onSubmit={handleUnstake} className="space-y-2">
+        <input
+          className="border p-2 w-full"
+          placeholder="Stake ID"
+          value={unstakeId}
+          onChange={(e) => setUnstakeId(e.target.value)}
+        />
+        <button
+          type="submit"
+          className="bg-green-500 text-white px-4 py-2 rounded"
+          disabled={loading}
+        >
+          Unstake
+        </button>
+      </form>
+
+      <form onSubmit={handleClaim} className="space-y-2">
+        <input
+          className="border p-2 w-full"
+          placeholder="Stake ID"
+          value={claimId}
+          onChange={(e) => setClaimId(e.target.value)}
+        />
+        <button
+          type="submit"
+          className="bg-purple-500 text-white px-4 py-2 rounded"
+          disabled={loading}
+        >
+          Claim Rewards
         </button>
       </form>
     </div>

--- a/src/dao_frontend/src/hooks/useStaking.js
+++ b/src/dao_frontend/src/hooks/useStaking.js
@@ -21,5 +21,33 @@ export const useStaking = () => {
     }
   };
 
-  return { stake, loading, error };
+  const unstake = async (stakeId) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await actors.staking.unstake(BigInt(stakeId));
+      return result;
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const claimRewards = async (stakeId) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await actors.staking.claimRewards(BigInt(stakeId));
+      return result;
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { stake, unstake, claimRewards, loading, error };
 };


### PR DESCRIPTION
## Summary
- extend `useStaking` hook with `unstake` and `claimRewards`
- provide UI forms for unstaking and claiming rewards in `Staking` component

## Testing
- `npm test` *(fails: dfx: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ecd085c288320bb1f8d0547d553d4