### PR TITLE
feat: add governance canister initialization arguments

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -5,12 +5,13 @@
       "type": "motoko"
     },
     "governance": {
+      "main": "src/dao_backend/governance/main.mo",
+      "type": "motoko",
       "dependencies": [
         "dao_backend",
         "staking"
       ],
-      "main": "src/dao_backend/governance/main.mo",
-      "type": "motoko"
+      "arguments": "(principal \"canister:dao_backend\", principal \"canister:staking\")"
     },
     "staking": {
       "main": "src/dao_backend/staking/main.mo",


### PR DESCRIPTION
## Summary
- add deployment arguments to governance canister config

## Testing
- `npm test` (fails: dfx not found)
- `dfx deploy` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_689ef7be57908320adf068b3d45bd3ef