### PR TITLE
Integrate DAO management hooks across views

### DIFF
--- a/src/dao_frontend/src/components/management/ManagementAssets.tsx
+++ b/src/dao_frontend/src/components/management/ManagementAssets.tsx
@@ -1,71 +1,54 @@
-import React from 'react';
-import { motion } from 'framer-motion';
+import React, { useEffect, useState } from 'react';
 import { useOutletContext } from 'react-router-dom';
-import { 
-  Image, 
-  Upload, 
-  Download,
-  Folder,
-  File,
-  Video,
-  Music,
-  Archive
-} from 'lucide-react';
 import { DAO } from '../../types/dao';
+import { useAssets } from '../../hooks/useAssets';
 
 const ManagementAssets: React.FC = () => {
   const { dao } = useOutletContext<{ dao: DAO }>();
+  const { getUserAssets, getAssetMetadata, loading, error } = useAssets();
+  const [assets, setAssets] = useState<any[]>([]);
+  const [metadata, setMetadata] = useState<Record<string, unknown>>({});
+
+  useEffect(() => {
+    getUserAssets()
+      .then(setAssets)
+      .catch(console.error);
+  }, []);
+
+  const handleMetadata = async (id: any) => {
+    try {
+      const meta = await getAssetMetadata(id);
+      setMetadata(prev => ({ ...prev, [id]: meta }));
+    } catch (err) {
+      console.error(err);
+    }
+  };
 
   return (
-    <div className="space-y-8">
-      {/* Header */}
-      <div className="flex justify-between items-center">
-        <div>
-          <h2 className="text-2xl font-bold text-white mb-2 font-mono">ASSETS</h2>
-          <p className="text-gray-400">
-            Manage digital assets and files for {dao.name}
-          </p>
-        </div>
-        <motion.button
-          whileHover={{ scale: 1.05 }}
-          whileTap={{ scale: 0.95 }}
-          className="flex items-center space-x-2 px-6 py-3 bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white rounded-lg transition-all font-semibold"
-        >
-          <Upload className="w-4 h-4" />
-          <span>Upload Asset</span>
-        </motion.button>
-      </div>
-
-      {/* Placeholder Content */}
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        className="bg-gray-800/50 border border-gray-700/50 rounded-xl p-8 text-center"
-      >
-        <Image className="w-16 h-16 text-gray-400 mx-auto mb-4" />
-        <h3 className="text-xl font-bold text-white mb-2 font-mono">ASSET MANAGEMENT</h3>
-        <p className="text-gray-400 mb-6">
-          This section will contain comprehensive asset management functionality
-        </p>
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-          <div className="bg-gray-900/50 border border-blue-500/30 p-4 rounded-lg">
-            <Image className="w-8 h-8 text-blue-400 mx-auto mb-2" />
-            <p className="text-blue-400 font-mono text-sm">Images</p>
-          </div>
-          <div className="bg-gray-900/50 border border-green-500/30 p-4 rounded-lg">
-            <Video className="w-8 h-8 text-green-400 mx-auto mb-2" />
-            <p className="text-green-400 font-mono text-sm">Videos</p>
-          </div>
-          <div className="bg-gray-900/50 border border-purple-500/30 p-4 rounded-lg">
-            <File className="w-8 h-8 text-purple-400 mx-auto mb-2" />
-            <p className="text-purple-400 font-mono text-sm">Documents</p>
-          </div>
-          <div className="bg-gray-900/50 border border-orange-500/30 p-4 rounded-lg">
-            <Archive className="w-8 h-8 text-orange-400 mx-auto mb-2" />
-            <p className="text-orange-400 font-mono text-sm">Archives</p>
-          </div>
-        </div>
-      </motion.div>
+    <div className="space-y-4">
+      <h2 className="text-2xl font-bold text-white font-mono">ASSETS for {dao.name}</h2>
+      {loading && <p className="text-gray-400">Loading...</p>}
+      {error && <p className="text-red-400">{error}</p>}
+      <ul className="space-y-2">
+        {assets.map(id => (
+          <li key={id.toString()} className="p-4 border border-gray-700 rounded-lg">
+            <div className="flex justify-between items-center">
+              <span className="text-white font-mono">Asset {id.toString()}</span>
+              <button
+                className="text-blue-400 hover:underline text-sm"
+                onClick={() => handleMetadata(id)}
+              >
+                Metadata
+              </button>
+            </div>
+            {metadata[id] && (
+              <pre className="text-xs text-gray-400 mt-2">
+                {JSON.stringify(metadata[id], null, 2)}
+              </pre>
+            )}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 };

--- a/src/dao_frontend/src/components/management/ManagementGovernance.tsx
+++ b/src/dao_frontend/src/components/management/ManagementGovernance.tsx
@@ -1,230 +1,76 @@
-import React from 'react';
-import { motion } from 'framer-motion';
+import React, { useState } from 'react';
 import { useOutletContext } from 'react-router-dom';
-import { 
-  Vote, 
-  Plus, 
-  Clock, 
-  CheckCircle, 
-  XCircle,
-  Users,
-  TrendingUp,
-  Calendar,
-  Target
-} from 'lucide-react';
 import { DAO } from '../../types/dao';
+import { useGovernance } from '../../hooks/useGovernance';
 
 const ManagementGovernance: React.FC = () => {
   const { dao } = useOutletContext<{ dao: DAO }>();
+  const { updateConfig, loading, error } = useGovernance();
+  const [config, setConfig] = useState({
+    maxProposalsPerUser: '',
+    proposalDeposit: '',
+    votingPeriod: '',
+    quorumThreshold: '',
+    approvalThreshold: ''
+  });
 
-  const proposals = [
-    {
-      id: 1,
-      title: 'Increase Development Fund Allocation',
-      description: 'Proposal to allocate an additional 20% of treasury funds to development initiatives',
-      status: 'active',
-      votesFor: 1247,
-      votesAgainst: 234,
-      totalVotes: 1481,
-      quorum: 1000,
-      timeLeft: '3 days',
-      proposer: 'alice.dao'
-    },
-    {
-      id: 2,
-      title: 'Update Staking Rewards Structure',
-      description: 'Modify the staking rewards to incentivize longer-term commitments',
-      status: 'passed',
-      votesFor: 2156,
-      votesAgainst: 445,
-      totalVotes: 2601,
-      quorum: 1000,
-      timeLeft: 'Ended',
-      proposer: 'bob.dao'
-    },
-    {
-      id: 3,
-      title: 'Partnership with DeFi Protocol X',
-      description: 'Strategic partnership proposal for cross-protocol liquidity sharing',
-      status: 'failed',
-      votesFor: 567,
-      votesAgainst: 1234,
-      totalVotes: 1801,
-      quorum: 1000,
-      timeLeft: 'Ended',
-      proposer: 'charlie.dao'
-    }
-  ];
-
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case 'active':
-        return 'bg-blue-500/20 text-blue-400 border-blue-500/30';
-      case 'passed':
-        return 'bg-green-500/20 text-green-400 border-green-500/30';
-      case 'failed':
-        return 'bg-red-500/20 text-red-400 border-red-500/30';
-      default:
-        return 'bg-gray-500/20 text-gray-400 border-gray-500/30';
-    }
-  };
-
-  const getStatusIcon = (status: string) => {
-    switch (status) {
-      case 'active':
-        return Clock;
-      case 'passed':
-        return CheckCircle;
-      case 'failed':
-        return XCircle;
-      default:
-        return Clock;
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const cfg = {
+      maxProposalsPerUser: BigInt(config.maxProposalsPerUser || '0'),
+      proposalDeposit: BigInt(config.proposalDeposit || '0'),
+      votingPeriod: BigInt(config.votingPeriod || '0'),
+      quorumThreshold: BigInt(config.quorumThreshold || '0'),
+      approvalThreshold: BigInt(config.approvalThreshold || '0')
+    } as any;
+    try {
+      await updateConfig(cfg);
+      setConfig({ maxProposalsPerUser: '', proposalDeposit: '', votingPeriod: '', quorumThreshold: '', approvalThreshold: '' });
+    } catch (err) {
+      console.error(err);
     }
   };
 
   return (
-    <div className="space-y-8">
-      {/* Header */}
-      <div className="flex justify-between items-center">
-        <div>
-          <h2 className="text-2xl font-bold text-white mb-2 font-mono">GOVERNANCE</h2>
-          <p className="text-gray-400">
-            Manage proposals and participate in DAO governance
-          </p>
-        </div>
-        <motion.button
-          whileHover={{ scale: 1.05 }}
-          whileTap={{ scale: 0.95 }}
-          className="flex items-center space-x-2 px-6 py-3 bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white rounded-lg transition-all font-semibold"
-        >
-          <Plus className="w-4 h-4" />
-          <span>Create Proposal</span>
-        </motion.button>
-      </div>
-
-      {/* Governance Stats */}
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          className="bg-gray-800/50 border border-blue-500/30 p-6 rounded-xl"
-        >
-          <div className="flex items-center space-x-2 mb-2">
-            <Vote className="w-5 h-5 text-blue-400" />
-            <span className="text-sm text-gray-400 font-mono">TOTAL PROPOSALS</span>
-          </div>
-          <p className="text-2xl font-bold text-white">{dao.governance.totalProposals}</p>
-        </motion.div>
-
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.1 }}
-          className="bg-gray-800/50 border border-green-500/30 p-6 rounded-xl"
-        >
-          <div className="flex items-center space-x-2 mb-2">
-            <Activity className="w-5 h-5 text-green-400" />
-            <span className="text-sm text-gray-400 font-mono">ACTIVE</span>
-          </div>
-          <p className="text-2xl font-bold text-white">{dao.governance.activeProposals}</p>
-        </motion.div>
-
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.2 }}
-          className="bg-gray-800/50 border border-purple-500/30 p-6 rounded-xl"
-        >
-          <div className="flex items-center space-x-2 mb-2">
-            <Users className="w-5 h-5 text-purple-400" />
-            <span className="text-sm text-gray-400 font-mono">PARTICIPATION</span>
-          </div>
-          <p className="text-2xl font-bold text-white">78%</p>
-        </motion.div>
-
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.3 }}
-          className="bg-gray-800/50 border border-orange-500/30 p-6 rounded-xl"
-        >
-          <div className="flex items-center space-x-2 mb-2">
-            <TrendingUp className="w-5 h-5 text-orange-400" />
-            <span className="text-sm text-gray-400 font-mono">SUCCESS RATE</span>
-          </div>
-          <p className="text-2xl font-bold text-white">85%</p>
-        </motion.div>
-      </div>
-
-      {/* Proposals List */}
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ delay: 0.4 }}
-        className="bg-gray-800/50 border border-gray-700/50 rounded-xl p-6"
-      >
-        <h3 className="text-xl font-bold text-white mb-6 font-mono">RECENT PROPOSALS</h3>
-        
-        <div className="space-y-4">
-          {proposals.map((proposal, index) => {
-            const StatusIcon = getStatusIcon(proposal.status);
-            const approvalRate = Math.round((proposal.votesFor / proposal.totalVotes) * 100);
-            
-            return (
-              <motion.div
-                key={proposal.id}
-                initial={{ opacity: 0, x: -20 }}
-                animate={{ opacity: 1, x: 0 }}
-                transition={{ delay: 0.5 + index * 0.1 }}
-                className="p-6 bg-gray-900/50 rounded-lg border border-gray-700/30 hover:border-gray-600/50 transition-colors"
-              >
-                <div className="flex items-start justify-between mb-4">
-                  <div className="flex-1">
-                    <div className="flex items-center space-x-3 mb-2">
-                      <h4 className="text-lg font-semibold text-white">{proposal.title}</h4>
-                      <span className={`px-3 py-1 rounded-full text-xs font-medium border ${getStatusColor(proposal.status)}`}>
-                        <StatusIcon className="w-3 h-3 inline mr-1" />
-                        {proposal.status.toUpperCase()}
-                      </span>
-                    </div>
-                    <p className="text-gray-400 text-sm mb-3">{proposal.description}</p>
-                    <div className="flex items-center space-x-4 text-xs text-gray-500">
-                      <span>Proposed by {proposal.proposer}</span>
-                      <span>•</span>
-                      <span>{proposal.timeLeft}</span>
-                    </div>
-                  </div>
-                </div>
-
-                {/* Voting Progress */}
-                <div className="space-y-3">
-                  <div className="flex justify-between text-sm">
-                    <span className="text-gray-400 font-mono">Approval Rate</span>
-                    <span className="text-blue-400 font-bold">{approvalRate}%</span>
-                  </div>
-                  <div className="w-full bg-gray-700 rounded-full h-2">
-                    <motion.div 
-                      className={`h-2 rounded-full ${
-                        proposal.status === 'passed' ? 'bg-gradient-to-r from-green-500 to-emerald-500' :
-                        proposal.status === 'failed' ? 'bg-gradient-to-r from-red-500 to-pink-500' :
-                        'bg-gradient-to-r from-blue-500 to-purple-500'
-                      }`}
-                      initial={{ width: 0 }}
-                      animate={{ width: `${approvalRate}%` }}
-                      transition={{ duration: 1, delay: 0.8 + index * 0.2 }}
-                    />
-                  </div>
-                  
-                  <div className="flex justify-between text-sm font-mono">
-                    <span className="text-green-400">For: {proposal.votesFor.toLocaleString()}</span>
-                    <span className="text-red-400">Against: {proposal.votesAgainst.toLocaleString()}</span>
-                  </div>
-                </div>
-              </motion.div>
-            );
-          })}
-        </div>
-      </motion.div>
+    <div className="space-y-4">
+      <h2 className="text-2xl font-bold text-white font-mono">GOVERNANCE for {dao.name}</h2>
+      {loading && <p className="text-gray-400">Updating...</p>}
+      {error && <p className="text-red-400">{error}</p>}
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <input
+          className="w-full p-2 bg-gray-900 border border-gray-700 rounded"
+          placeholder="Max Proposals Per User"
+          value={config.maxProposalsPerUser}
+          onChange={e => setConfig({ ...config, maxProposalsPerUser: e.target.value })}
+        />
+        <input
+          className="w-full p-2 bg-gray-900 border border-gray-700 rounded"
+          placeholder="Proposal Deposit"
+          value={config.proposalDeposit}
+          onChange={e => setConfig({ ...config, proposalDeposit: e.target.value })}
+        />
+        <input
+          className="w-full p-2 bg-gray-900 border border-gray-700 rounded"
+          placeholder="Voting Period (ns)"
+          value={config.votingPeriod}
+          onChange={e => setConfig({ ...config, votingPeriod: e.target.value })}
+        />
+        <input
+          className="w-full p-2 bg-gray-900 border border-gray-700 rounded"
+          placeholder="Quorum Threshold"
+          value={config.quorumThreshold}
+          onChange={e => setConfig({ ...config, quorumThreshold: e.target.value })}
+        />
+        <input
+          className="w-full p-2 bg-gray-900 border border-gray-700 rounded"
+          placeholder="Approval Threshold"
+          value={config.approvalThreshold}
+          onChange={e => setConfig({ ...config, approvalThreshold: e.target.value })}
+        />
+        <button type="submit" className="px-4 py-2 bg-green-600 text-white rounded">
+          Update Config
+        </button>
+      </form>
     </div>
   );
 };

