### PR TITLE
feat: allow agent initialization with identity

### DIFF
--- a/src/dao_frontend/src/config/agent.ts
+++ b/src/dao_frontend/src/config/agent.ts
@@ -103,7 +103,7 @@ const createActor = async <T>(
   }
 };
 
-export const initializeAgents = async () => {
+export const initializeAgents = async (identity?: Identity) => {
   console.log("=== DEBUGGING ENVIRONMENT VARIABLES ===");
   console.log("All import.meta.env:", import.meta.env);
   
@@ -128,13 +128,15 @@ export const initializeAgents = async () => {
   try {
     // Create actors for required canisters
     const daoBackend = await createActor<DaoBackendService>(
-      import.meta.env.VITE_CANISTER_ID_DAO_BACKEND, 
-      daoBackendIdl
+      import.meta.env.VITE_CANISTER_ID_DAO_BACKEND,
+      daoBackendIdl,
+      identity
     );
-    
+
     const assets = await createActor<AssetsService>(
-      import.meta.env.VITE_CANISTER_ID_ASSETS, 
-      assetsIdl
+      import.meta.env.VITE_CANISTER_ID_ASSETS,
+      assetsIdl,
+      identity
     );
 
     // Create mock actors for optional canisters if they don't exist
@@ -166,8 +168,9 @@ export const initializeAgents = async () => {
     try {
       if (import.meta.env.VITE_CANISTER_ID_GOVERNANCE) {
         governance = await createActor<GovernanceService>(
-          import.meta.env.VITE_CANISTER_ID_GOVERNANCE, 
-          governanceIdl
+          import.meta.env.VITE_CANISTER_ID_GOVERNANCE,
+          governanceIdl,
+          identity
         );
       } else {
         governance = createMockActor<GovernanceService>();
@@ -180,8 +183,9 @@ export const initializeAgents = async () => {
     try {
       if (import.meta.env.VITE_CANISTER_ID_STAKING) {
         staking = await createActor<StakingService>(
-          import.meta.env.VITE_CANISTER_ID_STAKING, 
-          stakingIdl
+          import.meta.env.VITE_CANISTER_ID_STAKING,
+          stakingIdl,
+          identity
         );
       } else {
         staking = createMockActor<StakingService>();
@@ -194,8 +198,9 @@ export const initializeAgents = async () => {
     try {
       if (import.meta.env.VITE_CANISTER_ID_TREASURY) {
         treasury = await createActor<TreasuryService>(
-          import.meta.env.VITE_CANISTER_ID_TREASURY, 
-          treasuryIdl
+          import.meta.env.VITE_CANISTER_ID_TREASURY,
+          treasuryIdl,
+          identity
         );
       } else {
         treasury = createMockActor<TreasuryService>();
@@ -208,8 +213,9 @@ export const initializeAgents = async () => {
     try {
       if (import.meta.env.VITE_CANISTER_ID_PROPOSALS) {
         proposals = await createActor<ProposalsService>(
-          import.meta.env.VITE_CANISTER_ID_PROPOSALS, 
-          proposalsIdl
+          import.meta.env.VITE_CANISTER_ID_PROPOSALS,
+          proposalsIdl,
+          identity
         );
       } else {
         proposals = createMockActor<ProposalsService>();

--- a/src/dao_frontend/src/context/ActorContext.tsx
+++ b/src/dao_frontend/src/context/ActorContext.tsx
@@ -26,7 +26,7 @@ export const ActorProvider = ({ children }: ActorProviderProps) => {
     const setup = async () => {
       setLoading(true);
       try {
-        const initializedActors = await initializeAgents(identity ?? undefined);
+        const initializedActors = await initializeAgents(identity);
         setActors(initializedActors);
       } catch (err) {
         console.error("Failed to initialize actors:", err);


### PR DESCRIPTION
## Summary
- allow initializeAgents to accept an optional Identity and propagate it to all canister actors
- invoke initializeAgents with the user's identity in ActorContext

## Testing
- `npm test` *(fails: dfx: not found)*
- `npm run build` *(fails: dfx: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ff0a31fb48320bbce13b3ab7c8cb5