### PR TITLE
Throw error for missing canister IDs

### DIFF
--- a/src/dao_frontend/src/context/ActorContext.tsx
+++ b/src/dao_frontend/src/context/ActorContext.tsx
@@ -46,8 +46,10 @@ export const ActorProvider = ({ children }: ActorProviderProps) => {
           <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-gray-900"></div>
         </div>
       ) : error ? (
-        <div className="flex items-center justify-center min-h-screen text-red-600">
-          Error: {error}
+        <div className="flex flex-col items-center justify-center min-h-screen text-red-600 p-4 text-center">
+          <h1 className="text-xl font-bold mb-2">Configuration Error</h1>
+          <p className="mb-2">{error}</p>
+          <p>Please verify your environment configuration and canister IDs.</p>
         </div>
       ) : (
         children


### PR DESCRIPTION
## Summary
- Ensure `initializeAgents` throws when required `VITE_CANISTER_ID_*` variables are missing outside development
- Display a clear configuration error message in the frontend when initialization fails

## Testing
- ⚠️ `npm test` (missing dfx)
- ✅ `cd src/dao_frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a18d5fcb148320878e83687a4dd74d