### PR TITLE
Validate numeric DAO config inputs

### DIFF
--- a/src/dao_frontend/src/components/LaunchDAO.jsx
+++ b/src/dao_frontend/src/components/LaunchDAO.jsx
@@ -228,17 +228,23 @@ const LaunchDAO = () => {
         if (!formData.tokenName.trim()) newErrors.tokenName = 'Token name is required';
         if (!formData.tokenSymbol.trim()) newErrors.tokenSymbol = 'Token symbol is required';
         if (!formData.totalSupply) newErrors.totalSupply = 'Total supply is required';
+        else if (!/^\d+$/.test(formData.totalSupply)) newErrors.totalSupply = 'Total supply must be numeric';
         if (!formData.initialPrice) newErrors.initialPrice = 'Initial price is required';
+        else if (!/^\d+$/.test(formData.initialPrice)) newErrors.initialPrice = 'Initial price must be numeric';
         break;
-      
+
       case 4:
         if (!formData.votingPeriod) newErrors.votingPeriod = 'Voting period is required';
+        else if (!/^\d+$/.test(formData.votingPeriod)) newErrors.votingPeriod = 'Voting period must be numeric';
         if (!formData.quorumThreshold) newErrors.quorumThreshold = 'Quorum threshold is required';
+        else if (!/^\d+$/.test(formData.quorumThreshold)) newErrors.quorumThreshold = 'Quorum threshold must be numeric';
         break;
-      
+
       case 5:
         if (!formData.fundingGoal) newErrors.fundingGoal = 'Funding goal is required';
+        else if (!/^\d+$/.test(formData.fundingGoal)) newErrors.fundingGoal = 'Funding goal must be numeric';
         if (!formData.minInvestment) newErrors.minInvestment = 'Minimum investment is required';
+        else if (!/^\d+$/.test(formData.minInvestment)) newErrors.minInvestment = 'Minimum investment must be numeric';
         break;
       
       case 6:

--- a/src/dao_frontend/src/hooks/useDAOOperations.js
+++ b/src/dao_frontend/src/hooks/useDAOOperations.js
@@ -5,7 +5,20 @@ import { useActors } from '../context/ActorContext';
 import { useAuth } from '../context/AuthContext';
 import { Principal } from '@dfinity/principal';
 
-const toNanoseconds = (seconds) => BigInt(seconds) * 1_000_000_000n;
+const safeBigInt = (value, field) => {
+    if (value === undefined || value === null || value === '') return 0n;
+    const str = value.toString();
+    if (!/^\d+$/.test(str)) {
+        throw new Error(`${field} must be a valid number`);
+    }
+    try {
+        return BigInt(str);
+    } catch {
+        throw new Error(`${field} is too large or invalid`);
+    }
+};
+
+const toNanoseconds = (seconds, field) => safeBigInt(seconds, field) * 1_000_000_000n;
 
 export const useDAOOperations = () => {
     const actors = useActors();
@@ -99,14 +112,14 @@ export const useDAOOperations = () => {
                 moduleFeatures,
                 tokenName: daoConfig.tokenName,
                 tokenSymbol: daoConfig.tokenSymbol,
-                totalSupply: BigInt(daoConfig.totalSupply || 0),
-                initialPrice: BigInt(daoConfig.initialPrice || 0),
-                votingPeriod: toNanoseconds(daoConfig.votingPeriod || 0),
-                quorumThreshold: BigInt(daoConfig.quorumThreshold || 0),
-                proposalThreshold: BigInt(daoConfig.proposalThreshold || 0),
-                fundingGoal: BigInt(daoConfig.fundingGoal || 0),
-                fundingDuration: toNanoseconds(daoConfig.fundingDuration || 0),
-                minInvestment: BigInt(daoConfig.minInvestment || 0),
+                totalSupply: safeBigInt(daoConfig.totalSupply, 'Total supply'),
+                initialPrice: safeBigInt(daoConfig.initialPrice, 'Initial price'),
+                votingPeriod: toNanoseconds(daoConfig.votingPeriod, 'Voting period'),
+                quorumThreshold: safeBigInt(daoConfig.quorumThreshold, 'Quorum threshold'),
+                proposalThreshold: safeBigInt(daoConfig.proposalThreshold, 'Proposal threshold'),
+                fundingGoal: safeBigInt(daoConfig.fundingGoal, 'Funding goal'),
+                fundingDuration: toNanoseconds(daoConfig.fundingDuration, 'Funding duration'),
+                minInvestment: safeBigInt(daoConfig.minInvestment, 'Minimum investment'),
                 termsAccepted: daoConfig.termsAccepted,
                 kycRequired: daoConfig.kycRequired
             });


### PR DESCRIPTION
## Summary
- ensure numeric DAO setup fields only allow digits
- guard BigInt conversions in DAO operations with validation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f47847b108320b7d1379d9b76bee4