### PR TITLE
feat: extend treasury utilities

### DIFF
--- a/src/dao_frontend/src/components/Treasury.jsx
+++ b/src/dao_frontend/src/components/Treasury.jsx
@@ -5,8 +5,14 @@ const Treasury = () => {
   const {
     deposit,
     withdraw,
+    lockTokens,
+    unlockTokens,
+    reserveTokens,
+    releaseReservedTokens,
     getBalance,
-    getAllTransactions,
+    getTransactionsByType,
+    getRecentTransactions,
+    getTreasuryStats,
     loading,
     error,
   } = useTreasury();
@@ -15,16 +21,28 @@ const Treasury = () => {
   const [recipient, setRecipient] = useState('');
   const [withdrawAmount, setWithdrawAmount] = useState('');
   const [withdrawDesc, setWithdrawDesc] = useState('');
+  const [lockAmount, setLockAmount] = useState('');
+  const [lockReason, setLockReason] = useState('');
+  const [unlockAmount, setUnlockAmount] = useState('');
+  const [unlockReason, setUnlockReason] = useState('');
+  const [reserveAmount, setReserveAmount] = useState('');
+  const [reserveReason, setReserveReason] = useState('');
+  const [releaseAmount, setReleaseAmount] = useState('');
+  const [releaseReason, setReleaseReason] = useState('');
+  const [filterType, setFilterType] = useState('deposit');
+  const [filteredTransactions, setFilteredTransactions] = useState([]);
   const [balance, setBalance] = useState(null);
   const [transactions, setTransactions] = useState([]);
+  const [stats, setStats] = useState(null);
 
   const fetchData = async () => {
     try {
       const bal = await getBalance();
       setBalance(bal);
-      const txs = await getAllTransactions();
-      txs.sort((a, b) => Number(b.timestamp - a.timestamp));
-      setTransactions(txs.slice(0, 5));
+      const txs = await getRecentTransactions(5);
+      setTransactions(txs);
+      const s = await getTreasuryStats();
+      setStats(s);
     } catch (e) {
       // error handled in hook
     }
@@ -51,6 +69,44 @@ const Treasury = () => {
     await fetchData();
   };
 
+  const handleLock = async (e) => {
+    e.preventDefault();
+    await lockTokens(lockAmount, lockReason);
+    setLockAmount('');
+    setLockReason('');
+    await fetchData();
+  };
+
+  const handleUnlock = async (e) => {
+    e.preventDefault();
+    await unlockTokens(unlockAmount, unlockReason);
+    setUnlockAmount('');
+    setUnlockReason('');
+    await fetchData();
+  };
+
+  const handleReserve = async (e) => {
+    e.preventDefault();
+    await reserveTokens(reserveAmount, reserveReason);
+    setReserveAmount('');
+    setReserveReason('');
+    await fetchData();
+  };
+
+  const handleRelease = async (e) => {
+    e.preventDefault();
+    await releaseReservedTokens(releaseAmount, releaseReason);
+    setReleaseAmount('');
+    setReleaseReason('');
+    await fetchData();
+  };
+
+  const handleFilter = async (e) => {
+    e.preventDefault();
+    const txs = await getTransactionsByType(filterType);
+    setFilteredTransactions(txs);
+  };
+
   return (
     <div className="p-4 space-y-8">
       <h1 className="text-2xl font-bold">Treasury</h1>
@@ -63,6 +119,18 @@ const Treasury = () => {
           <p>Available: {balance.available.toString()} tokens</p>
           <p>Locked: {balance.locked.toString()} tokens</p>
           <p>Reserved: {balance.reserved.toString()} tokens</p>
+        </div>
+      )}
+
+      {stats && (
+        <div className="space-y-1">
+          <h2 className="text-xl font-semibold">Statistics</h2>
+          <p>Total Transactions: {stats.totalTransactions.toString()}</p>
+          <p>Total Deposits: {stats.totalDeposits.toString()} tokens</p>
+          <p>Total Withdrawals: {stats.totalWithdrawals.toString()} tokens</p>
+          <p>
+            Avg. Amount: {stats.averageTransactionAmount.toFixed(2)} tokens
+          </p>
         </div>
       )}
 
@@ -118,11 +186,144 @@ const Treasury = () => {
         </button>
       </form>
 
+      <form onSubmit={handleLock} className="space-y-2">
+        <h2 className="text-xl font-semibold">Lock Tokens</h2>
+        <input
+          className="border p-2 w-full"
+          placeholder="Amount"
+          value={lockAmount}
+          onChange={(e) => setLockAmount(e.target.value)}
+        />
+        <input
+          className="border p-2 w-full"
+          placeholder="Reason"
+          value={lockReason}
+          onChange={(e) => setLockReason(e.target.value)}
+        />
+        <button
+          type="submit"
+          className="bg-purple-500 text-white px-4 py-2 rounded"
+          disabled={loading}
+        >
+          Lock
+        </button>
+      </form>
+
+      <form onSubmit={handleUnlock} className="space-y-2">
+        <h2 className="text-xl font-semibold">Unlock Tokens</h2>
+        <input
+          className="border p-2 w-full"
+          placeholder="Amount"
+          value={unlockAmount}
+          onChange={(e) => setUnlockAmount(e.target.value)}
+        />
+        <input
+          className="border p-2 w-full"
+          placeholder="Reason"
+          value={unlockReason}
+          onChange={(e) => setUnlockReason(e.target.value)}
+        />
+        <button
+          type="submit"
+          className="bg-pink-500 text-white px-4 py-2 rounded"
+          disabled={loading}
+        >
+          Unlock
+        </button>
+      </form>
+
+      <form onSubmit={handleReserve} className="space-y-2">
+        <h2 className="text-xl font-semibold">Reserve Tokens</h2>
+        <input
+          className="border p-2 w-full"
+          placeholder="Amount"
+          value={reserveAmount}
+          onChange={(e) => setReserveAmount(e.target.value)}
+        />
+        <input
+          className="border p-2 w-full"
+          placeholder="Reason"
+          value={reserveReason}
+          onChange={(e) => setReserveReason(e.target.value)}
+        />
+        <button
+          type="submit"
+          className="bg-yellow-500 text-white px-4 py-2 rounded"
+          disabled={loading}
+        >
+          Reserve
+        </button>
+      </form>
+
+      <form onSubmit={handleRelease} className="space-y-2">
+        <h2 className="text-xl font-semibold">Release Reserved Tokens</h2>
+        <input
+          className="border p-2 w-full"
+          placeholder="Amount"
+          value={releaseAmount}
+          onChange={(e) => setReleaseAmount(e.target.value)}
+        />
+        <input
+          className="border p-2 w-full"
+          placeholder="Reason"
+          value={releaseReason}
+          onChange={(e) => setReleaseReason(e.target.value)}
+        />
+        <button
+          type="submit"
+          className="bg-indigo-500 text-white px-4 py-2 rounded"
+          disabled={loading}
+        >
+          Release
+        </button>
+      </form>
+
+      <form onSubmit={handleFilter} className="space-y-2">
+        <h2 className="text-xl font-semibold">Filter Transactions</h2>
+        <select
+          className="border p-2 w-full"
+          value={filterType}
+          onChange={(e) => setFilterType(e.target.value)}
+        >
+          <option value="deposit">Deposit</option>
+          <option value="withdrawal">Withdrawal</option>
+          <option value="stakingReward">Staking Reward</option>
+          <option value="fee">Fee</option>
+        </select>
+        <button
+          type="submit"
+          className="bg-gray-500 text-white px-4 py-2 rounded"
+          disabled={loading}
+        >
+          Apply Filter
+        </button>
+      </form>
+
       {transactions.length > 0 && (
         <div className="space-y-2">
           <h2 className="text-xl font-semibold">Recent Transactions</h2>
           <ul className="space-y-1">
             {transactions.map((tx) => {
+              const type = Object.keys(tx.transactionType)[0];
+              const time = new Date(
+                Number(tx.timestamp / BigInt(1_000_000))
+              ).toLocaleString();
+              return (
+                <li key={tx.id.toString()} className="border p-2 rounded">
+                  <span className="font-mono">#{tx.id.toString()}</span> - {type}
+                  : {tx.amount.toString()} tokens on {time}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+
+      {filteredTransactions.length > 0 && (
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold">Filtered Transactions</h2>
+          <ul className="space-y-1">
+            {filteredTransactions.map((tx) => {
               const type = Object.keys(tx.transactionType)[0];
               const time = new Date(
                 Number(tx.timestamp / BigInt(1_000_000))

--- a/src/dao_frontend/src/hooks/useTreasury.js
+++ b/src/dao_frontend/src/hooks/useTreasury.js
@@ -41,6 +41,74 @@ export const useTreasury = () => {
     }
   };
 
+  const lockTokens = async (amount, reason) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await actors.treasury.lockTokens(
+        BigInt(amount),
+        reason
+      );
+      return result;
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const unlockTokens = async (amount, reason) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await actors.treasury.unlockTokens(
+        BigInt(amount),
+        reason
+      );
+      return result;
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const reserveTokens = async (amount, reason) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await actors.treasury.reserveTokens(
+        BigInt(amount),
+        reason
+      );
+      return result;
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const releaseReservedTokens = async (amount, reason) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await actors.treasury.releaseReservedTokens(
+        BigInt(amount),
+        reason
+      );
+      return result;
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
   const getBalance = async () => {
     setLoading(true);
     setError(null);
@@ -69,11 +137,62 @@ export const useTreasury = () => {
     }
   };
 
+  const getTransactionsByType = async (type) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const txs = await actors.treasury.getTransactionsByType({
+        [type]: null,
+      });
+      return txs;
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getRecentTransactions = async (limit) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const txs = await actors.treasury.getRecentTransactions(BigInt(limit));
+      return txs;
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getTreasuryStats = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const stats = await actors.treasury.getTreasuryStats();
+      return stats;
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return {
     deposit,
     withdraw,
+    lockTokens,
+    unlockTokens,
+    reserveTokens,
+    releaseReservedTokens,
     getBalance,
     getAllTransactions,
+    getTransactionsByType,
+    getRecentTransactions,
+    getTreasuryStats,
     loading,
     error,
   };


### PR DESCRIPTION
## Summary
- add lock/unlock/reserve/release helpers and transaction filters in treasury hook
- expand Treasury UI with token controls, stats, and filtering view

## Testing
- `npm test` *(fails: dfx: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689edd60071c8320a5b1373b9d64ff7d