### PR TITLE
Restrict uploads when no authorized uploaders

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -26,7 +26,8 @@
     },
     "assets": {
       "main": "src/dao_backend/assets/main.mo",
-      "type": "motoko"
+      "type": "motoko",
+      "init": { "args": "(null, false)" }
     },
     "dao_frontend": {
       "dependencies": [

--- a/src/dao_backend/assets/main.test.mo
+++ b/src/dao_backend/assets/main.test.mo
@@ -1,23 +1,36 @@
 import Asset "./main";
 import Principal "mo:base/Principal";
 import Array "mo:base/Array";
+import Blob "mo:base/Blob";
 import Debug "mo:base/Debug";
 
-// Simple runtime test that verifies the first call to `addAuthorizedUploader`
-// succeeds even when no uploader has been configured yet.
+// Simple runtime test that verifies uploads are rejected until an uploader is
+// authorized and that the first call to `addAuthorizedUploader` succeeds even
+// when no uploader has been configured yet.
 actor {
     public func main() : async () {
-        let testPrincipal = Principal.fromText("aaaaa-aa");
-        let res = await Asset.addAuthorizedUploader(testPrincipal);
+        let selfPrincipal = Principal.fromActor(this);
+
+        // Upload should fail while no authorized uploaders exist.
+        let data = Blob.fromArray([1,2,3]);
+        let uploadBefore = await Asset.uploadAsset("test", "image/png", data, true, []);
+        assert uploadBefore == #err("Uploads are disabled until an uploader is authorized or open uploads are enabled");
+
+        // Anyone can authorize the first uploader.
+        let res = await Asset.addAuthorizedUploader(selfPrincipal);
         assert res == #ok();
 
         let uploaders = await Asset.getAuthorizedUploaders();
-        assert Array.find<Principal>(uploaders, func(p) = p == testPrincipal) != null;
+        assert Array.find<Principal>(uploaders, func(p) = p == selfPrincipal) != null;
 
-        let duplicateRes = await Asset.addAuthorizedUploader(testPrincipal);
+        // After authorization, upload succeeds.
+        let uploadAfter = await Asset.uploadAsset("test2", "image/png", data, true, []);
+        switch uploadAfter { case (#ok(_)) {}; case (_) { assert false } };
+
+        let duplicateRes = await Asset.addAuthorizedUploader(selfPrincipal);
         assert duplicateRes == #err("Uploader already authorized");
 
-        Debug.print("initial uploader configuration test passed");
+        Debug.print("initial uploader configuration and upload permission test passed");
     };
 }
 


### PR DESCRIPTION
## Summary
- require explicit flag to allow uploads before any uploader is authorized
- update asset tests to assert uploads are blocked until authorization
- document and configure new initialization parameter

## Testing
- `npm test` *(fails: dfx: not found)*
- `moc -r src/dao_backend/assets/main.test.mo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f4ed8547c8320b04bf575964cc193