### PR TITLE
Refactor DAO context to use actor provider

### DIFF
--- a/src/dao_frontend/src/context/DAOContext.jsx
+++ b/src/dao_frontend/src/context/DAOContext.jsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import { useAuth } from './AuthContext';
-import { dao_backend } from '../declarations/dao_backend';
+import { useActors } from './ActorContext';
 
 // Create the DAO Context
 const DAOContext = createContext();
@@ -8,6 +8,7 @@ const DAOContext = createContext();
 // DAO Provider component
 export const DAOProvider = ({ children }) => {
   const { isAuthenticated, principal } = useAuth();
+  const { daoBackend } = useActors();
   const [activeDAO, setActiveDAO] = useState(null);
   const [userDAOs, setUserDAOs] = useState([]);
   const [loading, setLoading] = useState(false);
@@ -20,18 +21,18 @@ export const DAOProvider = ({ children }) => {
       setActiveDAO(null);
       setUserDAOs([]);
     }
-  }, [isAuthenticated, principal]);
+  }, [isAuthenticated, principal, daoBackend]);
 
   const checkUserDAOs = async () => {
     setLoading(true);
     try {
-      if (!dao_backend || !principal) {
+      if (!daoBackend || !principal) {
         setUserDAOs([]);
         setActiveDAO(null);
         return;
       }
 
-      const response = await dao_backend.getAllUsers();
+      const response = await daoBackend.getAllUsers();
       let daos = [];
 
       if (Array.isArray(response)) {


### PR DESCRIPTION
## Summary
- retrieve `daoBackend` actor via `useActors` in DAO context
- update DAO context to call `daoBackend` methods from actor provider

## Testing
- `npm test` *(fails: dfx: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ff0c27b948320b1c905ed1df5c9d0