### PR TITLE
Fix init unused parameter warning

### DIFF
--- a/src/dao_backend/governance/main.mo
+++ b/src/dao_backend/governance/main.mo
@@ -46,7 +46,7 @@ actor GovernanceCanister {
     private var votes = HashMap.HashMap<Text, Vote>(100, Text.equal, Text.hash);
     private var config = HashMap.HashMap<Text, GovernanceConfig>(1, Text.equal, Text.hash);
 
-    public shared(msg) func init(daoId: Principal, stakingId: Principal) {
+    public shared(_msg) func init(daoId: Principal, stakingId: Principal) {
         if (Principal.isAnonymous(daoId) or Principal.isAnonymous(stakingId)) {
             Debug.trap("Invalid DAO or Staking principal provided");
         };


### PR DESCRIPTION
## Summary
- silence unused `msg` in governance `init`

## Testing
- `npm test` *(fails: dfx: not found)*
- `npm run build` *(fails: dfx: not found)*
- `dfx build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ef7c7118883208c182f47d7c457a4