### PR TITLE
refactor: convert system init to shared

### DIFF
--- a/src/dao_backend/assets/main.mo
+++ b/src/dao_backend/assets/main.mo
@@ -77,7 +77,7 @@ actor AssetCanister {
     // principal that is immediately granted upload permissions. If omitted,
     // the list of authorized uploaders starts empty and can be populated
     // later via `addAuthorizedUploader`.
-    system func init(initialUploader : ?Principal) {
+    shared ({caller}) func init(initialUploader : ?Principal) {
         switch (initialUploader) {
             case (?p) { authorizedUploaders := [p] };
             case null {};


### PR DESCRIPTION
## Summary
- convert asset canister's `system` init to `shared` initializer

## Testing
- `npm test` *(fails: dfx: not found)*
- `moc src/dao_backend/assets/main.test.mo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ee98cf8c08320a12cf0c7ec6c4099