### PR TITLE
Use Blob.size for asset data length

### DIFF
--- a/src/dao_backend/assets/main.mo
+++ b/src/dao_backend/assets/main.mo
@@ -132,7 +132,7 @@ persistent actor AssetCanister {
         } else if (not isAuthorized(caller)) {
             return #err("Not authorized to upload assets");
         };
-        let dataSize = data.size();
+        let dataSize = Blob.size(data);
 
         // Validate input
         if (name == "") {


### PR DESCRIPTION
## Summary
- fix asset upload data size to use `Blob.size`

## Testing
- `npm test` *(fails: dfx: not found)*
- `dfx build` *(fails: command not found: dfx)*

------
https://chatgpt.com/codex/tasks/task_e_689ff0ab3a0483208b0f780aca478dbf