### PR TITLE
Display assets and enable uploads in management dashboard

### DIFF
--- a/src/dao_frontend/src/components/management/ManagementAssets.tsx
+++ b/src/dao_frontend/src/components/management/ManagementAssets.tsx
@@ -1,24 +1,81 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { motion } from 'framer-motion';
 import { useOutletContext } from 'react-router-dom';
-import { 
-  Image, 
-  Upload, 
-  Download,
-  Folder,
-  File,
-  Video,
-  Music,
-  Archive
-} from 'lucide-react';
+import { Upload, Download, File } from 'lucide-react';
+import { useAssets } from '../../hooks/useAssets';
 import { DAO } from '../../types/dao';
 
 const ManagementAssets: React.FC = () => {
   const { dao } = useOutletContext<{ dao: DAO }>();
+  const { getUserAssets, getPublicAssets, uploadAsset, getAsset } = useAssets();
+  const [assets, setAssets] = useState<any[]>([]);
+  const [uploadProgress, setUploadProgress] = useState(0);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const fetchAssets = async () => {
+    try {
+      const [userAssets, publicAssets] = await Promise.all([
+        getUserAssets(),
+        getPublicAssets(),
+      ]);
+      const userIds = new Set(userAssets.map((a: any) => Number(a.id)));
+      const combined = [
+        ...userAssets,
+        ...publicAssets.filter((a: any) => !userIds.has(Number(a.id))),
+      ];
+      setAssets(combined);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  useEffect(() => {
+    fetchAssets();
+  }, []);
+
+  const handleFileChange = async (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setUploadProgress(0);
+    const interval = setInterval(() => {
+      setUploadProgress((p) => (p < 90 ? p + 10 : p));
+    }, 200);
+    try {
+      await uploadAsset(file, true, []);
+      setUploadProgress(100);
+      await fetchAssets();
+    } catch (err) {
+      console.error(err);
+    } finally {
+      clearInterval(interval);
+      setTimeout(() => setUploadProgress(0), 500);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = '';
+      }
+    }
+  };
+
+  const handleDownload = async (id: bigint) => {
+    try {
+      const asset = await getAsset(id);
+      const blob = new Blob([new Uint8Array(asset.data)], {
+        type: asset.contentType,
+      });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = asset.name;
+      link.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error(err);
+    }
+  };
 
   return (
     <div className="space-y-8">
-      {/* Header */}
       <div className="flex justify-between items-center">
         <div>
           <h2 className="text-2xl font-bold text-white mb-2 font-mono">ASSETS</h2>
@@ -26,46 +83,79 @@ const ManagementAssets: React.FC = () => {
             Manage digital assets and files for {dao.name}
           </p>
         </div>
-        <motion.button
-          whileHover={{ scale: 1.05 }}
-          whileTap={{ scale: 0.95 }}
-          className="flex items-center space-x-2 px-6 py-3 bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white rounded-lg transition-all font-semibold"
-        >
-          <Upload className="w-4 h-4" />
-          <span>Upload Asset</span>
-        </motion.button>
+        <div>
+          <motion.button
+            whileHover={{ scale: 1.05 }}
+            whileTap={{ scale: 0.95 }}
+            className="flex items-center space-x-2 px-6 py-3 bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white rounded-lg transition-all font-semibold"
+            onClick={() => fileInputRef.current?.click()}
+          >
+            <Upload className="w-4 h-4" />
+            <span>Upload Asset</span>
+          </motion.button>
+          <input
+            type="file"
+            ref={fileInputRef}
+            className="hidden"
+            onChange={handleFileChange}
+          />
+          {uploadProgress > 0 && (
+            <div className="mt-2 h-2 w-full bg-gray-700 rounded">
+              <div
+                className="h-full bg-green-500 rounded"
+                style={{ width: `${uploadProgress}%` }}
+              />
+            </div>
+          )}
+        </div>
       </div>
 
-      {/* Placeholder Content */}
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        className="bg-gray-800/50 border border-gray-700/50 rounded-xl p-8 text-center"
-      >
-        <Image className="w-16 h-16 text-gray-400 mx-auto mb-4" />
-        <h3 className="text-xl font-bold text-white mb-2 font-mono">ASSET MANAGEMENT</h3>
-        <p className="text-gray-400 mb-6">
-          This section will contain comprehensive asset management functionality
-        </p>
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-          <div className="bg-gray-900/50 border border-blue-500/30 p-4 rounded-lg">
-            <Image className="w-8 h-8 text-blue-400 mx-auto mb-2" />
-            <p className="text-blue-400 font-mono text-sm">Images</p>
-          </div>
-          <div className="bg-gray-900/50 border border-green-500/30 p-4 rounded-lg">
-            <Video className="w-8 h-8 text-green-400 mx-auto mb-2" />
-            <p className="text-green-400 font-mono text-sm">Videos</p>
-          </div>
-          <div className="bg-gray-900/50 border border-purple-500/30 p-4 rounded-lg">
-            <File className="w-8 h-8 text-purple-400 mx-auto mb-2" />
-            <p className="text-purple-400 font-mono text-sm">Documents</p>
-          </div>
-          <div className="bg-gray-900/50 border border-orange-500/30 p-4 rounded-lg">
-            <Archive className="w-8 h-8 text-orange-400 mx-auto mb-2" />
-            <p className="text-orange-400 font-mono text-sm">Archives</p>
-          </div>
-        </div>
-      </motion.div>
+      {assets.length === 0 ? (
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="bg-gray-800/50 border border-gray-700/50 rounded-xl p-8 text-center"
+        >
+          <File className="w-16 h-16 text-gray-400 mx-auto mb-4" />
+          <h3 className="text-xl font-bold text-white mb-2 font-mono">
+            NO ASSETS AVAILABLE
+          </h3>
+          <p className="text-gray-400 mb-6">
+            Upload files to start building your asset library.
+          </p>
+        </motion.div>
+      ) : (
+        <motion.ul
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="space-y-4"
+        >
+          {assets.map((asset: any) => (
+            <li
+              key={Number(asset.id)}
+              className="flex justify-between items-center bg-gray-800/50 border border-gray-700/50 rounded-lg p-4"
+            >
+              <div className="flex items-center space-x-3">
+                <File className="w-6 h-6 text-blue-400" />
+                <div>
+                  <p className="text-white font-mono">{asset.name}</p>
+                  {asset.tags && asset.tags.length > 0 && (
+                    <p className="text-gray-400 text-sm">
+                      {asset.tags.join(', ')}
+                    </p>
+                  )}
+                </div>
+              </div>
+              <button
+                onClick={() => handleDownload(asset.id)}
+                className="text-green-400 hover:text-green-300"
+              >
+                <Download className="w-5 h-5" />
+              </button>
+            </li>
+          ))}
+        </motion.ul>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- integrate `useAssets` hook into management assets page
- list user and public assets with download links
- allow uploading assets with progress bar and refresh

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a18d8138c08320af44c80b65b86903