### PR TITLE
chore: remove unused hook methods

### DIFF
--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -675,4 +675,36 @@ const useDAO = () => {
 };
 ```
 
-This API documentation provides comprehensive coverage of all endpoints and their usage patterns. For more detailed examples and integration guides, refer to the user guides documentation.
+  This API documentation provides comprehensive coverage of all endpoints and their usage patterns. For more detailed examples and integration guides, refer to the user guides documentation.
+
+## Frontend Hook Summary
+
+### Assets
+- `uploadAsset`
+- `getAsset`
+- `getPublicAssets`
+- `searchAssetsByTag`
+- `deleteAsset`
+- `updateAssetMetadata`
+- `getStorageStats`
+
+### Proposals
+- `createProposal`
+- `vote`
+- `getAllProposals`
+- `getProposalsByCategory`
+- `getProposalTemplates`
+
+### Treasury
+- `deposit`
+- `withdraw`
+- `lockTokens`
+- `unlockTokens`
+- `reserveTokens`
+- `releaseReservedTokens`
+- `getBalance`
+- `getTransactionsByType`
+- `getRecentTransactions`
+- `getTreasuryStats`
+
+> Unused methods such as `getUserAssets`, `getAssetMetadata`, `addTemplate`, `getTrendingProposals`, and `getAllTransactions` have been removed to keep the hooks aligned with the current UI.

--- a/src/dao_frontend/src/declarations/assets/assets.did
+++ b/src/dao_frontend/src/declarations/assets/assets.did
@@ -52,7 +52,6 @@ service : {
   deleteAsset: (assetId: AssetId) -> (Result_1);
   getAsset: (assetId: AssetId) -> (Result_2);
   getAssetByName: (name: text) -> (opt AssetMetadata) query;
-  getAssetMetadata: (assetId: AssetId) -> (opt AssetMetadata) query;
   getAuthorizedUploaders: () -> (vec principal) query;
   getPublicAssets: () -> (vec AssetMetadata) query;
   getStorageStats: () ->
@@ -64,7 +63,6 @@ service : {
       totalAssets: nat;
     }) query;
   getSupportedContentTypes: () -> (vec text) query;
-  getUserAssets: () -> (vec AssetMetadata);
   health: () ->
    (record {
       status: text;

--- a/src/dao_frontend/src/declarations/assets/assets.did.d.ts
+++ b/src/dao_frontend/src/declarations/assets/assets.did.d.ts
@@ -41,7 +41,6 @@ export interface _SERVICE {
   'deleteAsset' : ActorMethod<[AssetId], Result_1>,
   'getAsset' : ActorMethod<[AssetId], Result_2>,
   'getAssetByName' : ActorMethod<[string], [] | [AssetMetadata]>,
-  'getAssetMetadata' : ActorMethod<[AssetId], [] | [AssetMetadata]>,
   'getAuthorizedUploaders' : ActorMethod<[], Array<Principal>>,
   'getPublicAssets' : ActorMethod<[], Array<AssetMetadata>>,
   'getStorageStats' : ActorMethod<
@@ -55,7 +54,6 @@ export interface _SERVICE {
     }
   >,
   'getSupportedContentTypes' : ActorMethod<[], Array<string>>,
-  'getUserAssets' : ActorMethod<[], Array<AssetMetadata>>,
   'health' : ActorMethod<
     [],
     { 'status' : string, 'storageUsed' : bigint, 'timestamp' : Time }

--- a/src/dao_frontend/src/declarations/assets/assets.did.js
+++ b/src/dao_frontend/src/declarations/assets/assets.did.js
@@ -50,11 +50,6 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Opt(AssetMetadata)],
         ['query'],
       ),
-    'getAssetMetadata' : IDL.Func(
-        [AssetId],
-        [IDL.Opt(AssetMetadata)],
-        ['query'],
-      ),
     'getAuthorizedUploaders' : IDL.Func(
         [],
         [IDL.Vec(IDL.Principal)],
@@ -75,7 +70,6 @@ export const idlFactory = ({ IDL }) => {
         ['query'],
       ),
     'getSupportedContentTypes' : IDL.Func([], [IDL.Vec(IDL.Text)], ['query']),
-    'getUserAssets' : IDL.Func([], [IDL.Vec(AssetMetadata)], []),
     'health' : IDL.Func(
         [],
         [

--- a/src/dao_frontend/src/declarations/proposals/proposals.did
+++ b/src/dao_frontend/src/declarations/proposals/proposals.did
@@ -12,12 +12,7 @@ type TreasuryTransferProposal =
  };
 type TokenAmount = nat;
 type Time = int;
-type Result_2 = 
- variant {
-   err: text;
-   ok: nat;
- };
-type Result_1 = 
+type Result_1 =
  variant {
    err: text;
    ok: ProposalId;
@@ -96,8 +91,6 @@ type MembershipChangeProposal =
 service : {
   addCategory: (id: text, name: text, description: text, color: text) ->
    (Result);
-  addTemplate: (name: text, description: text, category: text,
-   requiredFields: vec text, template: text) -> (Result_2);
   batchVote: (votes: vec record {
                            ProposalId;
                            VoteChoice;
@@ -127,7 +120,6 @@ service : {
   getProposalsByCategory: (category: text) -> (vec Proposal) query;
   getTemplate: (templateId: nat) -> (opt ProposalTemplate) query;
   getTemplatesByCategory: (category: text) -> (vec ProposalTemplate) query;
-  getTrendingProposals: (limit: nat) -> (vec Proposal) query;
   init: (stakingId: principal) -> () oneway;
   vote: (proposalId: ProposalId, choice: VoteChoice, reason: opt text) ->
    (Result);

--- a/src/dao_frontend/src/declarations/proposals/proposals.did.d.ts
+++ b/src/dao_frontend/src/declarations/proposals/proposals.did.d.ts
@@ -59,8 +59,6 @@ export type Result = { 'ok' : null } |
   { 'err' : string };
 export type Result_1 = { 'ok' : ProposalId } |
   { 'err' : string };
-export type Result_2 = { 'ok' : bigint } |
-  { 'err' : string };
 export type Time = bigint;
 export type TokenAmount = bigint;
 export interface TreasuryTransferProposal {
@@ -73,10 +71,6 @@ export type VoteChoice = { 'against' : null } |
   { 'inFavor' : null };
 export interface _SERVICE {
   'addCategory' : ActorMethod<[string, string, string, string], Result>,
-  'addTemplate' : ActorMethod<
-    [string, string, string, Array<string>, string],
-    Result_2
-  >,
   'batchVote' : ActorMethod<
     [Array<[ProposalId, VoteChoice, [] | [string]]>],
     Array<Result>
@@ -108,7 +102,6 @@ export interface _SERVICE {
   'getProposalsByCategory' : ActorMethod<[string], Array<Proposal>>,
   'getTemplate' : ActorMethod<[bigint], [] | [ProposalTemplate]>,
   'getTemplatesByCategory' : ActorMethod<[string], Array<ProposalTemplate>>,
-  'getTrendingProposals' : ActorMethod<[bigint], Array<Proposal>>,
   'init' : ActorMethod<[Principal], undefined>,
   'vote' : ActorMethod<[ProposalId, VoteChoice, [] | [string]], Result>,
 }

--- a/src/dao_frontend/src/declarations/proposals/proposals.did.js
+++ b/src/dao_frontend/src/declarations/proposals/proposals.did.js
@@ -1,6 +1,5 @@
 export const idlFactory = ({ IDL }) => {
   const Result = IDL.Variant({ 'ok' : IDL.Null, 'err' : IDL.Text });
-  const Result_2 = IDL.Variant({ 'ok' : IDL.Nat, 'err' : IDL.Text });
   const ProposalId = IDL.Nat;
   const VoteChoice = IDL.Variant({
     'against' : IDL.Null,
@@ -76,11 +75,6 @@ export const idlFactory = ({ IDL }) => {
         [Result],
         [],
       ),
-    'addTemplate' : IDL.Func(
-        [IDL.Text, IDL.Text, IDL.Text, IDL.Vec(IDL.Text), IDL.Text],
-        [Result_2],
-        [],
-      ),
     'batchVote' : IDL.Func(
         [IDL.Vec(IDL.Tuple(ProposalId, VoteChoice, IDL.Opt(IDL.Text)))],
         [IDL.Vec(Result)],
@@ -137,11 +131,6 @@ export const idlFactory = ({ IDL }) => {
     'getTemplatesByCategory' : IDL.Func(
         [IDL.Text],
         [IDL.Vec(ProposalTemplate)],
-        ['query'],
-      ),
-    'getTrendingProposals' : IDL.Func(
-        [IDL.Nat],
-        [IDL.Vec(Proposal)],
         ['query'],
       ),
     'init' : IDL.Func([IDL.Principal], [], ['oneway']),

--- a/src/dao_frontend/src/declarations/treasury/treasury.did
+++ b/src/dao_frontend/src/declarations/treasury/treasury.did
@@ -46,7 +46,6 @@ type Principal = principal;
 service : {
   addAuthorizedPrincipal: ("principal": principal) -> (Result_1);
   deposit: (amount: TokenAmount, description: text) -> (Result);
-  getAllTransactions: () -> (vec TreasuryTransaction) query;
   getAuthorizedPrincipals: () -> (vec principal) query;
   getBalance: () -> (TreasuryBalance) query;
   getRecentTransactions: (limit: nat) -> (vec TreasuryTransaction) query;

--- a/src/dao_frontend/src/declarations/treasury/treasury.did.d.ts
+++ b/src/dao_frontend/src/declarations/treasury/treasury.did.d.ts
@@ -37,7 +37,6 @@ export type TreasuryTransactionType = { 'fee' : null } |
 export interface _SERVICE {
   'addAuthorizedPrincipal' : ActorMethod<[Principal], Result_1>,
   'deposit' : ActorMethod<[TokenAmount, string], Result>,
-  'getAllTransactions' : ActorMethod<[], Array<TreasuryTransaction>>,
   'getAuthorizedPrincipals' : ActorMethod<[], Array<Principal>>,
   'getBalance' : ActorMethod<[], TreasuryBalance>,
   'getRecentTransactions' : ActorMethod<[bigint], Array<TreasuryTransaction>>,

--- a/src/dao_frontend/src/declarations/treasury/treasury.did.js
+++ b/src/dao_frontend/src/declarations/treasury/treasury.did.js
@@ -36,11 +36,6 @@ export const idlFactory = ({ IDL }) => {
   return IDL.Service({
     'addAuthorizedPrincipal' : IDL.Func([IDL.Principal], [Result_1], []),
     'deposit' : IDL.Func([TokenAmount, IDL.Text], [Result], []),
-    'getAllTransactions' : IDL.Func(
-        [],
-        [IDL.Vec(TreasuryTransaction)],
-        ['query'],
-      ),
     'getAuthorizedPrincipals' : IDL.Func(
         [],
         [IDL.Vec(IDL.Principal)],

--- a/src/dao_frontend/src/hooks/useAssets.js
+++ b/src/dao_frontend/src/hooks/useAssets.js
@@ -48,37 +48,11 @@ export const useAssets = () => {
     }
   };
 
-  const getAssetMetadata = async (assetId) => {
-    setLoading(true);
-    setError(null);
-    try {
-      return await actors.assets.getAssetMetadata(BigInt(assetId));
-    } catch (err) {
-      setError(err.message);
-      throw err;
-    } finally {
-      setLoading(false);
-    }
-  };
-
   const getPublicAssets = async () => {
     setLoading(true);
     setError(null);
     try {
       return await actors.assets.getPublicAssets();
-    } catch (err) {
-      setError(err.message);
-      throw err;
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const getUserAssets = async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      return await actors.assets.getUserAssets();
     } catch (err) {
       setError(err.message);
       throw err;
@@ -155,9 +129,7 @@ export const useAssets = () => {
   return {
     uploadAsset,
     getAsset,
-    getAssetMetadata,
     getPublicAssets,
-    getUserAssets,
     searchAssetsByTag,
     deleteAsset,
     updateAssetMetadata,

--- a/src/dao_frontend/src/hooks/useProposals.js
+++ b/src/dao_frontend/src/hooks/useProposals.js
@@ -55,49 +55,11 @@ export const useProposals = () => {
     }
   };
 
-  const getTrendingProposals = async (limit) => {
-    setLoading(true);
-    setError(null);
-    try {
-      return await actors.proposals.getTrendingProposals(BigInt(limit));
-    } catch (err) {
-      setError(err.message);
-      throw err;
-    } finally {
-      setLoading(false);
-    }
-  };
-
   const getProposalTemplates = async () => {
     setLoading(true);
     setError(null);
     try {
       return await actors.proposals.getProposalTemplates();
-    } catch (err) {
-      setError(err.message);
-      throw err;
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const addTemplate = async (
-    name,
-    description,
-    category,
-    requiredFields,
-    template
-  ) => {
-    setLoading(true);
-    setError(null);
-    try {
-      return await actors.proposals.addTemplate(
-        name,
-        description,
-        category,
-        requiredFields,
-        template
-      );
     } catch (err) {
       setError(err.message);
       throw err;
@@ -131,9 +93,7 @@ export const useProposals = () => {
     vote,
     getAllProposals,
     getProposalsByCategory,
-    getTrendingProposals,
     getProposalTemplates,
-    addTemplate,
     loading,
     error,
   };

--- a/src/dao_frontend/src/hooks/useTreasury.js
+++ b/src/dao_frontend/src/hooks/useTreasury.js
@@ -126,21 +126,6 @@ export const useTreasury = () => {
     }
   };
 
-  const getAllTransactions = async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const res = await actors.treasury.getAllTransactions();
-      if ('err' in res) throw new Error(res.err);
-      return 'ok' in res ? res.ok : res;
-    } catch (err) {
-      setError(err.message);
-      throw err;
-    } finally {
-      setLoading(false);
-    }
-  };
-
   const getTransactionsByType = async (type) => {
     setLoading(true);
     setError(null);
@@ -193,7 +178,6 @@ export const useTreasury = () => {
     reserveTokens,
     releaseReservedTokens,
     getBalance,
-    getAllTransactions,
     getTransactionsByType,
     getRecentTransactions,
     getTreasuryStats,


### PR DESCRIPTION
## Summary
- streamline hooks by removing unused calls and exports
- trim matching canister declarations for assets, proposals and treasury
- document current hook surface

## Testing
- `cd src/dao_frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a18d5062ac83209dff1ed8e86ba344