### PR TITLE
feat: secure governance init

### DIFF
--- a/src/dao_backend/governance/main.test.mo
+++ b/src/dao_backend/governance/main.test.mo
@@ -1,0 +1,41 @@
+import Governance "./main";
+import Types "../shared/types";
+import Principal "mo:base/Principal";
+import Debug "mo:base/Debug";
+
+actor {
+    public func main() : async () {
+        let admin = Principal.fromActor(this);
+
+        let daoStub = actor {
+            public shared query func getUserProfile(_: Principal) -> async ?Types.UserProfile { null };
+            public query func checkIsAdmin(p: Principal) : async Bool { p == admin };
+        };
+        let stakingStub = actor {
+            public shared query func getUserStakingSummary(_: Principal) -> async {
+                totalStaked: Nat;
+                totalRewards: Nat;
+                activeStakes: Nat;
+                totalVotingPower: Nat;
+            } {
+                { totalStaked = 0; totalRewards = 0; activeStakes = 0; totalVotingPower = 0 }
+            };
+        };
+
+        await Governance.init(Principal.fromActor(daoStub), Principal.fromActor(stakingStub));
+
+        let malicious = actor {
+            public func attemptReinit() : async Bool {
+                try {
+                    await Governance.init(Principal.fromActor(daoStub), Principal.fromActor(stakingStub));
+                    false
+                } catch (_) {
+                    true
+                }
+            }
+        };
+
+        assert (await malicious.attemptReinit());
+        Debug.print("Unauthorized init attempt correctly rejected");
+    }
+}


### PR DESCRIPTION
## Summary
- restrict governance init to admins or self and persist dao/staking references
- rebuild actor references on upgrade
- add test preventing unauthorized init after setup

## Testing
- `dfx test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f4edac8788320977182802f75d937