--- a/src/dao_frontend/src/components/management/ManagementProposals.tsx
+++ b/src/dao_frontend/src/components/management/ManagementProposals.tsx
@@ -1,69 +1,86 @@
-import React from 'react';
-import { motion } from 'framer-motion';
+import React, { useEffect, useState } from 'react';
 import { useOutletContext } from 'react-router-dom';
-import { 
-  FileText, 
-  Plus, 
-  Vote,
-  Clock,
-  CheckCircle,
-  XCircle,
-  Users,
-  Calendar,
-  Target,
-  TrendingUp
-} from 'lucide-react';
 import { DAO } from '../../types/dao';
+import { useProposals } from '../../hooks/useProposals';
 
 const ManagementProposals: React.FC = () => {
   const { dao } = useOutletContext<{ dao: DAO }>();
+  const { getTrendingProposals, addTemplate, loading, error } = useProposals();
+  const [trending, setTrending] = useState<any[]>([]);
+  const [form, setForm] = useState({
+    name: '',
+    description: '',
+    category: '',
+    required: ''
+  });
+
+  useEffect(() => {
+    getTrendingProposals(5)
+      .then(setTrending)
+      .catch(console.error);
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const fields = form.required
+      .split(',')
+      .map(f => f.trim())
+      .filter(Boolean);
+    try {
+      await addTemplate(form.name, form.description, form.category, fields, {});
+      setForm({ name: '', description: '', category: '', required: '' });
+    } catch (err) {
+      console.error(err);
+    }
+  };
 
   return (
-    <div className="space-y-8">
-      {/* Header */}
-      <div className="flex justify-between items-center">
-        <div>
-          <h2 className="text-2xl font-bold text-white mb-2 font-mono">PROPOSALS</h2>
-          <p className="text-gray-400">
-            Create and manage governance proposals for {dao.name}
-          </p>
-        </div>
-        <motion.button
-          whileHover={{ scale: 1.05 }}
-          whileTap={{ scale: 0.95 }}
-          className="flex items-center space-x-2 px-6 py-3 bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white rounded-lg transition-all font-semibold"
-        >
-          <Plus className="w-4 h-4" />
-          <span>New Proposal</span>
-        </motion.button>
+    <div className="space-y-4">
+      <h2 className="text-2xl font-bold text-white font-mono">PROPOSALS for {dao.name}</h2>
+      {loading && <p className="text-gray-400">Loading...</p>}
+      {error && <p className="text-red-400">{error}</p>}
+      <div>
+        <h3 className="text-xl font-semibold text-white font-mono mb-2">Trending</h3>
+        <ul className="space-y-2">
+          {trending.map(p => (
+            <li key={p.id?.toString?.()} className="p-4 border border-gray-700 rounded-lg">
+              <span className="text-white">{p.title}</span>
+            </li>
+          ))}
+        </ul>
       </div>
-
-      {/* Placeholder Content */}
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        className="bg-gray-800/50 border border-gray-700/50 rounded-xl p-8 text-center"
-      >
-        <FileText className="w-16 h-16 text-gray-400 mx-auto mb-4" />
-        <h3 className="text-xl font-bold text-white mb-2 font-mono">PROPOSALS MANAGEMENT</h3>
-        <p className="text-gray-400 mb-6">
-          This section will contain detailed proposal management functionality
-        </p>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <div className="bg-gray-900/50 border border-blue-500/30 p-4 rounded-lg">
-            <Vote className="w-8 h-8 text-blue-400 mx-auto mb-2" />
-            <p className="text-blue-400 font-mono">Create Proposals</p>
-          </div>
-          <div className="bg-gray-900/50 border border-green-500/30 p-4 rounded-lg">
-            <Users className="w-8 h-8 text-green-400 mx-auto mb-2" />
-            <p className="text-green-400 font-mono">Vote on Proposals</p>
-          </div>
-          <div className="bg-gray-900/50 border border-purple-500/30 p-4 rounded-lg">
-            <TrendingUp className="w-8 h-8 text-purple-400 mx-auto mb-2" />
-            <p className="text-purple-400 font-mono">Track Results</p>
-          </div>
-        </div>
-      </motion.div>
+      <div>
+        <h3 className="text-xl font-semibold text-white font-mono mb-2">Add Template</h3>
+        <form onSubmit={handleSubmit} className="space-y-2">
+          <input
+            className="w-full p-2 bg-gray-900 border border-gray-700 rounded"
+            placeholder="Name"
+            value={form.name}
+            onChange={e => setForm({ ...form, name: e.target.value })}
+          />
+          <input
+            className="w-full p-2 bg-gray-900 border border-gray-700 rounded"
+            placeholder="Description"
+            value={form.description}
+            onChange={e => setForm({ ...form, description: e.target.value })}
+          />
+          <input
+            className="w-full p-2 bg-gray-900 border border-gray-700 rounded"
+            placeholder="Category"
+            value={form.category}
+            onChange={e => setForm({ ...form, category: e.target.value })}
+          />
+          <input
+            className="w-full p-2 bg-gray-900 border border-gray-700 rounded"
+            placeholder="Required Fields (comma separated)"
+            value={form.required}
+            onChange={e => setForm({ ...form, required: e.target.value })}
+          />
+          <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded">
+            Add Template
+          </button>
+        </form>
+      </div>
     </div>
   );
 };

--- a/src/dao_frontend/src/components/management/ManagementStaking.tsx
+++ b/src/dao_frontend/src/components/management/ManagementStaking.tsx
@@ -1,273 +1,74 @@
-import React from 'react';
-import { motion } from 'framer-motion';
+import React, { useEffect, useState } from 'react';
 import { useOutletContext } from 'react-router-dom';
-import { 
-  Coins, 
-  Plus, 
-  Clock, 
-  TrendingUp,
-  Award,
-  Lock,
-  Unlock,
-  Calendar,
-  DollarSign
-} from 'lucide-react';
 import { DAO } from '../../types/dao';
+import { useStaking } from '../../hooks/useStaking';
 
 const ManagementStaking: React.FC = () => {
   const { dao } = useOutletContext<{ dao: DAO }>();
+  const {
+    getStake,
+    getUserStakes,
+    getUserStakingSummary,
+    getStakingStats,
+    loading,
+    error
+  } = useStaking();
 
-  const stakingPools = [
-    {
-      id: 1,
-      name: 'Flexible Staking',
-      duration: 'No lock',
-      apr: '5.2%',
-      totalStaked: '$245K',
-      userStaked: '$1,250',
-      multiplier: '1.0x',
-      status: 'active'
-    },
-    {
-      id: 2,
-      name: '30-Day Lock',
-      duration: '30 days',
-      apr: '8.5%',
-      totalStaked: '$180K',
-      userStaked: '$2,500',
-      multiplier: '1.1x',
-      status: 'active'
-    },
-    {
-      id: 3,
-      name: '90-Day Lock',
-      duration: '90 days',
-      apr: '12.8%',
-      totalStaked: '$320K',
-      userStaked: '$5,000',
-      multiplier: '1.3x',
-      status: 'active'
-    },
-    {
-      id: 4,
-      name: '365-Day Lock',
-      duration: '365 days',
-      apr: '25.0%',
-      totalStaked: '$455K',
-      userStaked: '$0',
-      multiplier: '2.0x',
-      status: 'active'
-    }
-  ];
+  const [stakes, setStakes] = useState<any[]>([]);
+  const [summary, setSummary] = useState<any>(null);
+  const [stats, setStats] = useState<any>(null);
+  const [selected, setSelected] = useState<any>(null);
 
-  const userStakes = [
-    {
-      id: 1,
-      amount: '$2,500',
-      pool: '30-Day Lock',
-      startDate: new Date('2024-01-15'),
-      endDate: new Date('2024-02-14'),
-      rewards: '$45.20',
-      status: 'active'
-    },
-    {
-      id: 2,
-      amount: '$5,000',
-      pool: '90-Day Lock',
-      startDate: new Date('2024-02-01'),
-      endDate: new Date('2024-05-01'),
-      rewards: '$128.50',
-      status: 'active'
-    }
-  ];
+  useEffect(() => {
+    getUserStakes().then(setStakes).catch(console.error);
+    getUserStakingSummary().then(setSummary).catch(console.error);
+    getStakingStats().then(setStats).catch(console.error);
+  }, []);
 
-  const getPoolColor = (index: number) => {
-    const colors = ['blue', 'green', 'purple', 'orange'];
-    return colors[index % colors.length];
-  };
-
-  const getColorClasses = (color: string) => {
-    switch (color) {
-      case 'blue':
-        return 'border-blue-500/30 bg-blue-500/10';
-      case 'green':
-        return 'border-green-500/30 bg-green-500/10';
-      case 'purple':
-        return 'border-purple-500/30 bg-purple-500/10';
-      case 'orange':
-        return 'border-orange-500/30 bg-orange-500/10';
-      default:
-        return 'border-gray-500/30 bg-gray-500/10';
+  const handleStake = async (id: any) => {
+    try {
+      const s = await getStake(id);
+      setSelected(s);
+    } catch (err) {
+      console.error(err);
     }
   };
 
   return (
-    <div className="space-y-8">
-      {/* Header */}
-      <div className="flex justify-between items-center">
-        <div>
-          <h2 className="text-2xl font-bold text-white mb-2 font-mono">STAKING</h2>
-          <p className="text-gray-400">
-            Stake your tokens to earn rewards and gain voting power
-          </p>
+    <div className="space-y-4">
+      <h2 className="text-2xl font-bold text-white font-mono">STAKING for {dao.name}</h2>
+      {loading && <p className="text-gray-400">Loading...</p>}
+      {error && <p className="text-red-400">{error}</p>}
+      {summary && (
+        <div className="p-4 border border-gray-700 rounded">
+          <pre className="text-xs text-gray-400">{JSON.stringify(summary, null, 2)}</pre>
         </div>
-        <motion.button
-          whileHover={{ scale: 1.05 }}
-          whileTap={{ scale: 0.95 }}
-          className="flex items-center space-x-2 px-6 py-3 bg-gradient-to-r from-purple-500 to-pink-600 hover:from-purple-600 hover:to-pink-700 text-white rounded-lg transition-all font-semibold"
-        >
-          <Plus className="w-4 h-4" />
-          <span>Stake Tokens</span>
-        </motion.button>
-      </div>
-
-      {/* Staking Overview */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          className="bg-gray-800/50 border border-purple-500/30 p-6 rounded-xl"
-        >
-          <div className="flex items-center space-x-2 mb-2">
-            <Coins className="w-5 h-5 text-purple-400" />
-            <span className="text-sm text-gray-400 font-mono">TOTAL STAKED</span>
-          </div>
-          <p className="text-2xl font-bold text-white">{dao.staking.totalStaked}</p>
-          <p className="text-sm text-green-400 mt-1">+12.5% this month</p>
-        </motion.div>
-
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.1 }}
-          className="bg-gray-800/50 border border-green-500/30 p-6 rounded-xl"
-        >
-          <div className="flex items-center space-x-2 mb-2">
-            <TrendingUp className="w-5 h-5 text-green-400" />
-            <span className="text-sm text-gray-400 font-mono">AVG APR</span>
-          </div>
-          <p className="text-2xl font-bold text-white">{dao.staking.apr}</p>
-          <p className="text-sm text-blue-400 mt-1">Across all pools</p>
-        </motion.div>
-
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.2 }}
-          className="bg-gray-800/50 border border-blue-500/30 p-6 rounded-xl"
-        >
-          <div className="flex items-center space-x-2 mb-2">
-            <Award className="w-5 h-5 text-blue-400" />
-            <span className="text-sm text-gray-400 font-mono">YOUR STAKE</span>
-          </div>
-          <p className="text-2xl font-bold text-white">$7,500</p>
-          <p className="text-sm text-purple-400 mt-1">2 active stakes</p>
-        </motion.div>
-      </div>
-
-      {/* Staking Pools */}
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ delay: 0.3 }}
-        className="bg-gray-800/50 border border-gray-700/50 rounded-xl p-6"
-      >
-        <h3 className="text-xl font-bold text-white mb-6 font-mono">STAKING POOLS</h3>
-        
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          {stakingPools.map((pool, index) => (
-            <motion.div
-              key={pool.id}
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.4 + index * 0.1 }}
-              whileHover={{ scale: 1.02 }}
-              className={`p-6 rounded-xl border ${getColorClasses(getPoolColor(index))} hover:border-opacity-60 transition-all`}
-            >
-              <div className="flex items-center justify-between mb-4">
-                <h4 className="text-lg font-semibold text-white">{pool.name}</h4>
-                <span className="text-sm font-mono text-gray-400">{pool.multiplier} voting power</span>
-              </div>
-              
-              <div className="space-y-3 mb-6">
-                <div className="flex justify-between">
-                  <span className="text-gray-400 text-sm font-mono">Duration</span>
-                  <span className="text-white font-semibold">{pool.duration}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-gray-400 text-sm font-mono">APR</span>
-                  <span className="text-green-400 font-bold">{pool.apr}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-gray-400 text-sm font-mono">Total Staked</span>
-                  <span className="text-white">{pool.totalStaked}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-gray-400 text-sm font-mono">Your Stake</span>
-                  <span className="text-blue-400 font-semibold">{pool.userStaked}</span>
-                </div>
-              </div>
-
-              <button className="w-full py-3 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors font-semibold">
-                {pool.userStaked === '$0' ? 'Stake Now' : 'Add More'}
+      )}
+      {stats && (
+        <div className="p-4 border border-gray-700 rounded">
+          <pre className="text-xs text-gray-400">{JSON.stringify(stats, null, 2)}</pre>
+        </div>
+      )}
+      <ul className="space-y-2">
+        {stakes.map(stake => (
+          <li key={stake.id?.toString?.()} className="p-4 border border-gray-700 rounded">
+            <div className="flex justify-between items-center">
+              <span className="text-white font-mono">Stake {stake.id?.toString?.()}</span>
+              <button
+                className="text-blue-400 hover:underline text-sm"
+                onClick={() => handleStake(stake.id)}
+              >
+                Details
               </button>
-            </motion.div>
-          ))}
-        </div>
-      </motion.div>
-
-      {/* Your Stakes */}
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ delay: 0.5 }}
-        className="bg-gray-800/50 border border-gray-700/50 rounded-xl p-6"
-      >
-        <h3 className="text-xl font-bold text-white mb-6 font-mono">YOUR ACTIVE STAKES</h3>
-        
-        <div className="space-y-4">
-          {userStakes.map((stake, index) => (
-            <motion.div
-              key={stake.id}
-              initial={{ opacity: 0, x: -20 }}
-              animate={{ opacity: 1, x: 0 }}
-              transition={{ delay: 0.6 + index * 0.1 }}
-              className="p-6 bg-gray-900/50 rounded-lg border border-gray-700/30"
-            >
-              <div className="flex items-center justify-between mb-4">
-                <div>
-                  <h4 className="text-lg font-semibold text-white">{stake.pool}</h4>
-                  <p className="text-blue-400 font-bold">{stake.amount}</p>
-                </div>
-                <div className="text-right">
-                  <p className="text-green-400 font-bold">{stake.rewards}</p>
-                  <p className="text-xs text-gray-400 font-mono">Rewards earned</p>
-                </div>
-              </div>
-              
-              <div className="grid grid-cols-2 gap-4 text-sm mb-4">
-                <div>
-                  <span className="text-gray-400 font-mono">Start Date</span>
-                  <p className="text-white">{stake.startDate.toLocaleDateString()}</p>
-                </div>
-                <div>
-                  <span className="text-gray-400 font-mono">End Date</span>
-                  <p className="text-white">{stake.endDate.toLocaleDateString()}</p>
-                </div>
-              </div>
-
-              <div className="flex space-x-3">
-                <button className="flex-1 py-2 bg-green-500/20 border border-green-500/30 text-green-400 rounded-lg hover:bg-green-500/30 transition-colors font-mono">
-                  Claim Rewards
-                </button>
-                <button className="flex-1 py-2 bg-red-500/20 border border-red-500/30 text-red-400 rounded-lg hover:bg-red-500/30 transition-colors font-mono">
-                  Unstake
-                </button>
-              </div>
-            </motion.div>
-          ))}
-        </div>
-      </motion.div>
+            </div>
+            {selected && selected[0]?.id === stake.id && (
+              <pre className="text-xs text-gray-400 mt-2">
+                {JSON.stringify(selected[0], null, 2)}
+              </pre>
+            )}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 };

