### PR TITLE
Extend governance proposal API and update component

### DIFF
--- a/src/dao_frontend/src/components/Governance.jsx
+++ b/src/dao_frontend/src/components/Governance.jsx
@@ -5,9 +5,10 @@ const Governance = () => {
   const { createProposal, vote, getConfig, getStats, loading, error } = useGovernance();
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
+  const [proposalType, setProposalType] = useState('textProposal');
+  const [votingPeriod, setVotingPeriod] = useState('');
   const [proposalId, setProposalId] = useState('');
   const [choice, setChoice] = useState('inFavor');
-  const [votingPower, setVotingPower] = useState('');
   const [reason, setReason] = useState('');
   const [config, setConfig] = useState(null);
   const [stats, setStats] = useState(null);
@@ -28,16 +29,22 @@ const Governance = () => {
 
   const handleCreate = async (e) => {
     e.preventDefault();
-    await createProposal(title, description);
+    await createProposal(
+      title,
+      description,
+      { [proposalType]: proposalType === 'textProposal' ? '' : null },
+      votingPeriod
+    );
     setTitle('');
     setDescription('');
+    setProposalType('textProposal');
+    setVotingPeriod('');
   };
 
   const handleVote = async (e) => {
     e.preventDefault();
-    await vote(proposalId, choice, votingPower, reason);
+    await vote(proposalId, choice, reason);
     setProposalId('');
-    setVotingPower('');
     setReason('');
   };
 
@@ -58,6 +65,18 @@ const Governance = () => {
           placeholder="Description"
           value={description}
           onChange={(e) => setDescription(e.target.value)}
+        />
+        <input
+          className="border p-2 w-full"
+          placeholder="Proposal Type"
+          value={proposalType}
+          onChange={(e) => setProposalType(e.target.value)}
+        />
+        <input
+          className="border p-2 w-full"
+          placeholder="Voting Period (optional)"
+          value={votingPeriod}
+          onChange={(e) => setVotingPeriod(e.target.value)}
         />
         <button
           type="submit"
@@ -85,12 +104,6 @@ const Governance = () => {
           <option value="against">Against</option>
           <option value="abstain">Abstain</option>
         </select>
-        <input
-          className="border p-2 w-full"
-          placeholder="Voting Power"
-          value={votingPower}
-          onChange={(e) => setVotingPower(e.target.value)}
-        />
         <input
           className="border p-2 w-full"
           placeholder="Reason (optional)"

--- a/src/dao_frontend/src/hooks/useGovernance.js
+++ b/src/dao_frontend/src/hooks/useGovernance.js
@@ -6,11 +6,21 @@ export const useGovernance = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
-  const createProposal = async (title, description) => {
+  const createProposal = async (
+    title,
+    description,
+    proposalType,
+    votingPeriod
+  ) => {
     setLoading(true);
     setError(null);
     try {
-      const result = await actors.governance.createProposal(title, description);
+      const result = await actors.governance.createProposal(
+        title,
+        description,
+        proposalType,
+        votingPeriod ? [BigInt(votingPeriod)] : []
+      );
       return result;
     } catch (err) {
       setError(err.message);
@@ -20,7 +30,7 @@ export const useGovernance = () => {
     }
   };
 
-  const vote = async (proposalId, choice, votingPower, reason) => {
+  const vote = async (proposalId, choice, reason) => {
     setLoading(true);
     setError(null);
     try {
@@ -28,7 +38,6 @@ export const useGovernance = () => {
       const res = await actors.governance.vote(
         BigInt(proposalId),
         choiceVariant,
-        BigInt(votingPower),
         reason ? [reason] : []
       );
       return res;


### PR DESCRIPTION
## Summary
- support proposal type and optional voting period when creating governance proposals
- simplify governance voting to omit voting power parameter
- update Governance component UI for new proposal fields

## Testing
- `npm test` *(fails: dfx not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ed9a020348320b2b59fffdd6b9166