### PR TITLE
fix: remove duplicate useAssets import

### DIFF
--- a/src/dao_frontend/src/components/management/ManagementAssets.tsx
+++ b/src/dao_frontend/src/components/management/ManagementAssets.tsx
@@ -5,7 +5,6 @@ import { useOutletContext } from 'react-router-dom';
 import { Upload, Download, File } from 'lucide-react';
 import { useAssets } from '../../hooks/useAssets';
 import { DAO } from '../../types/dao';
-import { useAssets } from '../../hooks/useAssets';
 
 const ManagementAssets: React.FC = () => {
   const { dao } = useOutletContext<{ dao: DAO }>();


### PR DESCRIPTION
## Summary
- remove duplicate useAssets import from ManagementAssets component

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a199c267088320a796c3a29f0612ee