### PR TITLE
refactor: centralize auth provider in main.jsx

### DIFF
--- a/src/dao_frontend/src/App.jsx
+++ b/src/dao_frontend/src/App.jsx
@@ -41,28 +41,24 @@ function App() {
   }, [isAuthenticated, actors, principal, userSettings.displayName]);
 
   return (
-
-    <AuthProvider>
-      <Router>
-        <div className="App">
-          <Navbar />
-          <Routes>
-            <Route path="/" element={<LandingPage />} />
-            <Route path="/dashboard" element={<Dashboard />} />
-            <Route path="/status" element={<DAOStatus />} />
-            <Route path="/signin" element={<SignIn />} />
-            <Route path="/launch" element={<LaunchDAO />} />
-            <Route path="/settings" element={<Settings />} />
-            <Route path="/proposals" element={<Proposals />} />
-            <Route path="/staking" element={<Staking />} />
-            <Route path="/treasury" element={<Treasury />} />
-            <Route path="/governance" element={<Governance />} />
-            <Route path="/assets" element={<Assets />} />
-          </Routes>
-        </div>
-      </Router>
-    </AuthProvider>
-
+    <Router>
+      <div className="App">
+        <Navbar />
+        <Routes>
+          <Route path="/" element={<LandingPage />} />
+          <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/status" element={<DAOStatus />} />
+          <Route path="/signin" element={<SignIn />} />
+          <Route path="/launch" element={<LaunchDAO />} />
+          <Route path="/settings" element={<Settings />} />
+          <Route path="/proposals" element={<Proposals />} />
+          <Route path="/staking" element={<Staking />} />
+          <Route path="/treasury" element={<Treasury />} />
+          <Route path="/governance" element={<Governance />} />
+          <Route path="/assets" element={<Assets />} />
+        </Routes>
+      </div>
+    </Router>
   );
 }
 


### PR DESCRIPTION
## Summary
- remove AuthProvider wrapper from `App` so Router renders directly
- keep AuthProvider in `main.jsx` as the single app-wide wrapper

## Testing
- `npm test` *(fails: dfx: not found)*
- `npm test --ignore-scripts`


------
https://chatgpt.com/codex/tasks/task_e_689ed6587df88320834bd46f83d698f7