### PR TITLE
Convert duration inputs to nanoseconds

### DIFF
--- a/src/dao_frontend/src/components/LaunchDAO.jsx
+++ b/src/dao_frontend/src/components/LaunchDAO.jsx
@@ -63,13 +63,13 @@ const LaunchDAO = () => {
     initialPrice: '',
     
     // Governance
-    votingPeriod: '7',
+    votingPeriod: '604800',
     quorumThreshold: '10',
     proposalThreshold: '1',
     
     // Funding
     fundingGoal: '',
-    fundingDuration: '30',
+    fundingDuration: '2592000',
     minInvestment: '',
     
     // Team
@@ -738,7 +738,7 @@ const LaunchDAO = () => {
               <div className="grid md:grid-cols-2 gap-6">
                 <div>
                   <label className="block text-sm font-semibold text-gray-300 mb-2 font-mono">
-                    Voting Period (days) <span className="text-red-400">*</span>
+                    Voting Period (seconds) <span className="text-red-400">*</span>
                   </label>
                   <input
                     type="number"
@@ -747,8 +747,8 @@ const LaunchDAO = () => {
                     className={`w-full px-4 py-3 bg-gray-800 border rounded-lg focus:ring-2 focus:ring-cyan-500 focus:border-transparent text-white font-mono ${
                       errors.votingPeriod ? 'border-red-500' : 'border-gray-600'
                     }`}
-                    min="1"
-                    max="30"
+                    min="86400"
+                    max="2592000"
                   />
                 </div>
 
@@ -809,15 +809,15 @@ const LaunchDAO = () => {
 
                 <div>
                   <label className="block text-sm font-semibold text-gray-300 mb-2 font-mono">
-                    Funding Duration (days)
+                    Funding Duration (seconds)
                   </label>
                   <input
                     type="number"
                     value={formData.fundingDuration}
                     onChange={(e) => setFormData(prev => ({ ...prev, fundingDuration: e.target.value }))}
                     className="w-full px-4 py-3 bg-gray-800 border border-gray-600 rounded-lg focus:ring-2 focus:ring-cyan-500 focus:border-transparent text-white font-mono"
-                    min="7"
-                    max="365"
+                    min="604800"
+                    max="31536000"
                   />
                 </div>
 
@@ -1149,7 +1149,7 @@ const LaunchDAO = () => {
                         </div>
                         <div>
                           <span className="text-gray-400">Duration:</span>
-                          <div className="text-white font-semibold">{formData.fundingDuration} days</div>
+                          <div className="text-white font-semibold">{formData.fundingDuration} seconds</div>
                         </div>
                         <div>
                           <span className="text-gray-400">Min Investment:</span>

--- a/src/dao_frontend/src/components/Proposals.jsx
+++ b/src/dao_frontend/src/components/Proposals.jsx
@@ -54,7 +54,7 @@ const Proposals = () => {
         />
         <input
           className="border p-2 w-full"
-          placeholder="Voting Period (seconds, optional)"
+          placeholder="Voting Period in seconds (optional)"
           value={votingPeriod}
           onChange={(e) => setVotingPeriod(e.target.value)}
         />

--- a/src/dao_frontend/src/hooks/useDAOOperations.js
+++ b/src/dao_frontend/src/hooks/useDAOOperations.js
@@ -5,6 +5,8 @@ import { useActors } from '../context/ActorContext';
 import { useAuth } from '../context/AuthContext';
 import { Principal } from '@dfinity/principal';
 
+const toNanoseconds = (seconds) => BigInt(seconds) * 1_000_000_000n;
+
 export const useDAOOperations = () => {
     const actors = useActors();
     const { principal } = useAuth();
@@ -99,11 +101,11 @@ export const useDAOOperations = () => {
                 tokenSymbol: daoConfig.tokenSymbol,
                 totalSupply: BigInt(daoConfig.totalSupply || 0),
                 initialPrice: BigInt(daoConfig.initialPrice || 0),
-                votingPeriod: BigInt(daoConfig.votingPeriod || 0),
+                votingPeriod: toNanoseconds(daoConfig.votingPeriod || 0),
                 quorumThreshold: BigInt(daoConfig.quorumThreshold || 0),
                 proposalThreshold: BigInt(daoConfig.proposalThreshold || 0),
                 fundingGoal: BigInt(daoConfig.fundingGoal || 0),
-                fundingDuration: BigInt(daoConfig.fundingDuration || 0),
+                fundingDuration: toNanoseconds(daoConfig.fundingDuration || 0),
                 minInvestment: BigInt(daoConfig.minInvestment || 0),
                 termsAccepted: daoConfig.termsAccepted,
                 kycRequired: daoConfig.kycRequired

--- a/src/dao_frontend/src/hooks/useGovernance.js
+++ b/src/dao_frontend/src/hooks/useGovernance.js
@@ -6,6 +6,8 @@ export const useGovernance = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
+  const toNanoseconds = (seconds) => BigInt(seconds) * 1_000_000_000n;
+
   const createProposal = async (
     title,
     description,
@@ -19,7 +21,7 @@ export const useGovernance = () => {
         title,
         description,
         proposalType,
-        votingPeriod ? [BigInt(votingPeriod)] : []
+        votingPeriod ? [toNanoseconds(votingPeriod)] : []
       );
       return result;
     } catch (err) {

--- a/src/dao_frontend/src/hooks/useProposals.js
+++ b/src/dao_frontend/src/hooks/useProposals.js
@@ -6,6 +6,8 @@ export const useProposals = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
+  const toNanoseconds = (seconds) => BigInt(seconds) * 1_000_000_000n;
+
   const createProposal = async (title, description, category, votingPeriod) => {
     setLoading(true);
     setError(null);
@@ -15,7 +17,7 @@ export const useProposals = () => {
         description,
         { textProposal: '' },
         category ? [category] : [],
-        votingPeriod ? [BigInt(votingPeriod)] : []
+        votingPeriod ? [toNanoseconds(votingPeriod)] : []
       );
       return result;
     } catch (err) {


### PR DESCRIPTION
## Summary
- convert duration inputs to nanoseconds in DAO launch, governance, and proposals hooks
- clarify UI form labels/placeholder to indicate seconds

## Testing
- `npm test` *(fails: dfx: not found)*
- `sh -ci "$(curl -fsSL https://internetcomputer.org/install.sh)"` *(fails: 403)*
- `npm test --ignore-scripts`


------
https://chatgpt.com/codex/tasks/task_e_689edcf0ad8483209544763738cc2d9f