### PR TITLE
feat: add proposal queries and templates

### DIFF
--- a/src/dao_frontend/src/components/Proposals.jsx
+++ b/src/dao_frontend/src/components/Proposals.jsx
@@ -1,8 +1,16 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useProposals } from '../hooks/useProposals';
 
 const Proposals = () => {
-  const { createProposal, vote, loading, error } = useProposals();
+  const {
+    createProposal,
+    vote,
+    getAllProposals,
+    getProposalsByCategory,
+    getProposalTemplates,
+    loading,
+    error,
+  } = useProposals();
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [category, setCategory] = useState('');
@@ -11,6 +19,24 @@ const Proposals = () => {
   const [proposalId, setProposalId] = useState('');
   const [choice, setChoice] = useState('inFavor');
   const [reason, setReason] = useState('');
+  const [proposals, setProposals] = useState([]);
+  const [categoryFilter, setCategoryFilter] = useState('');
+  const [templates, setTemplates] = useState([]);
+
+  useEffect(() => {
+    loadProposals();
+    loadTemplates();
+  }, []);
+
+  const loadProposals = async () => {
+    const all = await getAllProposals();
+    setProposals(all);
+  };
+
+  const loadTemplates = async () => {
+    const tpls = await getProposalTemplates();
+    setTemplates(tpls);
+  };
 
   const handleCreate = async (e) => {
     e.preventDefault();
@@ -19,6 +45,7 @@ const Proposals = () => {
     setDescription('');
     setCategory('');
     setVotingPeriod('');
+    loadProposals();
   };
 
   const handleVote = async (e) => {
@@ -28,10 +55,67 @@ const Proposals = () => {
     setReason('');
   };
 
+  const handleFilter = async (e) => {
+    const value = e.target.value;
+    setCategoryFilter(value);
+    if (value) {
+      const filtered = await getProposalsByCategory(value);
+      setProposals(filtered);
+    } else {
+      loadProposals();
+    }
+  };
+
+  const handleCreateFromTemplate = async (template) => {
+    await createProposal(
+      template.name,
+      template.template,
+      template.category,
+      votingPeriod
+    );
+    loadProposals();
+  };
+
   return (
     <div className="p-4 space-y-8">
       <h1 className="text-2xl font-bold">Proposals</h1>
       {error && <p className="text-red-500">{error}</p>}
+
+      <div className="space-y-2">
+        <h2 className="text-xl font-semibold">Existing Proposals</h2>
+        <input
+          className="border p-2 w-full"
+          placeholder="Filter by category"
+          value={categoryFilter}
+          onChange={handleFilter}
+        />
+        <ul className="space-y-2">
+          {proposals.map((p) => (
+            <li key={p.id.toString()} className="border p-2 rounded">
+              <h3 className="font-semibold">{p.title}</h3>
+              <p className="text-sm">{p.description}</p>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="space-y-2">
+        <h2 className="text-xl font-semibold">Create from Template</h2>
+        <ul className="space-y-2">
+          {templates.map((t) => (
+            <li key={t.id.toString()} className="border p-2 rounded">
+              <h3 className="font-semibold">{t.name}</h3>
+              <p className="text-sm">{t.description}</p>
+              <button
+                className="mt-2 bg-purple-500 text-white px-2 py-1 rounded"
+                onClick={() => handleCreateFromTemplate(t)}
+              >
+                Create
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
       <form onSubmit={handleCreate} className="space-y-2">
         <h2 className="text-xl font-semibold">Create Proposal</h2>
         <input

--- a/src/dao_frontend/src/hooks/useProposals.js
+++ b/src/dao_frontend/src/hooks/useProposals.js
@@ -26,6 +26,83 @@ export const useProposals = () => {
     }
   };
 
+  const getAllProposals = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      return await actors.proposals.getAllProposals();
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getProposalsByCategory = async (category) => {
+    setLoading(true);
+    setError(null);
+    try {
+      return await actors.proposals.getProposalsByCategory(category);
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getTrendingProposals = async (limit) => {
+    setLoading(true);
+    setError(null);
+    try {
+      return await actors.proposals.getTrendingProposals(BigInt(limit));
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getProposalTemplates = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      return await actors.proposals.getProposalTemplates();
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const addTemplate = async (
+    name,
+    description,
+    category,
+    requiredFields,
+    template
+  ) => {
+    setLoading(true);
+    setError(null);
+    try {
+      return await actors.proposals.addTemplate(
+        name,
+        description,
+        category,
+        requiredFields,
+        template
+      );
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
   const vote = async (proposalId, choice, reason) => {
     setLoading(true);
     setError(null);
@@ -45,5 +122,15 @@ export const useProposals = () => {
     }
   };
 
-  return { createProposal, vote, loading, error };
+  return {
+    createProposal,
+    vote,
+    getAllProposals,
+    getProposalsByCategory,
+    getTrendingProposals,
+    getProposalTemplates,
+    addTemplate,
+    loading,
+    error,
+  };
 };


### PR DESCRIPTION
## Summary
- extend proposals hook with proposal fetching, trending, and templates helpers
- show proposals list with category filter and template creation in Proposals page

## Testing
- `npm test` *(fails: dfx: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689edd5ebedc8320b7069878851ceea1