### PR TITLE
feat: add authorization checks to DAO modules

### DIFF
--- a/src/dao_backend/assets/main.mo
+++ b/src/dao_backend/assets/main.mo
@@ -10,10 +10,12 @@ import Nat "mo:base/Nat";
 import Text "mo:base/Text";
 import Blob "mo:base/Blob";
 import Nat32 "mo:base/Nat32";
+import Types "../shared/types";
 
 persistent actor AssetCanister {
     type Result<T, E> = Result.Result<T, E>;
     type Time = Time.Time;
+    type CommonError = Types.CommonError;
 
     // Asset types
     public type AssetId = Nat;
@@ -375,14 +377,14 @@ persistent actor AssetCanister {
     // Administrative functions
 
     // Add authorized uploader
-    public shared(msg) func addAuthorizedUploader(principal: Principal) : async Result<(), Text> {
+    public shared(msg) func addAuthorizedUploader(principal: Principal) : async Result<(), CommonError> {
         // Allow the first uploader to be added by anyone when the list is empty.
         if (authorizedUploaders.size() > 0 and not isAuthorized(msg.caller)) {
-            return #err("Not authorized to add uploaders");
+            return #err(#notAuthorized);
         };
 
         if (isAuthorized(principal)) {
-            return #err("Uploader already authorized");
+            return #err(#alreadyExists);
         };
 
         let principals = Buffer.fromArray<Principal>(authorizedUploaders);
@@ -394,13 +396,13 @@ persistent actor AssetCanister {
     };
 
     // Remove authorized uploader
-    public shared(msg) func removeAuthorizedUploader(principal: Principal) : async Result<(), Text> {
+    public shared(msg) func removeAuthorizedUploader(principal: Principal) : async Result<(), CommonError> {
         if (not isAuthorized(msg.caller)) {
-            return #err("Not authorized to remove uploaders");
+            return #err(#notAuthorized);
         };
 
         authorizedUploaders := Array.filter<Principal>(authorizedUploaders, func(p) = p != principal);
-        
+
         Debug.print("Authorized uploader removed: " # Principal.toText(principal));
         #ok()
     };
@@ -409,9 +411,9 @@ persistent actor AssetCanister {
     public shared(msg) func updateStorageLimits(
         maxFileSizeNew: ?Nat,
         maxTotalStorageNew: ?Nat
-    ) : async Result<(), Text> {
+    ) : async Result<(), CommonError> {
         if (not isAuthorized(msg.caller)) {
-            return #err("Not authorized to update storage limits");
+            return #err(#notAuthorized);
         };
 
         switch (maxFileSizeNew) {
@@ -422,7 +424,7 @@ persistent actor AssetCanister {
         switch (maxTotalStorageNew) {
             case (?size) {
                 if (size < currentStorageUsed) {
-                    return #err("New storage limit cannot be less than current usage");
+                    return #err(#invalidInput);
                 };
                 maxTotalStorage := size;
             };

--- a/src/dao_backend/assets/main.test.mo
+++ b/src/dao_backend/assets/main.test.mo
@@ -2,20 +2,30 @@ import Asset "./main";
 import Principal "mo:base/Principal";
 import Array "mo:base/Array";
 import Debug "mo:base/Debug";
+import Types "../shared/types";
+import Result "mo:base/Result";
 
 // Simple runtime test that verifies the first call to `addAuthorizedUploader`
 // succeeds even when no uploader has been configured yet.
 actor {
     public func main() : async () {
-        let testPrincipal = Principal.fromText("aaaaa-aa");
-        let res = await Asset.addAuthorizedUploader(testPrincipal);
+        let myPrincipal = Principal.fromActor(this);
+        let res = await Asset.addAuthorizedUploader(myPrincipal);
         assert res == #ok();
 
         let uploaders = await Asset.getAuthorizedUploaders();
-        assert Array.find<Principal>(uploaders, func(p) = p == testPrincipal) != null;
+        assert Array.find<Principal>(uploaders, func(p) = p == myPrincipal) != null;
 
-        let duplicateRes = await Asset.addAuthorizedUploader(testPrincipal);
-        assert duplicateRes == #err("Uploader already authorized");
+        let unauthorized = actor {
+            public func tryAdd(p: Principal) : async Result<(), Types.CommonError> {
+                await Asset.addAuthorizedUploader(p);
+            }
+        };
+        let unauthorizedRes = await unauthorized.tryAdd(myPrincipal);
+        assert unauthorizedRes == #err(#notAuthorized);
+
+        let duplicateRes = await Asset.addAuthorizedUploader(myPrincipal);
+        assert duplicateRes == #err(#alreadyExists);
 
         Debug.print("initial uploader configuration test passed");
     };

--- a/src/dao_backend/governance/main.mo
+++ b/src/dao_backend/governance/main.mo
@@ -64,6 +64,8 @@ persistent actor GovernanceCanister {
     private var votesEntries : [(Text, Vote)] = []; // Key format: "proposalId_voterPrincipal"
     private var configEntries : [(Text, GovernanceConfig)] = [];
 
+    private var authorizedPrincipals : [Principal] = [];
+
     // Runtime storage - rebuilt from stable storage after upgrades
     // HashMaps provide O(1) lookup performance for governance operations
     private transient var proposals = HashMap.HashMap<ProposalId, Proposal>(10, Nat.equal, func(n: Nat) : Nat32 { Nat32.fromNat(n) });
@@ -457,9 +459,36 @@ public shared(_msg) func init(daoId: Principal, stakingId: Principal) {
         config.get("default")
     };
 
+    public shared(msg) func addAuthorizedPrincipal(principal: Principal) : async Result<(), CommonError> {
+        if (authorizedPrincipals.size() > 0 and not isAuthorized(msg.caller)) {
+            return #err(#notAuthorized);
+        };
+        if (isAuthorized(principal)) {
+            return #err(#alreadyExists);
+        };
+        let principals = Buffer.fromArray<Principal>(authorizedPrincipals);
+        principals.add(principal);
+        authorizedPrincipals := Buffer.toArray(principals);
+        #ok()
+    };
+
+    public shared(msg) func removeAuthorizedPrincipal(principal: Principal) : async Result<(), CommonError> {
+        if (not isAuthorized(msg.caller)) {
+            return #err(#notAuthorized);
+        };
+        authorizedPrincipals := Array.filter<Principal>(authorizedPrincipals, func(p) = p != principal);
+        #ok()
+    };
+
+    public query func getAuthorizedPrincipals() : async [Principal] {
+        authorizedPrincipals
+    };
+
     // Update governance configuration (admin only)
-    public shared(_msg) func updateConfig(newConfig: GovernanceConfig) : async Result<(), Text> {
-        // In a real implementation, you'd check if the caller is an admin
+    public shared(msg) func updateConfig(newConfig: GovernanceConfig) : async Result<(), CommonError> {
+        if (not isAuthorized(msg.caller)) {
+            return #err(#notAuthorized);
+        };
         config.put("default", newConfig);
         #ok()
     };
@@ -469,10 +498,14 @@ public shared(_msg) func init(daoId: Principal, stakingId: Principal) {
         let userProposals = Buffer.Buffer<Proposal>(0);
         for (proposal in proposals.vals()) {
             if (proposal.proposer == user and proposal.status == #active) {
-                userProposals.add(proposal);
+            userProposals.add(proposal);
             };
         };
         Buffer.toArray(userProposals)
+    };
+
+    private func isAuthorized(principal: Principal) : Bool {
+        Array.find<Principal>(authorizedPrincipals, func(p) = p == principal) != null
     };
 
     // Get governance statistics

--- a/src/dao_backend/governance/main.test.mo
+++ b/src/dao_backend/governance/main.test.mo
@@ -1,0 +1,33 @@
+import Governance "./main";
+import Principal "mo:base/Principal";
+import Debug "mo:base/Debug";
+import Types "../shared/types";
+import Result "mo:base/Result";
+
+actor {
+    public func main() : async () {
+        let admin = actor {
+            public func update(cfg: Types.GovernanceConfig) : async Result<(), Types.CommonError> {
+                await Governance.updateConfig(cfg);
+            };
+        };
+        let adminPrincipal = Principal.fromActor(admin);
+        ignore await Governance.addAuthorizedPrincipal(adminPrincipal);
+
+        let cfg : Types.GovernanceConfig = {
+            votingPeriod = 1;
+            quorumThreshold = 1;
+            approvalThreshold = 51;
+            proposalDeposit = 0;
+            maxProposalsPerUser = 1;
+        };
+
+        let unauthorized = await Governance.updateConfig(cfg);
+        assert unauthorized == #err(#notAuthorized);
+
+        let authorized = await admin.update(cfg);
+        assert authorized == #ok();
+
+        Debug.print("governance auth test passed");
+    };
+}

--- a/src/dao_backend/staking/main.mo
+++ b/src/dao_backend/staking/main.mo
@@ -64,6 +64,7 @@ persistent actor StakingCanister {
     private var stakingEnabled : Bool = true;
     private var minimumStakeAmount : TokenAmount = 10; // Minimum 10 tokens to prevent dust attacks
     private var maximumStakeAmount : TokenAmount = 1000000; // Maximum 1M tokens to prevent centralization
+    private var authorizedPrincipals : [Principal] = [];
 
     // System functions for upgrades
     system func preupgrade() {
@@ -418,23 +419,50 @@ persistent actor StakingCanister {
 
     // Administrative functions
 
+    public shared(msg) func addAuthorizedPrincipal(principal: Principal) : async Result<(), CommonError> {
+        if (authorizedPrincipals.size() > 0 and not isAuthorized(msg.caller)) {
+            return #err(#notAuthorized);
+        };
+        if (isAuthorized(principal)) {
+            return #err(#alreadyExists);
+        };
+        let principals = Buffer.fromArray<Principal>(authorizedPrincipals);
+        principals.add(principal);
+        authorizedPrincipals := Buffer.toArray(principals);
+        #ok()
+    };
+
+    public shared(msg) func removeAuthorizedPrincipal(principal: Principal) : async Result<(), CommonError> {
+        if (not isAuthorized(msg.caller)) {
+            return #err(#notAuthorized);
+        };
+        authorizedPrincipals := Array.filter<Principal>(authorizedPrincipals, func(p) = p != principal);
+        #ok()
+    };
+
     // Enable/disable staking
-    public shared(_msg) func setStakingEnabled(enabled: Bool) : async Result<(), Text> {
-        // In real implementation, only governance should be able to do this
+    public shared(msg) func setStakingEnabled(enabled: Bool) : async Result<(), CommonError> {
+        if (not isAuthorized(msg.caller)) {
+            return #err(#notAuthorized);
+        };
         stakingEnabled := enabled;
         #ok()
     };
 
     // Update minimum stake amount
-    public shared(_msg) func setMinimumStakeAmount(amount: TokenAmount) : async Result<(), Text> {
-        // In real implementation, only governance should be able to do this
+    public shared(msg) func setMinimumStakeAmount(amount: TokenAmount) : async Result<(), CommonError> {
+        if (not isAuthorized(msg.caller)) {
+            return #err(#notAuthorized);
+        };
         minimumStakeAmount := amount;
         #ok()
     };
 
     // Update maximum stake amount
-    public shared(_msg) func setMaximumStakeAmount(amount: TokenAmount) : async Result<(), Text> {
-        // In real implementation, only governance should be able to do this
+    public shared(msg) func setMaximumStakeAmount(amount: TokenAmount) : async Result<(), CommonError> {
+        if (not isAuthorized(msg.caller)) {
+            return #err(#notAuthorized);
+        };
         maximumStakeAmount := amount;
         #ok()
     };
@@ -483,5 +511,9 @@ persistent actor StakingCanister {
         };
 
         newValue > currentValue
+    };
+
+    private func isAuthorized(principal: Principal) : Bool {
+        Array.find<Principal>(authorizedPrincipals, func(p) = p == principal) != null
     };
 }

--- a/src/dao_backend/staking/main.test.mo
+++ b/src/dao_backend/staking/main.test.mo
@@ -1,0 +1,25 @@
+import Staking "./main";
+import Principal "mo:base/Principal";
+import Debug "mo:base/Debug";
+import Types "../shared/types";
+import Result "mo:base/Result";
+
+actor {
+    public func main() : async () {
+        let admin = actor {
+            public func enable() : async Result<(), Types.CommonError> {
+                await Staking.setStakingEnabled(true);
+            };
+        };
+        let adminPrincipal = Principal.fromActor(admin);
+        ignore await Staking.addAuthorizedPrincipal(adminPrincipal);
+
+        let unauthorized = await Staking.setStakingEnabled(false);
+        assert unauthorized == #err(#notAuthorized);
+
+        let authorized = await admin.enable();
+        assert authorized == #ok();
+
+        Debug.print("staking auth test passed");
+    };
+}

--- a/src/dao_backend/treasury/main.mo
+++ b/src/dao_backend/treasury/main.mo
@@ -418,8 +418,14 @@ persistent actor TreasuryCanister {
     // Administrative functions
 
     // Add authorized principal
-    public shared(_msg) func addAuthorizedPrincipal(principal: Principal) : async Result<(), Text> {
+    public shared(msg) func addAuthorizedPrincipal(principal: Principal) : async Result<(), CommonError> {
         // In real implementation, only governance or admin should be able to do this
+        if (authorizedPrincipals.size() > 0 and not isAuthorized(msg.caller)) {
+            return #err(#notAuthorized);
+        };
+        if (isAuthorized(principal)) {
+            return #err(#alreadyExists);
+        };
         let principals = Buffer.fromArray<Principal>(authorizedPrincipals);
         principals.add(principal);
         authorizedPrincipals := Buffer.toArray(principals);
@@ -427,8 +433,11 @@ persistent actor TreasuryCanister {
     };
 
     // Remove authorized principal
-    public shared(_msg) func removeAuthorizedPrincipal(principal: Principal) : async Result<(), Text> {
+    public shared(msg) func removeAuthorizedPrincipal(principal: Principal) : async Result<(), CommonError> {
         // In real implementation, only governance or admin should be able to do this
+        if (not isAuthorized(msg.caller)) {
+            return #err(#notAuthorized);
+        };
         authorizedPrincipals := Array.filter<Principal>(authorizedPrincipals, func(p) = p != principal);
         #ok()
     };

--- a/src/dao_backend/treasury/main.test.mo
+++ b/src/dao_backend/treasury/main.test.mo
@@ -1,0 +1,28 @@
+import Treasury "./main";
+import Principal "mo:base/Principal";
+import Debug "mo:base/Debug";
+import Types "../shared/types";
+import Result "mo:base/Result";
+
+actor {
+    public func main() : async () {
+        let admin = actor {
+            public func add(p: Principal) : async Result<(), Types.CommonError> {
+                await Treasury.addAuthorizedPrincipal(p);
+            };
+        };
+        let adminPrincipal = Principal.fromActor(admin);
+        ignore await Treasury.addAuthorizedPrincipal(adminPrincipal);
+
+        let unauthorizedAdd = await Treasury.addAuthorizedPrincipal(Principal.fromActor(this));
+        assert unauthorizedAdd == #err(#notAuthorized);
+
+        let unauthorizedRemove = await Treasury.removeAuthorizedPrincipal(adminPrincipal);
+        assert unauthorizedRemove == #err(#notAuthorized);
+
+        let addRes = await admin.add(Principal.fromActor(this));
+        assert addRes == #ok();
+
+        Debug.print("treasury auth test passed");
+    };
+}


### PR DESCRIPTION
## Summary
- restrict staking admin functions via local authorized principal list
- enforce authorization for treasury and governance configuration changes
- harden asset canister admin operations with standardized `#notAuthorized` errors
- add tests demonstrating authorization failures

## Testing
- `moc -r src/dao_backend/assets/main.test.mo` *(fails: command not found)*
- `moc -r src/dao_backend/staking/main.test.mo` *(fails: command not found)*
- `moc -r src/dao_backend/treasury/main.test.mo` *(fails: command not found)*
- `moc -r src/dao_backend/governance/main.test.mo` *(fails: command not found)*
- `npm test` *(fails: dfx: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f4edcc28483208137209a42d79bff