### PR TITLE
feat: expand staking hook and UI controls

### DIFF
--- a/src/dao_frontend/src/components/Staking.jsx
+++ b/src/dao_frontend/src/components/Staking.jsx
@@ -1,12 +1,31 @@
 import React, { useState } from 'react';
 import { useStaking } from '../hooks/useStaking';
+import { useAuth } from '../context/AuthContext';
 
 const Staking = () => {
-  const { stake, unstake, claimRewards, loading, error } = useStaking();
+  const {
+    stake,
+    unstake,
+    claimRewards,
+    extendStakingPeriod,
+    getUserStakingSummary,
+    setMinimumStakeAmount,
+    setMaximumStakeAmount,
+    setStakingEnabled,
+    loading,
+    error,
+  } = useStaking();
+  const { principal } = useAuth();
   const [amount, setAmount] = useState('');
   const [period, setPeriod] = useState('instant');
   const [unstakeId, setUnstakeId] = useState('');
   const [claimId, setClaimId] = useState('');
+  const [summary, setSummary] = useState(null);
+  const [extendId, setExtendId] = useState('');
+  const [extendPeriod, setExtendPeriod] = useState('locked30');
+  const [minAmount, setMinAmount] = useState('');
+  const [maxAmount, setMaxAmount] = useState('');
+  const [enabled, setEnabled] = useState(true);
 
   const handleStake = async (e) => {
     e.preventDefault();
@@ -36,6 +55,54 @@ const Staking = () => {
       const rewards = await claimRewards(claimId);
       console.log('Rewards claimed:', rewards);
       setClaimId('');
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleSummary = async () => {
+    try {
+      const res = await getUserStakingSummary(principal);
+      setSummary(res);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleExtend = async (e) => {
+    e.preventDefault();
+    try {
+      await extendStakingPeriod(extendId, extendPeriod);
+      setExtendId('');
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleSetMin = async (e) => {
+    e.preventDefault();
+    try {
+      await setMinimumStakeAmount(minAmount);
+      setMinAmount('');
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleSetMax = async (e) => {
+    e.preventDefault();
+    try {
+      await setMaximumStakeAmount(maxAmount);
+      setMaxAmount('');
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleToggleEnabled = async () => {
+    try {
+      await setStakingEnabled(!enabled);
+      setEnabled(!enabled);
     } catch (err) {
       console.error(err);
     }
@@ -103,6 +170,91 @@ const Staking = () => {
           Claim Rewards
         </button>
       </form>
+
+      <div className="space-y-2">
+        <button
+          onClick={handleSummary}
+          className="bg-yellow-500 text-white px-4 py-2 rounded"
+          disabled={loading}
+        >
+          Get My Summary
+        </button>
+        {summary && (
+          <div className="p-2 border rounded">
+            <p>Active Stakes: {summary.activeStakes?.toString()}</p>
+            <p>Total Staked: {summary.totalStaked?.toString()}</p>
+            <p>Total Rewards: {summary.totalRewards?.toString()}</p>
+            <p>Total Voting Power: {summary.totalVotingPower?.toString()}</p>
+          </div>
+        )}
+      </div>
+
+      <form onSubmit={handleExtend} className="space-y-2">
+        <input
+          className="border p-2 w-full"
+          placeholder="Stake ID"
+          value={extendId}
+          onChange={(e) => setExtendId(e.target.value)}
+        />
+        <select
+          className="border p-2 w-full"
+          value={extendPeriod}
+          onChange={(e) => setExtendPeriod(e.target.value)}
+        >
+          <option value="instant">Instant</option>
+          <option value="locked30">30 Days</option>
+          <option value="locked90">90 Days</option>
+          <option value="locked180">180 Days</option>
+          <option value="locked365">365 Days</option>
+        </select>
+        <button
+          type="submit"
+          className="bg-indigo-500 text-white px-4 py-2 rounded"
+          disabled={loading}
+        >
+          Extend Period
+        </button>
+      </form>
+
+      <form onSubmit={handleSetMin} className="space-y-2">
+        <input
+          className="border p-2 w-full"
+          placeholder="Minimum Stake Amount"
+          value={minAmount}
+          onChange={(e) => setMinAmount(e.target.value)}
+        />
+        <button
+          type="submit"
+          className="bg-teal-500 text-white px-4 py-2 rounded"
+          disabled={loading}
+        >
+          Set Minimum
+        </button>
+      </form>
+
+      <form onSubmit={handleSetMax} className="space-y-2">
+        <input
+          className="border p-2 w-full"
+          placeholder="Maximum Stake Amount"
+          value={maxAmount}
+          onChange={(e) => setMaxAmount(e.target.value)}
+        />
+        <button
+          type="submit"
+          className="bg-orange-500 text-white px-4 py-2 rounded"
+          disabled={loading}
+        >
+          Set Maximum
+        </button>
+      </form>
+
+      <button
+        onClick={handleToggleEnabled}
+        className="bg-gray-500 text-white px-4 py-2 rounded"
+        disabled={loading}
+      >
+        {enabled ? 'Disable Staking' : 'Enable Staking'}
+      </button>
     </div>
   );
 };

--- a/src/dao_frontend/src/hooks/useStaking.js
+++ b/src/dao_frontend/src/hooks/useStaking.js
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Principal } from '@dfinity/principal';
 import { useActors } from '../context/ActorContext';
 
 export const useStaking = () => {
@@ -52,5 +53,166 @@ export const useStaking = () => {
     }
   };
 
-  return { stake, unstake, claimRewards, loading, error };
+  const extendStakingPeriod = async (stakeId, newPeriod) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const periodVariant = { [newPeriod]: null };
+      const res = await actors.staking.extendStakingPeriod(
+        BigInt(stakeId),
+        periodVariant
+      );
+      if ('err' in res) throw new Error(res.err);
+      return res.ok;
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getStake = async (stakeId) => {
+    setLoading(true);
+    setError(null);
+    try {
+      return await actors.staking.getStake(BigInt(stakeId));
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getStakingRewards = async (stakeId) => {
+    setLoading(true);
+    setError(null);
+    try {
+      return await actors.staking.getStakingRewards(BigInt(stakeId));
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getStakingStats = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      return await actors.staking.getStakingStats();
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getUserStakes = async (user) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const principal = Principal.fromText(user);
+      return await actors.staking.getUserStakes(principal);
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getUserActiveStakes = async (user) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const principal = Principal.fromText(user);
+      return await actors.staking.getUserActiveStakes(principal);
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getUserStakingSummary = async (user) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const principal = Principal.fromText(user);
+      return await actors.staking.getUserStakingSummary(principal);
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const setMinimumStakeAmount = async (amount) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await actors.staking.setMinimumStakeAmount(BigInt(amount));
+      if ('err' in res) throw new Error(res.err);
+      return res.ok;
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const setMaximumStakeAmount = async (amount) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await actors.staking.setMaximumStakeAmount(BigInt(amount));
+      if ('err' in res) throw new Error(res.err);
+      return res.ok;
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const setStakingEnabled = async (enabled) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await actors.staking.setStakingEnabled(enabled);
+      if ('err' in res) throw new Error(res.err);
+      return res.ok;
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return {
+    stake,
+    unstake,
+    claimRewards,
+    extendStakingPeriod,
+    getStake,
+    getStakingRewards,
+    getStakingStats,
+    getUserStakes,
+    getUserActiveStakes,
+    getUserStakingSummary,
+    setMinimumStakeAmount,
+    setMaximumStakeAmount,
+    setStakingEnabled,
+    loading,
+    error,
+  };
 };


### PR DESCRIPTION
## Summary
- extend `useStaking` hook with full staking canister methods including period extensions, queries, and admin parameter setters
- enhance `Staking` page with user summary, extend period form, and controls for staking parameters

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a18da262348320a2430684290184a2