### PR TITLE
feat: add voting power to proposal votes

### DIFF
--- a/src/dao_frontend/src/components/Proposals.jsx
+++ b/src/dao_frontend/src/components/Proposals.jsx
@@ -1,5 +1,8 @@
 import React, { useEffect, useState } from 'react';
+import { Principal } from '@dfinity/principal';
 import { useProposals } from '../hooks/useProposals';
+import { useActors } from '../context/ActorContext';
+import { useAuth } from '../context/AuthContext';
 
 const Proposals = () => {
   const {
@@ -11,6 +14,8 @@ const Proposals = () => {
     loading,
     error,
   } = useProposals();
+  const actors = useActors();
+  const { principal } = useAuth();
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [category, setCategory] = useState('');
@@ -57,7 +62,10 @@ const Proposals = () => {
   const handleVote = async (e) => {
     e.preventDefault();
     try {
-      await vote(proposalId, choice, reason);
+      const userPrincipal = Principal.fromText(principal);
+      const summary = await actors.staking.getUserStakingSummary(userPrincipal);
+      const votingPower = summary.totalVotingPower;
+      await vote(proposalId, choice, votingPower, reason);
       console.log('Voted on proposal');
       setProposalId('');
       setReason('');

--- a/src/dao_frontend/src/hooks/useProposals.js
+++ b/src/dao_frontend/src/hooks/useProposals.js
@@ -106,7 +106,7 @@ export const useProposals = () => {
     }
   };
 
-  const vote = async (proposalId, choice, reason) => {
+  const vote = async (proposalId, choice, votingPower, reason) => {
     setLoading(true);
     setError(null);
     try {
@@ -114,6 +114,7 @@ export const useProposals = () => {
       const res = await actors.proposals.vote(
         BigInt(proposalId),
         choiceVariant,
+        BigInt(votingPower),
         reason ? [reason] : []
       );
       if ('err' in res) throw new Error(res.err);


### PR DESCRIPTION
## Summary
- include voting power in proposal vote call
- compute user's voting power from staking summary in UI

## Testing
- `npm test` *(fails: dfx not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f4715e2b88320bd4aff12b6b4dad0