### PR TITLE
feat: display treasury balances and transactions

### DIFF
--- a/src/dao_frontend/src/components/Treasury.jsx
+++ b/src/dao_frontend/src/components/Treasury.jsx
@@ -1,19 +1,45 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useTreasury } from '../hooks/useTreasury';
 
 const Treasury = () => {
-  const { deposit, withdraw, loading, error } = useTreasury();
+  const {
+    deposit,
+    withdraw,
+    getBalance,
+    getAllTransactions,
+    loading,
+    error,
+  } = useTreasury();
   const [depositAmount, setDepositAmount] = useState('');
   const [depositDesc, setDepositDesc] = useState('');
   const [recipient, setRecipient] = useState('');
   const [withdrawAmount, setWithdrawAmount] = useState('');
   const [withdrawDesc, setWithdrawDesc] = useState('');
+  const [balance, setBalance] = useState(null);
+  const [transactions, setTransactions] = useState([]);
+
+  const fetchData = async () => {
+    try {
+      const bal = await getBalance();
+      setBalance(bal);
+      const txs = await getAllTransactions();
+      txs.sort((a, b) => Number(b.timestamp - a.timestamp));
+      setTransactions(txs.slice(0, 5));
+    } catch (e) {
+      // error handled in hook
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
 
   const handleDeposit = async (e) => {
     e.preventDefault();
     await deposit(depositAmount, depositDesc);
     setDepositAmount('');
     setDepositDesc('');
+    await fetchData();
   };
 
   const handleWithdraw = async (e) => {
@@ -22,12 +48,23 @@ const Treasury = () => {
     setRecipient('');
     setWithdrawAmount('');
     setWithdrawDesc('');
+    await fetchData();
   };
 
   return (
     <div className="p-4 space-y-8">
       <h1 className="text-2xl font-bold">Treasury</h1>
       {error && <p className="text-red-500">{error}</p>}
+
+      {balance && (
+        <div className="space-y-1">
+          <h2 className="text-xl font-semibold">Current Balance</h2>
+          <p>Total: {balance.total.toString()} tokens</p>
+          <p>Available: {balance.available.toString()} tokens</p>
+          <p>Locked: {balance.locked.toString()} tokens</p>
+          <p>Reserved: {balance.reserved.toString()} tokens</p>
+        </div>
+      )}
 
       <form onSubmit={handleDeposit} className="space-y-2">
         <h2 className="text-xl font-semibold">Deposit</h2>
@@ -80,6 +117,26 @@ const Treasury = () => {
           Withdraw
         </button>
       </form>
+
+      {transactions.length > 0 && (
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold">Recent Transactions</h2>
+          <ul className="space-y-1">
+            {transactions.map((tx) => {
+              const type = Object.keys(tx.transactionType)[0];
+              const time = new Date(
+                Number(tx.timestamp / BigInt(1_000_000))
+              ).toLocaleString();
+              return (
+                <li key={tx.id.toString()} className="border p-2 rounded">
+                  <span className="font-mono">#{tx.id.toString()}</span> - {type}
+                  : {tx.amount.toString()} tokens on {time}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/dao_frontend/src/hooks/useTreasury.js
+++ b/src/dao_frontend/src/hooks/useTreasury.js
@@ -41,5 +41,40 @@ export const useTreasury = () => {
     }
   };
 
-  return { deposit, withdraw, loading, error };
+  const getBalance = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const balance = await actors.treasury.getBalance();
+      return balance;
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getAllTransactions = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const txs = await actors.treasury.getAllTransactions();
+      return txs;
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return {
+    deposit,
+    withdraw,
+    getBalance,
+    getAllTransactions,
+    loading,
+    error,
+  };
 };


### PR DESCRIPTION
## Summary
- add helpers to fetch treasury balance and transactions
- show current balances and recent transactions in treasury UI

## Testing
- `npm test` *(fails: dfx: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ecd0f62ac8320a361e8e102e5c982