--- a/src/dao_frontend/src/components/management/ManagementTreasury.tsx
+++ b/src/dao_frontend/src/components/management/ManagementTreasury.tsx
@@ -1,279 +1,36 @@
-import React from 'react';
-import { motion } from 'framer-motion';
+import React, { useEffect, useState } from 'react';
 import { useOutletContext } from 'react-router-dom';
-import { 
-  DollarSign, 
-  TrendingUp, 
-  TrendingDown,
-  ArrowUpRight,
-  ArrowDownLeft,
-  PieChart,
-  BarChart3,
-  Wallet,
-  Lock,
-  Shield
-} from 'lucide-react';
 import { DAO } from '../../types/dao';
+import { useTreasury } from '../../hooks/useTreasury';
 
 const ManagementTreasury: React.FC = () => {
   const { dao } = useOutletContext<{ dao: DAO }>();
+  const { getAllTransactions, getTreasuryStats, loading, error } = useTreasury();
+  const [transactions, setTransactions] = useState<any[]>([]);
+  const [stats, setStats] = useState<any>(null);
 
-  const treasuryStats = [
-    {
-      label: 'Total Balance',
-      value: dao.treasury.balance,
-      change: '+5.2%',
-      trend: 'up',
-      icon: Wallet,
-      color: 'green'
-    },
-    {
-      label: 'Monthly Inflow',
-      value: dao.treasury.monthlyInflow,
-      change: '+12.8%',
-      trend: 'up',
-      icon: TrendingUp,
-      color: 'blue'
-    },
-    {
-      label: 'Available Funds',
-      value: '$680K',
-      change: '-2.1%',
-      trend: 'down',
-      icon: DollarSign,
-      color: 'purple'
-    },
-    {
-      label: 'Locked Funds',
-      value: '$170K',
-      change: '+8.5%',
-      trend: 'up',
-      icon: Lock,
-      color: 'orange'
-    }
-  ];
-
-  const recentTransactions = [
-    {
-      id: 1,
-      type: 'inflow',
-      description: 'Revenue sharing from protocol fees',
-      amount: '+$12,500',
-      timestamp: '2 hours ago',
-      status: 'completed'
-    },
-    {
-      id: 2,
-      type: 'outflow',
-      description: 'Development team payment',
-      amount: '-$8,000',
-      timestamp: '1 day ago',
-      status: 'completed'
-    },
-    {
-      id: 3,
-      type: 'inflow',
-      description: 'Staking rewards distribution',
-      amount: '+$3,200',
-      timestamp: '2 days ago',
-      status: 'completed'
-    },
-    {
-      id: 4,
-      type: 'outflow',
-      description: 'Marketing campaign funding',
-      amount: '-$5,500',
-      timestamp: '3 days ago',
-      status: 'completed'
-    }
-  ];
-
-  const allocation = [
-    { category: 'Development', percentage: 40, amount: '$340K', color: 'blue' },
-    { category: 'Marketing', percentage: 25, amount: '$212K', color: 'green' },
-    { category: 'Operations', percentage: 20, amount: '$170K', color: 'purple' },
-    { category: 'Reserves', percentage: 15, amount: '$128K', color: 'orange' }
-  ];
-
-  const getColorClasses = (color: string) => {
-    switch (color) {
-      case 'blue':
-        return 'border-blue-500/30 text-blue-400';
-      case 'green':
-        return 'border-green-500/30 text-green-400';
-      case 'purple':
-        return 'border-purple-500/30 text-purple-400';
-      case 'orange':
-        return 'border-orange-500/30 text-orange-400';
-      default:
-        return 'border-gray-500/30 text-gray-400';
-    }
-  };
+  useEffect(() => {
+    getAllTransactions().then(setTransactions).catch(console.error);
+    getTreasuryStats().then(setStats).catch(console.error);
+  }, []);
 
   return (
-    <div className="space-y-8">
-      {/* Header */}
-      <div className="flex justify-between items-center">
-        <div>
-          <h2 className="text-2xl font-bold text-white mb-2 font-mono">TREASURY</h2>
-          <p className="text-gray-400">
-            Monitor and manage DAO financial resources
-          </p>
+    <div className="space-y-4">
+      <h2 className="text-2xl font-bold text-white font-mono">TREASURY for {dao.name}</h2>
+      {loading && <p className="text-gray-400">Loading...</p>}
+      {error && <p className="text-red-400">{error}</p>}
+      {stats && (
+        <div className="p-4 border border-gray-700 rounded">
+          <pre className="text-xs text-gray-400">{JSON.stringify(stats, null, 2)}</pre>
         </div>
-        <div className="flex space-x-3">
-          <motion.button
-            whileHover={{ scale: 1.05 }}
-            whileTap={{ scale: 0.95 }}
-            className="flex items-center space-x-2 px-4 py-2 bg-green-500/20 border border-green-500/30 text-green-400 rounded-lg hover:bg-green-500/30 transition-colors font-mono"
-          >
-            <ArrowUpRight className="w-4 h-4" />
-            <span>Deposit</span>
-          </motion.button>
-          <motion.button
-            whileHover={{ scale: 1.05 }}
-            whileTap={{ scale: 0.95 }}
-            className="flex items-center space-x-2 px-4 py-2 bg-red-500/20 border border-red-500/30 text-red-400 rounded-lg hover:bg-red-500/30 transition-colors font-mono"
-          >
-            <ArrowDownLeft className="w-4 h-4" />
-            <span>Withdraw</span>
-          </motion.button>
-        </div>
-      </div>
-
-      {/* Treasury Stats */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-        {treasuryStats.map((stat, index) => (
-          <motion.div
-            key={stat.label}
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: index * 0.1 }}
-            whileHover={{ scale: 1.02 }}
-            className={`bg-gray-800/50 border ${getColorClasses(stat.color)} p-6 rounded-xl backdrop-blur-sm`}
-          >
-            <div className="flex items-center justify-between mb-4">
-              <stat.icon className={`w-6 h-6 ${getColorClasses(stat.color).split(' ')[1]}`} />
-              <div className={`flex items-center space-x-1 text-sm ${
-                stat.trend === 'up' ? 'text-green-400' : 'text-red-400'
-              }`}>
-                <span>{stat.change}</span>
-                {stat.trend === 'up' ? (
-                  <TrendingUp className="w-4 h-4" />
-                ) : (
-                  <TrendingDown className="w-4 h-4" />
-                )}
-              </div>
-            </div>
-            <div>
-              <p className="text-2xl font-bold text-white mb-1">{stat.value}</p>
-              <p className="text-sm text-gray-400 font-mono">{stat.label}</p>
-            </div>
-          </motion.div>
+      )}
+      <ul className="space-y-2">
+        {transactions.map((tx, idx) => (
+          <li key={idx} className="p-4 border border-gray-700 rounded">
+            <pre className="text-xs text-gray-400">{JSON.stringify(tx, null, 2)}</pre>
+          </li>
         ))}
-      </div>
-
-      {/* Main Content Grid */}
-      <div className="grid lg:grid-cols-3 gap-8">
-        {/* Recent Transactions */}
-        <div className="lg:col-span-2">
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.4 }}
-            className="bg-gray-800/50 border border-gray-700/50 rounded-xl p-6"
-          >
-            <div className="flex items-center justify-between mb-6">
-              <h3 className="text-xl font-bold text-white font-mono">RECENT TRANSACTIONS</h3>
-              <button className="text-blue-400 hover:text-blue-300 transition-colors text-sm font-mono">
-                View All
-              </button>
-            </div>
-            
-            <div className="space-y-4">
-              {recentTransactions.map((transaction, index) => (
-                <motion.div
-                  key={transaction.id}
-                  initial={{ opacity: 0, x: -20 }}
-                  animate={{ opacity: 1, x: 0 }}
-                  transition={{ delay: 0.5 + index * 0.1 }}
-                  className="flex items-center justify-between p-4 bg-gray-900/50 rounded-lg border border-gray-700/30"
-                >
-                  <div className="flex items-center space-x-4">
-                    <div className={`w-10 h-10 rounded-lg flex items-center justify-center ${
-                      transaction.type === 'inflow' 
-                        ? 'bg-green-500/20 border border-green-500/30' 
-                        : 'bg-red-500/20 border border-red-500/30'
-                    }`}>
-                      {transaction.type === 'inflow' ? (
-                        <ArrowUpRight className={`w-5 h-5 ${transaction.type === 'inflow' ? 'text-green-400' : 'text-red-400'}`} />
-                      ) : (
-                        <ArrowDownLeft className={`w-5 h-5 ${transaction.type === 'inflow' ? 'text-green-400' : 'text-red-400'}`} />
-                      )}
-                    </div>
-                    <div>
-                      <p className="text-white font-semibold">{transaction.description}</p>
-                      <p className="text-gray-400 text-sm font-mono">{transaction.timestamp}</p>
-                    </div>
-                  </div>
-                  <div className="text-right">
-                    <p className={`font-bold ${
-                      transaction.type === 'inflow' ? 'text-green-400' : 'text-red-400'
-                    }`}>
-                      {transaction.amount}
-                    </p>
-                    <p className="text-xs text-gray-400 font-mono">{transaction.status}</p>
-                  </div>
-                </motion.div>
-              ))}
-            </div>
-          </motion.div>
-        </div>
-
-        {/* Treasury Allocation */}
-        <div>
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.6 }}
-            className="bg-gray-800/50 border border-gray-700/50 rounded-xl p-6"
-          >
-            <h3 className="text-lg font-bold text-white mb-6 font-mono">FUND ALLOCATION</h3>
-            
-            <div className="space-y-4">
-              {allocation.map((item, index) => (
-                <motion.div
-                  key={item.category}
-                  initial={{ opacity: 0, x: 20 }}
-                  animate={{ opacity: 1, x: 0 }}
-                  transition={{ delay: 0.7 + index * 0.1 }}
-                  className="space-y-2"
-                >
-                  <div className="flex justify-between text-sm">
-                    <span className="text-gray-400 font-mono">{item.category}</span>
-                    <span className="text-white font-bold">{item.percentage}%</span>
-                  </div>
-                  <div className="w-full bg-gray-700 rounded-full h-2">
-                    <motion.div 
-                      className={`h-2 rounded-full bg-gradient-to-r ${
-                        item.color === 'blue' ? 'from-blue-500 to-blue-600' :
-                        item.color === 'green' ? 'from-green-500 to-green-600' :
-                        item.color === 'purple' ? 'from-purple-500 to-purple-600' :
-                        'from-orange-500 to-orange-600'
-                      }`}
-                      initial={{ width: 0 }}
-                      animate={{ width: `${item.percentage}%` }}
-                      transition={{ duration: 1, delay: 0.8 + index * 0.2 }}
-                    />
-                  </div>
-                  <div className="flex justify-between text-xs">
-                    <span className="text-gray-500">{item.amount}</span>
-                  </div>
-                </motion.div>
-              ))}
-            </div>
-          </motion.div>
-        </div>
-      </div>
+      </ul>
     </div>
   );
 };

