### PR TITLE
Update proposals hook for optional fields

### DIFF
--- a/src/dao_frontend/src/components/Proposals.jsx
+++ b/src/dao_frontend/src/components/Proposals.jsx
@@ -5,24 +5,26 @@ const Proposals = () => {
   const { createProposal, vote, loading, error } = useProposals();
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
+  const [category, setCategory] = useState('');
+  const [votingPeriod, setVotingPeriod] = useState('');
 
   const [proposalId, setProposalId] = useState('');
   const [choice, setChoice] = useState('inFavor');
-  const [votingPower, setVotingPower] = useState('');
   const [reason, setReason] = useState('');
 
   const handleCreate = async (e) => {
     e.preventDefault();
-    await createProposal(title, description);
+    await createProposal(title, description, category, votingPeriod);
     setTitle('');
     setDescription('');
+    setCategory('');
+    setVotingPeriod('');
   };
 
   const handleVote = async (e) => {
     e.preventDefault();
-    await vote(proposalId, choice, votingPower, reason);
+    await vote(proposalId, choice, reason);
     setProposalId('');
-    setVotingPower('');
     setReason('');
   };
 
@@ -43,6 +45,18 @@ const Proposals = () => {
           placeholder="Description"
           value={description}
           onChange={(e) => setDescription(e.target.value)}
+        />
+        <input
+          className="border p-2 w-full"
+          placeholder="Category (optional)"
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+        />
+        <input
+          className="border p-2 w-full"
+          placeholder="Voting Period (seconds, optional)"
+          value={votingPeriod}
+          onChange={(e) => setVotingPeriod(e.target.value)}
         />
         <button
           type="submit"
@@ -70,12 +84,6 @@ const Proposals = () => {
           <option value="against">Against</option>
           <option value="abstain">Abstain</option>
         </select>
-        <input
-          className="border p-2 w-full"
-          placeholder="Voting Power"
-          value={votingPower}
-          onChange={(e) => setVotingPower(e.target.value)}
-        />
         <input
           className="border p-2 w-full"
           placeholder="Reason (optional)"

--- a/src/dao_frontend/src/declarations/proposals/proposals.did
+++ b/src/dao_frontend/src/declarations/proposals/proposals.did
@@ -129,6 +129,5 @@ service : {
   getTemplate: (templateId: nat) -> (opt ProposalTemplate) query;
   getTemplatesByCategory: (category: text) -> (vec ProposalTemplate) query;
   getTrendingProposals: (limit: nat) -> (vec Proposal) query;
-  vote: (proposalId: ProposalId, choice: VoteChoice, votingPower: nat,
-   reason: opt text) -> (Result);
+  vote: (proposalId: ProposalId, choice: VoteChoice, reason: opt text) -> (Result);
 }

--- a/src/dao_frontend/src/declarations/proposals/proposals.did.d.ts
+++ b/src/dao_frontend/src/declarations/proposals/proposals.did.d.ts
@@ -109,7 +109,7 @@ export interface _SERVICE {
   'getTemplate' : ActorMethod<[bigint], [] | [ProposalTemplate]>,
   'getTemplatesByCategory' : ActorMethod<[string], Array<ProposalTemplate>>,
   'getTrendingProposals' : ActorMethod<[bigint], Array<Proposal>>,
-  'vote' : ActorMethod<[ProposalId, VoteChoice, bigint, [] | [string]], Result>,
+  'vote' : ActorMethod<[ProposalId, VoteChoice, [] | [string]], Result>,
 }
 export declare const idlFactory: IDL.InterfaceFactory;
 export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/src/dao_frontend/src/declarations/proposals/proposals.did.js
+++ b/src/dao_frontend/src/declarations/proposals/proposals.did.js
@@ -149,7 +149,7 @@ export const idlFactory = ({ IDL }) => {
         ['query'],
       ),
     'vote' : IDL.Func(
-        [ProposalId, VoteChoice, IDL.Nat, IDL.Opt(IDL.Text)],
+        [ProposalId, VoteChoice, IDL.Opt(IDL.Text)],
         [Result],
         [],
       ),

--- a/src/dao_frontend/src/hooks/useProposals.js
+++ b/src/dao_frontend/src/hooks/useProposals.js
@@ -6,7 +6,7 @@ export const useProposals = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
-  const createProposal = async (title, description) => {
+  const createProposal = async (title, description, category, votingPeriod) => {
     setLoading(true);
     setError(null);
     try {
@@ -14,8 +14,8 @@ export const useProposals = () => {
         title,
         description,
         { textProposal: '' },
-        [],
-        []
+        category ? [category] : [],
+        votingPeriod ? [BigInt(votingPeriod)] : []
       );
       return result;
     } catch (err) {
@@ -26,7 +26,7 @@ export const useProposals = () => {
     }
   };
 
-  const vote = async (proposalId, choice, votingPower, reason) => {
+  const vote = async (proposalId, choice, reason) => {
     setLoading(true);
     setError(null);
     try {
@@ -34,7 +34,6 @@ export const useProposals = () => {
       const res = await actors.proposals.vote(
         BigInt(proposalId),
         choiceVariant,
-        BigInt(votingPower),
         reason ? [reason] : []
       );
       return res;


### PR DESCRIPTION
## Summary
- allow proposals hook to send optional category and voting period
- simplify vote to omit explicit voting power
- update proposals component and candid declarations accordingly

## Testing
- `npm test` *(fails: dfx: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ed99d22e483208ce91586c65a8d2b