### PR TITLE
Use getGovernanceStats in governance hook

### DIFF
--- a/src/dao_frontend/src/hooks/useGovernance.js
+++ b/src/dao_frontend/src/hooks/useGovernance.js
@@ -72,11 +72,8 @@ export const useGovernance = () => {
     setLoading(true);
     setError(null);
     try {
-
-      const res = await actors.governance.getStats();
-      if ('err' in res) throw new Error(res.err);
-      return 'ok' in res ? res.ok : res;
-
+      const res = await actors.governance.getGovernanceStats();
+      return res;
     } catch (err) {
       setError(err.message);
       throw err;


### PR DESCRIPTION
## Summary
- Call `getGovernanceStats` instead of deprecated `getStats` in governance hook
- Simplify stats response handling to return raw data

## Testing
- ⚠️ `npm test` (root) - fails: dfx: not found
- ✅ `npm test` (src/dao_frontend)


------
https://chatgpt.com/codex/tasks/task_e_689f47177e3c8320b3a5af2619534bd9