--- a/src/dao_frontend/src/hooks/useGovernance.js
+++ b/src/dao_frontend/src/hooks/useGovernance.js
@@ -68,6 +68,21 @@ export const useGovernance = () => {
     }
   };
 
+  const updateConfig = async (config) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await actors.governance.updateConfig(config);
+      if ('err' in res) throw new Error(res.err);
+      return res.ok;
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
   const getGovernanceStats = async () => {
     setLoading(true);
     setError(null);
@@ -82,5 +97,13 @@ export const useGovernance = () => {
     }
   };
 
-  return { createProposal, vote, getConfig, getGovernanceStats, loading, error };
+  return {
+    createProposal,
+    vote,
+    getConfig,
+    updateConfig,
+    getGovernanceStats,
+    loading,
+    error,
+  };
 };

--- a/src/dao_frontend/src/hooks/useStaking.js
+++ b/src/dao_frontend/src/hooks/useStaking.js
@@ -52,5 +52,69 @@ export const useStaking = () => {
     }
   };
 
-  return { stake, unstake, claimRewards, loading, error };
+  const getStake = async (stakeId) => {
+    setLoading(true);
+    setError(null);
+    try {
+      return await actors.staking.getStake(BigInt(stakeId));
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getUserStakes = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const principal = await actors.staking.agent.getPrincipal();
+      return await actors.staking.getUserStakes(principal);
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getUserStakingSummary = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const principal = await actors.staking.agent.getPrincipal();
+      return await actors.staking.getUserStakingSummary(principal);
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getStakingStats = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      return await actors.staking.getStakingStats();
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return {
+    stake,
+    unstake,
+    claimRewards,
+    getStake,
+    getUserStakes,
+    getUserStakingSummary,
+    getStakingStats,
+    loading,
+    error,
+  };
 };


### PR DESCRIPTION
## Summary
- Display user assets with metadata using `useAssets`
- Add proposal admin view for templates and trending proposals
- Provide governance config panel hooked to `updateConfig`
- Expose staking queries and stats in staking management
- Surface treasury transactions and stats

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a18d4104608320adb381b996ff8361