### PR TITLE
Nest auth and actor providers and relocate registration effect

### DIFF
--- a/src/dao_frontend/src/App.jsx
+++ b/src/dao_frontend/src/App.jsx
@@ -1,6 +1,5 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
-import { AuthClient } from '@dfinity/auth-client';
 import LandingPage from './components/LandingPage';
 import Dashboard from './components/Dashboard';
 import SignIn from './components/SignIn';
@@ -12,31 +11,52 @@ import Treasury from './components/Treasury';
 import Governance from './components/Governance';
 import Navbar from './components/Navbar';
 import Assets from './components/Assets';
-import { AuthProvider } from './context/AuthContext';
+import { useAuth } from './context/AuthContext';
+import { useActors } from './context/ActorContext';
 import './app.css';
 
 function App() {
+  const { isAuthenticated, principal, userSettings } = useAuth();
+  const actors = useActors();
+
+  useEffect(() => {
+    const registerProfile = async () => {
+      if (isAuthenticated && actors && principal) {
+        try {
+          const result = await actors.daoBackend.registerUser(
+            userSettings.displayName,
+            ''
+          );
+          if ('err' in result && result.err !== 'User already registered') {
+            console.error('Failed to register user:', result.err);
+          }
+        } catch (error) {
+          console.error('Failed to register user:', error);
+        }
+      }
+    };
+
+    registerProfile();
+  }, [isAuthenticated, actors, principal, userSettings.displayName]);
 
   return (
-    <AuthProvider>
-      <Router>
-        <div className="App">
-          <Navbar />
-          <Routes>
-            <Route path="/" element={<LandingPage />} />
-            <Route path="/dashboard" element={<Dashboard />} />
-            <Route path="/signin" element={<SignIn />} />
-            <Route path="/launch" element={<LaunchDAO />} />
-            <Route path="/settings" element={<Settings />} />
-            <Route path="/proposals" element={<Proposals />} />
-            <Route path="/staking" element={<Staking />} />
-            <Route path="/treasury" element={<Treasury />} />
-            <Route path="/governance" element={<Governance />} />
-            <Route path="/assets" element={<Assets />} />
-          </Routes>
-        </div>
-      </Router>
-    </AuthProvider>
+    <Router>
+      <div className="App">
+        <Navbar />
+        <Routes>
+          <Route path="/" element={<LandingPage />} />
+          <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/signin" element={<SignIn />} />
+          <Route path="/launch" element={<LaunchDAO />} />
+          <Route path="/settings" element={<Settings />} />
+          <Route path="/proposals" element={<Proposals />} />
+          <Route path="/staking" element={<Staking />} />
+          <Route path="/treasury" element={<Treasury />} />
+          <Route path="/governance" element={<Governance />} />
+          <Route path="/assets" element={<Assets />} />
+        </Routes>
+      </div>
+    </Router>
   );
 }
 

--- a/src/dao_frontend/src/main.jsx
+++ b/src/dao_frontend/src/main.jsx
@@ -2,13 +2,16 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
 import { ActorProvider } from './context/ActorContext'
+import { AuthProvider } from './context/AuthContext'
 import './index.css'
 import './app.css'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <ActorProvider>
-      <App />
-    </ActorProvider>
+    <AuthProvider>
+      <ActorProvider>
+        <App />
+      </ActorProvider>
+    </AuthProvider>
   </React.StrictMode>,
 )


### PR DESCRIPTION
## Summary
- Nest `ActorProvider` inside `AuthProvider` so actors load after authentication
- Decouple `AuthProvider` from actors and manage user registration in `App`
- Ensure identity is stored and supplied through `AuthContext`

## Testing
- `npm test` *(fails: dfx: not found)*
- `npm run build` *(fails: dfx: not found)*


------
https://chatgpt.com/codex/tasks/task_e_689ed26cc3f48320bc9a92e0ac1921e8