### PR TITLE
Refactor auth context registration flow

### DIFF
--- a/src/dao_frontend/src/App.jsx
+++ b/src/dao_frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import LandingPage from './components/LandingPage';
 import Dashboard from './components/Dashboard';
@@ -12,36 +12,14 @@ import Governance from './components/Governance';
 import DAOStatus from './components/DAOStatus';
 import Navbar from './components/Navbar';
 import Assets from './components/Assets';
-import { useAuth } from './context/AuthContext';
-import { useActors } from './context/ActorContext';
+import UserRegistrationHandler from './components/UserRegistrationHandler';
 import './app.css';
 
 function App() {
-  const { identity, userSettings } = useAuth();
-  const actors = useActors();
-
-  useEffect(() => {
-    const registerUser = async () => {
-      if (identity && actors) {
-        try {
-          const result = await actors.daoBackend.registerUser(
-            userSettings.displayName,
-            ''
-          );
-          if ('err' in result && result.err !== 'User already registered') {
-            console.error('Failed to register user:', result.err);
-          }
-        } catch (error) {
-          console.error('Failed to register user:', error);
-        }
-      }
-    };
-
-    registerUser();
-  }, [identity, actors, userSettings.displayName]);
-
+  
   return (
     <Router>
+      <UserRegistrationHandler />
       <div className="App">
         <Navbar />
         <Routes>

--- a/src/dao_frontend/src/components/UserRegistrationHandler.jsx
+++ b/src/dao_frontend/src/components/UserRegistrationHandler.jsx
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+import { useActors } from '../context/ActorContext';
+import { useAuth } from '../context/AuthContext';
+
+const UserRegistrationHandler = () => {
+  const { identity, userSettings } = useAuth();
+  const actors = useActors();
+
+  useEffect(() => {
+    const registerUser = async () => {
+      if (identity && actors) {
+        try {
+          const result = await actors.daoBackend.registerUser(
+            userSettings.displayName,
+            ''
+          );
+          if ('err' in result && result.err !== 'User already registered') {
+            console.error('Failed to register user:', result.err);
+          }
+        } catch (error) {
+          console.error('Failed to register user:', error);
+        }
+      }
+    };
+
+    registerUser();
+  }, [identity, actors, userSettings.displayName]);
+
+  return null;
+};
+
+export default UserRegistrationHandler;

--- a/src/dao_frontend/src/context/AuthContext.jsx
+++ b/src/dao_frontend/src/context/AuthContext.jsx
@@ -1,9 +1,6 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import { AuthClient } from '@dfinity/auth-client';
 
-import { useActors } from './ActorContext';
-
-
 // Create the AuthContext
 const AuthContext = createContext();
 
@@ -91,9 +88,6 @@ export const AuthProvider = ({ children }) => {
           setUserSettings({
             displayName
           });
-
-          await registerProfile(displayName);
-
         },
 
 


### PR DESCRIPTION
## Summary
- remove actor context usage from auth context and drop unused registerProfile call
- handle user registration after providers mount via new UserRegistrationHandler component
- update App to include dedicated registration handler

## Testing
- `npm test` *(fails: dfx: not found)*
- `npm test --ignore-scripts`


------
https://chatgpt.com/codex/tasks/task_e_689ed974e80c83208fcf0fe99da0dfe6