### PR TITLE
feat: expand asset management features

### DIFF
--- a/src/dao_frontend/src/components/Assets.jsx
+++ b/src/dao_frontend/src/components/Assets.jsx
@@ -2,13 +2,38 @@ import React, { useState, useEffect } from 'react';
 import { useAssets } from '../hooks/useAssets';
 
 const Assets = () => {
-  const { uploadAsset, getAsset, getPublicAssets, loading, error } = useAssets();
+  const {
+    uploadAsset,
+    getAsset,
+    getPublicAssets,
+    searchAssetsByTag,
+    deleteAsset,
+    updateAssetMetadata,
+    getStorageStats,
+    loading,
+    error,
+  } = useAssets();
   const [file, setFile] = useState(null);
   const [assets, setAssets] = useState([]);
+  const [tag, setTag] = useState('');
+  const [stats, setStats] = useState(null);
+  const [editingId, setEditingId] = useState(null);
+  const [editName, setEditName] = useState('');
+  const [editTags, setEditTags] = useState('');
+  const [editPublic, setEditPublic] = useState(true);
 
-  const fetchAssets = async () => {
+  const fetchStats = async () => {
     try {
-      const list = await getPublicAssets();
+      const s = await getStorageStats();
+      setStats(s);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const fetchAssets = async (t = '') => {
+    try {
+      const list = t ? await searchAssetsByTag(t) : await getPublicAssets();
       setAssets(list);
     } catch (err) {
       console.error(err);
@@ -17,6 +42,7 @@ const Assets = () => {
 
   useEffect(() => {
     fetchAssets();
+    fetchStats();
   }, []);
 
   const handleUpload = async (e) => {
@@ -25,10 +51,16 @@ const Assets = () => {
     try {
       await uploadAsset(file, true, []);
       setFile(null);
-      fetchAssets();
+      fetchAssets(tag);
+      fetchStats();
     } catch (err) {
       console.error(err);
     }
+  };
+
+  const handleSearch = async (e) => {
+    e.preventDefault();
+    await fetchAssets(tag);
   };
 
   const handleView = async (id) => {
@@ -42,23 +74,132 @@ const Assets = () => {
     }
   };
 
+  const handleDelete = async (id) => {
+    try {
+      await deleteAsset(id);
+      fetchAssets(tag);
+      fetchStats();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const startEdit = (asset) => {
+    setEditingId(asset.id);
+    setEditName(asset.name);
+    setEditTags(asset.tags.join(', '));
+    setEditPublic(asset.isPublic);
+  };
+
+  const handleUpdate = async (e, id) => {
+    e.preventDefault();
+    const tagsArray = editTags
+      .split(',')
+      .map((t) => t.trim())
+      .filter((t) => t.length > 0);
+    try {
+      await updateAssetMetadata(id, {
+        name: editName,
+        isPublic: editPublic,
+        tags: tagsArray,
+      });
+      setEditingId(null);
+      fetchAssets(tag);
+      fetchStats();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   return (
     <div className="min-h-screen bg-black text-white pt-24 px-4">
       <h2 className="text-2xl font-mono mb-4">Assets</h2>
+      {stats && (
+        <div className="mb-4 text-sm">
+          <p>Total Assets: {Number(stats.totalAssets)}</p>
+          <p>Storage Used: {Number(stats.storageUsed)}</p>
+          <p>Storage Available: {Number(stats.storageAvailable)}</p>
+          <p>Average File Size: {Number(stats.averageFileSize)}</p>
+        </div>
+      )}
       <form onSubmit={handleUpload} className="mb-6">
         <input type="file" onChange={(e) => setFile(e.target.files[0])} className="mb-2" />
         <button type="submit" disabled={loading} className="px-4 py-2 bg-cyan-600 rounded">
           {loading ? 'Uploading...' : 'Upload'}
         </button>
       </form>
+      <form onSubmit={handleSearch} className="mb-6 flex space-x-2">
+        <input
+          type="text"
+          value={tag}
+          onChange={(e) => setTag(e.target.value)}
+          placeholder="Search by tag"
+          className="px-2 py-1 text-black"
+        />
+        <button type="submit" className="px-3 py-1 bg-cyan-600 rounded">
+          Search
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setTag('');
+            fetchAssets();
+          }}
+          className="px-3 py-1 bg-gray-600 rounded"
+        >
+          Clear
+        </button>
+      </form>
       {error && <p className="text-red-500 mb-4">{error}</p>}
       <ul>
         {assets.map((asset) => (
-          <li key={Number(asset.id)} className="flex justify-between items-center mb-2">
-            <span>{asset.name}</span>
-            <button onClick={() => handleView(asset.id)} className="text-cyan-400 underline">
-              View
-            </button>
+          <li key={Number(asset.id)} className="mb-2">
+            {editingId === asset.id ? (
+              <form onSubmit={(e) => handleUpdate(e, asset.id)} className="flex flex-wrap items-center space-x-2">
+                <input
+                  type="text"
+                  value={editName}
+                  onChange={(e) => setEditName(e.target.value)}
+                  className="px-2 py-1 text-black"
+                />
+                <input
+                  type="text"
+                  value={editTags}
+                  onChange={(e) => setEditTags(e.target.value)}
+                  placeholder="tags"
+                  className="px-2 py-1 text-black"
+                />
+                <label className="flex items-center space-x-1">
+                  <input type="checkbox" checked={editPublic} onChange={(e) => setEditPublic(e.target.checked)} />
+                  <span>Public</span>
+                </label>
+                <button type="submit" className="px-2 py-1 bg-cyan-600 rounded">
+                  Save
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setEditingId(null)}
+                  className="px-2 py-1 bg-gray-600 rounded"
+                >
+                  Cancel
+                </button>
+              </form>
+            ) : (
+              <div className="flex justify-between items-center">
+                <span>{asset.name}</span>
+                <div className="space-x-2">
+                  <button onClick={() => handleView(asset.id)} className="text-cyan-400 underline">
+                    View
+                  </button>
+                  <button onClick={() => startEdit(asset)} className="text-yellow-400 underline">
+                    Edit
+                  </button>
+                  <button onClick={() => handleDelete(asset.id)} className="text-red-500 underline">
+                    Delete
+                  </button>
+                </div>
+              </div>
+            )}
           </li>
         ))}
       </ul>

--- a/src/dao_frontend/src/hooks/useAssets.js
+++ b/src/dao_frontend/src/hooks/useAssets.js
@@ -87,12 +87,81 @@ export const useAssets = () => {
     }
   };
 
+  const searchAssetsByTag = async (tag) => {
+    setLoading(true);
+    setError(null);
+    try {
+      return await actors.assets.searchAssetsByTag(tag);
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const deleteAsset = async (assetId) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await actors.assets.deleteAsset(BigInt(assetId));
+      if (res.err) {
+        throw new Error(res.err);
+      }
+      return res.ok;
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const updateAssetMetadata = async (assetId, { name = null, isPublic = null, tags = null }) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await actors.assets.updateAssetMetadata(
+        BigInt(assetId),
+        name === null ? [] : [name],
+        isPublic === null ? [] : [isPublic],
+        tags === null ? [] : [tags]
+      );
+      if (res.err) {
+        throw new Error(res.err);
+      }
+      return res.ok;
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getStorageStats = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      return await actors.assets.getStorageStats();
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return {
     uploadAsset,
     getAsset,
     getAssetMetadata,
     getPublicAssets,
     getUserAssets,
+    searchAssetsByTag,
+    deleteAsset,
+    updateAssetMetadata,
+    getStorageStats,
     loading,
     error,
   };


### PR DESCRIPTION
## Summary
- extend useAssets hook with tag search, deletion, metadata updates, and storage stats
- add asset management UI for searching, editing, deleting, and viewing storage usage

## Testing
- `npm test` *(fails: dfx not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ed60780f48320960ae3a77ba6a838