### PR TITLE
Make init function public shared in asset canister

### DIFF
--- a/src/dao_backend/assets/main.mo
+++ b/src/dao_backend/assets/main.mo
@@ -77,7 +77,7 @@ actor AssetCanister {
     // principal that is immediately granted upload permissions. If omitted,
     // the list of authorized uploaders starts empty and can be populated
     // later via `addAuthorizedUploader`.
-    shared ({caller}) func init(initialUploader : ?Principal) {
+    public shared ({caller}) func init(initialUploader : ?Principal) : async () {
         switch (initialUploader) {
             case (?p) { authorizedUploaders := [p] };
             case null {};


### PR DESCRIPTION
## Summary
- expose `init` as public shared with async return

## Testing
- `npm test` *(fails: dfx not found)*
- `dfx build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689eede70a848320a51e4b864dd9300f