### PR TITLE
Add service health widget

### DIFF
--- a/src/dao_frontend/src/components/DAOStatus.jsx
+++ b/src/dao_frontend/src/components/DAOStatus.jsx
@@ -3,6 +3,7 @@ import { useAuth } from '../context/AuthContext';
 import { useActors } from '../context/ActorContext';
 import BackgroundParticles from './BackgroundParticles';
 import { Loader2 } from 'lucide-react';
+import StatusWidget from './StatusWidget';
 
 const formatPrincipal = (opt) => (opt && opt[0] ? opt[0].toText() : 'Not set');
 
@@ -63,6 +64,7 @@ const DAOStatus = () => {
       <BackgroundParticles />
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 relative z-10 pt-24 sm:pt-28">
         <h1 className="text-3xl font-bold text-white mb-8 font-mono">DAO Status</h1>
+        <StatusWidget />
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
           <div className="bg-gray-800/50 p-6 rounded-xl border border-cyan-500/20">
             <h2 className="text-xl font-mono text-cyan-400 mb-4">Configuration</h2>

--- a/src/dao_frontend/src/components/StatusWidget.jsx
+++ b/src/dao_frontend/src/components/StatusWidget.jsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useState } from 'react';
+import { useActors } from '../context/ActorContext';
+
+const StatusWidget = () => {
+  const { daoBackend, assets } = useActors();
+  const [backendHealth, setBackendHealth] = useState(null);
+  const [assetsHealth, setAssetsHealth] = useState(null);
+
+  useEffect(() => {
+    const fetchHealth = async () => {
+      try {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore - health may not be in generated types
+        const backend = await daoBackend.health();
+        setBackendHealth(backend);
+      } catch (err) {
+        console.error('Failed to fetch daoBackend health', err);
+      }
+      try {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore - health may not be in generated types
+        const asset = await assets.health();
+        setAssetsHealth(asset);
+      } catch (err) {
+        console.error('Failed to fetch assets health', err);
+      }
+    };
+    fetchHealth();
+  }, [daoBackend, assets]);
+
+  const formatHeartbeat = (hb) => {
+    if (!hb) return 'N/A';
+    try {
+      const n = typeof hb === 'bigint' ? Number(hb) : hb;
+      // assume nanoseconds if large number
+      const ms = n > 1e12 ? n / 1e6 : n;
+      return new Date(ms).toLocaleString();
+    } catch {
+      return String(hb);
+    }
+  };
+
+  const backendStatus = backendHealth?.status || backendHealth?.ok?.status || 'Unknown';
+  const backendHeartbeat = backendHealth?.last_heartbeat || backendHealth?.ok?.last_heartbeat;
+  const assetsStatus = assetsHealth?.status || assetsHealth?.ok?.status || 'Unknown';
+  const assetsHeartbeat = assetsHealth?.last_heartbeat || assetsHealth?.ok?.last_heartbeat;
+
+  return (
+    <div className="bg-gray-800/50 p-4 rounded-xl border border-cyan-500/20 mb-8">
+      <h2 className="text-lg font-mono text-cyan-400 mb-2">Service Health</h2>
+      <div className="space-y-1 text-sm">
+        <div>
+          <span className="font-bold">DAO Backend:</span> {backendStatus}
+          <span className="ml-2 text-gray-400">Last heartbeat: {formatHeartbeat(backendHeartbeat)}</span>
+        </div>
+        <div>
+          <span className="font-bold">Assets:</span> {assetsStatus}
+          <span className="ml-2 text-gray-400">Last heartbeat: {formatHeartbeat(assetsHeartbeat)}</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default StatusWidget;


### PR DESCRIPTION
## Summary
- show overall service health in DAO status page
- query daoBackend and assets canister `health` endpoints and display last heartbeat

## Testing
- `npm test` *(fails: dfx: not found)*
- `curl -fsSL https://smartcontracts.org/install.sh` *(403 trying to fetch dfx installer)*

------
https://chatgpt.com/codex/tasks/task_e_689ed60d46988320bc173250497f154c