### PR TITLE
Add governance dependencies to dfx.json

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -5,6 +5,10 @@
       "type": "motoko"
     },
     "governance": {
+      "dependencies": [
+        "dao_backend",
+        "staking"
+      ],
       "main": "src/dao_backend/governance/main.mo",
       "type": "motoko"
     },


### PR DESCRIPTION
## Summary
- include dao_backend and staking in governance canister dependencies

## Testing
- `npm test` *(fails: dfx: not found)*
- `dfx deploy` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ee5c8f7448320a4c988d4f580cc82