### PR TITLE
Validate team member principals during launch

### DIFF
--- a/src/dao_frontend/src/components/LaunchDAO.jsx
+++ b/src/dao_frontend/src/components/LaunchDAO.jsx
@@ -27,8 +27,9 @@ import { useDAO } from '../context/DAOContext';
 import { useNavigate } from 'react-router-dom';
 import { useDAOOperations } from '../hooks/useDAOOperations';
 import BackgroundParticles from './BackgroundParticles';
-import { 
-  ArrowLeft, 
+import { Principal } from '@dfinity/principal';
+import {
+  ArrowLeft,
   ArrowRight, 
   Rocket, 
   Shield, 
@@ -242,8 +243,17 @@ const LaunchDAO = () => {
         break;
       
       case 6:
-        if (formData.teamMembers.some(member => !member.name.trim() || !member.role.trim())) {
-          newErrors.teamMembers = 'All team members must have name and role';
+        for (const member of formData.teamMembers) {
+          if (!member.name.trim() || !member.role.trim() || !member.wallet.trim()) {
+            newErrors.teamMembers = 'All team members must have name, role, and wallet address';
+            break;
+          }
+          try {
+            Principal.fromText(member.wallet);
+          } catch (err) {
+            newErrors.teamMembers = `Invalid wallet principal for team member ${member.name || ''}`;
+            break;
+          }
         }
         break;
       
@@ -937,11 +947,11 @@ const LaunchDAO = () => {
                           type="text"
                           value={member.name}
                           onChange={(e) => updateTeamMember(index, 'name', e.target.value)}
-                          className="w-full px-4 py-3 bg-gray-800 border border-gray-600 rounded-lg focus:ring-2 focus:ring-cyan-500 focus:border-transparent text-white font-mono"
+                          className={`w-full px-4 py-3 bg-gray-800 border ${errors.teamMembers ? 'border-red-500' : 'border-gray-600'} rounded-lg focus:ring-2 focus:ring-cyan-500 focus:border-transparent text-white font-mono`}
                           placeholder="John Doe"
                         />
                       </div>
-                      
+
                       <div>
                         <label className="block text-sm font-semibold text-gray-300 mb-2 font-mono">
                           Role <span className="text-red-400">*</span>
@@ -950,18 +960,18 @@ const LaunchDAO = () => {
                           type="text"
                           value={member.role}
                           onChange={(e) => updateTeamMember(index, 'role', e.target.value)}
-                          className="w-full px-4 py-3 bg-gray-800 border border-gray-600 rounded-lg focus:ring-2 focus:ring-cyan-500 focus:border-transparent text-white font-mono"
+                          className={`w-full px-4 py-3 bg-gray-800 border ${errors.teamMembers ? 'border-red-500' : 'border-gray-600'} rounded-lg focus:ring-2 focus:ring-cyan-500 focus:border-transparent text-white font-mono`}
                           placeholder="CEO"
                         />
                       </div>
-                      
+
                       <div>
                         <label className="block text-sm font-semibold text-gray-300 mb-2 font-mono">Wallet Address</label>
                         <input
                           type="text"
                           value={member.wallet}
                           onChange={(e) => updateTeamMember(index, 'wallet', e.target.value)}
-                          className="w-full px-4 py-3 bg-gray-800 border border-gray-600 rounded-lg focus:ring-2 focus:ring-cyan-500 focus:border-transparent text-white font-mono"
+                          className={`w-full px-4 py-3 bg-gray-800 border ${errors.teamMembers ? 'border-red-500' : 'border-gray-600'} rounded-lg focus:ring-2 focus:ring-cyan-500 focus:border-transparent text-white font-mono`}
                           placeholder="0x..."
                         />
                       </div>
@@ -969,6 +979,9 @@ const LaunchDAO = () => {
                   </div>
                 ))}
               </div>
+              {errors.teamMembers && (
+                <p className="text-red-400 text-sm font-mono">{errors.teamMembers}</p>
+              )}
             </div>
           )}
 

--- a/src/dao_frontend/src/hooks/useDAOOperations.js
+++ b/src/dao_frontend/src/hooks/useDAOOperations.js
@@ -19,10 +19,17 @@ export const useDAOOperations = () => {
         
         try {
             // Step 1: Initialize the DAO with basic info
-            const initialAdmins = daoConfig.teamMembers
-                .map(member => member.wallet)
-                .filter(wallet => wallet) // Remove empty wallets
-                .map(wallet => Principal.fromText(wallet)); // Convert to Principal
+            const initialAdmins = [];
+            for (const member of daoConfig.teamMembers || []) {
+                const { wallet, name } = member;
+                if (!wallet) continue;
+                try {
+                    initialAdmins.push(Principal.fromText(wallet));
+                } catch (err) {
+                    console.warn(`Failed to parse wallet for team member ${name || wallet}:`, err);
+                    throw new Error(`Invalid team member wallet: ${wallet}`);
+                }
+            }
             let creatorPrincipal = null;
             // Add the creator as an admin if not already included
             if (principal) {


### PR DESCRIPTION
## Summary
- require team member wallets to be present and valid principals during step 6
- surface an error message when invalid principals are entered
- guard initial admin parsing with try/catch to report malformed wallets

## Testing
- `npm test` *(fails: dfx not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f478a2e2083208cee881fd2477cfe