### PR TITLE
feat: extend governance hooks and UI

### DIFF
--- a/src/dao_frontend/src/components/ProposalDetail.jsx
+++ b/src/dao_frontend/src/components/ProposalDetail.jsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useState } from 'react';
+import { useGovernance } from '../hooks/useGovernance';
+
+const ProposalDetail = ({ proposalId, onClose }) => {
+  const { getProposal, getProposalVotes, executeProposal, loading, error } = useGovernance();
+  const [proposal, setProposal] = useState(null);
+  const [votes, setVotes] = useState([]);
+
+  useEffect(() => {
+    const load = async () => {
+      const p = await getProposal(proposalId);
+      setProposal(p);
+      const v = await getProposalVotes(proposalId);
+      setVotes(v);
+    };
+    load();
+  }, [proposalId]);
+
+  const handleExecute = async () => {
+    try {
+      await executeProposal(proposalId);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const voteSummary = votes.reduce(
+    (acc, v) => {
+      const key = Object.keys(v.choice)[0];
+      acc[key] = (acc[key] || 0n) + v.votingPower;
+      return acc;
+    },
+    { inFavor: 0n, against: 0n, abstain: 0n }
+  );
+
+  return (
+    <div className="border p-4 rounded mt-4">
+      {error && <p className="text-red-500">{error}</p>}
+      {proposal ? (
+        <>
+          <h3 className="text-xl font-semibold">{proposal.title}</h3>
+          <p className="mb-2">{proposal.description}</p>
+          <p className="mb-2">Status: {Object.keys(proposal.status)[0]}</p>
+          <div className="mb-2">
+            <p>Votes in Favor: {voteSummary.inFavor.toString()}</p>
+            <p>Votes Against: {voteSummary.against.toString()}</p>
+            <p>Votes Abstain: {voteSummary.abstain.toString()}</p>
+          </div>
+          {Object.keys(proposal.status)[0] === 'succeeded' && (
+            <button
+              onClick={handleExecute}
+              className="bg-purple-500 text-white px-2 py-1 rounded mr-2"
+              disabled={loading}
+            >
+              Execute
+            </button>
+          )}
+          <button onClick={onClose} className="bg-gray-300 px-2 py-1 rounded">
+            Close
+          </button>
+        </>
+      ) : (
+        <p>Loading...</p>
+      )}
+    </div>
+  );
+};
+
+export default ProposalDetail;

--- a/src/dao_frontend/src/components/Proposals.jsx
+++ b/src/dao_frontend/src/components/Proposals.jsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useProposals } from '../hooks/useProposals';
+import { useGovernance } from '../hooks/useGovernance';
+import ProposalDetail from './ProposalDetail';
 
 const Proposals = () => {
   const {
@@ -11,6 +13,11 @@ const Proposals = () => {
     loading,
     error,
   } = useProposals();
+  const {
+    getAllProposals: getGovProposals,
+    loading: govLoading,
+    error: govError,
+  } = useGovernance();
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [category, setCategory] = useState('');
@@ -22,10 +29,13 @@ const Proposals = () => {
   const [proposals, setProposals] = useState([]);
   const [categoryFilter, setCategoryFilter] = useState('');
   const [templates, setTemplates] = useState([]);
+  const [govProposals, setGovProposals] = useState([]);
+  const [selectedProposal, setSelectedProposal] = useState(null);
 
   useEffect(() => {
     loadProposals();
     loadTemplates();
+    loadGovProposals();
   }, []);
 
   const loadProposals = async () => {
@@ -36,6 +46,11 @@ const Proposals = () => {
   const loadTemplates = async () => {
     const tpls = await getProposalTemplates();
     setTemplates(tpls);
+  };
+
+  const loadGovProposals = async () => {
+    const gps = await getGovProposals();
+    setGovProposals(gps);
   };
 
   const handleCreate = async (e) => {
@@ -90,7 +105,9 @@ const Proposals = () => {
   return (
     <div className="p-4 space-y-8">
       <h1 className="text-2xl font-bold">Proposals</h1>
-      {error && <p className="text-red-500">{error}</p>}
+      {(error || govError) && (
+        <p className="text-red-500">{error || govError}</p>
+      )}
 
       <div className="space-y-2">
         <h2 className="text-xl font-semibold">Existing Proposals</h2>
@@ -108,6 +125,35 @@ const Proposals = () => {
             </li>
           ))}
         </ul>
+      </div>
+
+      <div className="space-y-2">
+        <h2 className="text-xl font-semibold">Governance Proposals</h2>
+        <ul className="space-y-2">
+          {govProposals.map((p) => (
+            <li key={p.id.toString()} className="border p-2 rounded">
+              <div className="flex justify-between items-center">
+                <div>
+                  <h3 className="font-semibold">{p.title}</h3>
+                  <p className="text-sm">Status: {Object.keys(p.status)[0]}</p>
+                </div>
+                <button
+                  className="bg-blue-500 text-white px-2 py-1 rounded"
+                  onClick={() => setSelectedProposal(p.id)}
+                  disabled={govLoading}
+                >
+                  View
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+        {selectedProposal && (
+          <ProposalDetail
+            proposalId={selectedProposal}
+            onClose={() => setSelectedProposal(null)}
+          />
+        )}
       </div>
 
       <div className="space-y-2">

--- a/src/dao_frontend/src/hooks/useGovernance.js
+++ b/src/dao_frontend/src/hooks/useGovernance.js
@@ -82,5 +82,134 @@ export const useGovernance = () => {
     }
   };
 
-  return { createProposal, vote, getConfig, getGovernanceStats, loading, error };
+  const executeProposal = async (proposalId) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await actors.governance.executeProposal(BigInt(proposalId));
+      if ('err' in res) throw new Error(res.err);
+      return res.ok;
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getActiveProposals = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      return await actors.governance.getActiveProposals();
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getAllProposals = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      return await actors.governance.getAllProposals();
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getProposal = async (proposalId) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await actors.governance.getProposal(BigInt(proposalId));
+      return res && res.length ? res[0] : null;
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getProposalVotes = async (proposalId) => {
+    setLoading(true);
+    setError(null);
+    try {
+      return await actors.governance.getProposalVotes(BigInt(proposalId));
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getProposalsByStatus = async (status) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const statusVariant = { [status]: null };
+      return await actors.governance.getProposalsByStatus(statusVariant);
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getUserVote = async (proposalId, user) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await actors.governance.getUserVote(
+        BigInt(proposalId),
+        user
+      );
+      return res && res.length ? res[0] : null;
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const updateConfig = async (newConfig) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await actors.governance.updateConfig(newConfig);
+      if ('err' in res) throw new Error(res.err);
+      return res.ok;
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return {
+    createProposal,
+    vote,
+    getConfig,
+    getGovernanceStats,
+    executeProposal,
+    getActiveProposals,
+    getAllProposals,
+    getProposal,
+    getProposalVotes,
+    getProposalsByStatus,
+    getUserVote,
+    updateConfig,
+    loading,
+    error,
+  };
 };


### PR DESCRIPTION
## Summary
- wrap additional governance canister endpoints
- show governance proposals with detail view and execution

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a18d9b5e548320b909d22cf1879f72