### PR TITLE
Restrict asset uploads to authorized users

### DIFF
--- a/src/dao_backend/assets/main.mo
+++ b/src/dao_backend/assets/main.mo
@@ -118,6 +118,9 @@ actor AssetCanister {
         tags: [Text]
     ) : async Result<AssetId, Text> {
         let caller = msg.caller;
+        if (authorizedUploaders.size() > 0 and not isAuthorized(caller)) {
+            return #err("Not authorized to upload assets");
+        };
         let dataSize = data.size();
 
         // Validate input


### PR DESCRIPTION
## Summary
- add authorization guard in `uploadAsset` to prevent unauthorized asset uploads
- batch uploading already routes through `uploadAsset`, so no further updates required

## Testing
- `npm test` *(fails: dfx: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ee99d927883208fda5408202bae69