### PR TITLE
Rename governance stats helper

### DIFF
--- a/src/dao_frontend/src/components/Governance.jsx
+++ b/src/dao_frontend/src/components/Governance.jsx
@@ -2,7 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { useGovernance } from '../hooks/useGovernance';
 
 const Governance = () => {
-  const { createProposal, vote, getConfig, getStats, loading, error } = useGovernance();
+  const { createProposal, vote, getConfig, getGovernanceStats, loading, error } =
+    useGovernance();
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [proposalType, setProposalType] = useState('textProposal');
@@ -18,7 +19,7 @@ const Governance = () => {
       try {
         const cfg = await getConfig();
         setConfig(cfg);
-        const st = await getStats();
+        const st = await getGovernanceStats();
         setStats(st);
       } catch (e) {
         // error handled in hook

--- a/src/dao_frontend/src/hooks/useGovernance.js
+++ b/src/dao_frontend/src/hooks/useGovernance.js
@@ -63,11 +63,11 @@ export const useGovernance = () => {
     }
   };
 
-  const getStats = async () => {
+  const getGovernanceStats = async () => {
     setLoading(true);
     setError(null);
     try {
-      const stats = await actors.governance.getStats();
+      const stats = await actors.governance.getGovernanceStats();
       return stats;
     } catch (err) {
       setError(err.message);
@@ -77,5 +77,5 @@ export const useGovernance = () => {
     }
   };
 
-  return { createProposal, vote, getConfig, getStats, loading, error };
+  return { createProposal, vote, getConfig, getGovernanceStats, loading, error };
 };


### PR DESCRIPTION
## Summary
- rename hook method `getStats` to `getGovernanceStats`
- call `actors.governance.getGovernanceStats()` internally
- update Governance component to use new helper

## Testing
- `npm test` *(fails: dfx: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689edcdd53008320b4b1b862c4d2c92e