### PR TITLE
Add DAO admin management component

### DIFF
--- a/src/dao_frontend/src/App.jsx
+++ b/src/dao_frontend/src/App.jsx
@@ -18,6 +18,7 @@ import ManagementStaking from './components/management/ManagementStaking';
 import ManagementTreasury from './components/management/ManagementTreasury';
 import ManagementProposals from './components/management/ManagementProposals';
 import ManagementAssets from './components/management/ManagementAssets';
+import ManagementAdmins from './components/management/ManagementAdmins';
 import './app.css';
 
 function App() {
@@ -45,6 +46,7 @@ function App() {
                 <Route path="treasury" element={<ManagementTreasury />} />
                 <Route path="proposals" element={<ManagementProposals />} />
                 <Route path="assets" element={<ManagementAssets />} />
+                <Route path="admins" element={<ManagementAdmins />} />
               </Route>
             </Routes>
           </div>

--- a/src/dao_frontend/src/components/DAOManagement.tsx
+++ b/src/dao_frontend/src/components/DAOManagement.tsx
@@ -34,7 +34,8 @@ const DAOManagement: React.FC = () => {
     { id: 'staking', name: 'Staking', icon: Coins, path: 'staking' },
     { id: 'treasury', name: 'Treasury', icon: DollarSign, path: 'treasury' },
     { id: 'proposals', name: 'Proposals', icon: FileText, path: 'proposals' },
-    { id: 'assets', name: 'Assets', icon: Image, path: 'assets' }
+    { id: 'assets', name: 'Assets', icon: Image, path: 'assets' },
+    { id: 'admins', name: 'Admins', icon: Users, path: 'admins' }
   ];
 
   useEffect(() => {

--- a/src/dao_frontend/src/components/management/ManagementAdmins.tsx
+++ b/src/dao_frontend/src/components/management/ManagementAdmins.tsx
@@ -1,0 +1,150 @@
+import React, { useEffect, useState } from 'react';
+import { Plus, Trash2 } from 'lucide-react';
+import { useDAOAPI } from '../../utils/daoAPI';
+// @ts-ignore - AuthContext is a .jsx file
+import { useAuth } from '../../context/AuthContext';
+import { useOutletContext } from 'react-router-dom';
+import { DAO } from '../../types/dao';
+import { Principal } from '@dfinity/principal';
+
+const ManagementAdmins: React.FC = () => {
+  const { dao } = useOutletContext<{ dao: DAO }>();
+  const daoAPI = useDAOAPI();
+  const { principal } = useAuth();
+
+  const [admins, setAdmins] = useState<string[]>([]);
+  const [newAdmin, setNewAdmin] = useState('');
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [isAuthorized, setIsAuthorized] = useState(false);
+
+  const loadAdmins = async () => {
+    if (!daoAPI) return;
+    try {
+      setLoading(true);
+      const users = await daoAPI.getAllUsers();
+      const adminList: string[] = [];
+      for (const user of users) {
+        const isAdmin = await daoAPI.checkIsAdmin(user.id);
+        if (isAdmin) {
+          adminList.push(user.id.toText());
+        }
+      }
+      setAdmins(adminList);
+    } catch (err: any) {
+      setError(err.message ?? String(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const verifyAccess = async () => {
+    if (!daoAPI || !principal) return;
+    try {
+      const isAdmin = await daoAPI.checkIsAdmin(Principal.fromText(principal));
+      setIsAuthorized(isAdmin);
+      if (isAdmin) {
+        await loadAdmins();
+      } else {
+        setError('Only admins can manage administrators');
+      }
+    } catch (err: any) {
+      setError(err.message ?? String(err));
+    }
+  };
+
+  useEffect(() => {
+    verifyAccess();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [daoAPI, principal]);
+
+  const handleAddAdmin = async () => {
+    if (!newAdmin || !daoAPI) return;
+    setMessage('');
+    setError('');
+    try {
+      await daoAPI.addAdmin(Principal.fromText(newAdmin));
+      setMessage('Admin added successfully');
+      setNewAdmin('');
+      await loadAdmins();
+    } catch (err: any) {
+      setError(err.message ?? String(err));
+    }
+  };
+
+  const handleRemoveAdmin = async (admin: string) => {
+    if (!daoAPI) return;
+    setMessage('');
+    setError('');
+    try {
+      await daoAPI.removeAdmin(Principal.fromText(admin));
+      setMessage('Admin removed successfully');
+      await loadAdmins();
+    } catch (err: any) {
+      setError(err.message ?? String(err));
+    }
+  };
+
+  if (!isAuthorized) {
+    return (
+      <div className="space-y-4">
+        {error && <p className="text-red-400">{error}</p>}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h2 className="text-2xl font-bold text-white mb-2 font-mono">ADMINISTRATORS</h2>
+        <p className="text-gray-400">Manage administrator access for {dao.name}</p>
+      </div>
+
+      {message && <p className="text-green-400">{message}</p>}
+      {error && <p className="text-red-400">{error}</p>}
+
+      <div className="space-y-4">
+        <h3 className="text-xl font-bold text-white font-mono">Current Admins</h3>
+        <div className="flex space-x-2">
+          <input
+            type="text"
+            value={newAdmin}
+            onChange={(e) => setNewAdmin(e.target.value)}
+            placeholder="Principal"
+            className="flex-grow px-3 py-2 bg-gray-800 text-white rounded"
+          />
+          <button
+            onClick={handleAddAdmin}
+            className="px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded flex items-center"
+          >
+            <Plus className="w-4 h-4 mr-1" /> Add
+          </button>
+        </div>
+        {loading ? (
+          <p className="text-gray-400">Loading admins...</p>
+        ) : (
+          <ul className="space-y-2">
+            {admins.map((p) => (
+              <li
+                key={p}
+                className="flex justify-between items-center bg-gray-800/50 p-2 rounded"
+              >
+                <span className="text-white font-mono text-sm break-all">{p}</span>
+                <button
+                  onClick={() => handleRemoveAdmin(p)}
+                  className="text-red-400 hover:text-red-300"
+                >
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ManagementAdmins;
+


### PR DESCRIPTION
## Summary
- add ManagementAdmins component for listing and managing DAO admins
- wire admin management route and tab into app navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1b599bc7083209477a7d1e821a2dd