### PR TITLE
Enable navigation to Settings from DAO management

### DIFF
--- a/src/dao_frontend/src/components/DAOManagement.tsx
+++ b/src/dao_frontend/src/components/DAOManagement.tsx
@@ -149,7 +149,10 @@ const DAOManagement: React.FC = () => {
                 <ArrowLeft className="w-4 h-4" />
                 <span>Back to Dashboard</span>
               </Link>
-              <button className="flex items-center space-x-2 px-4 py-2 bg-gray-800 border border-gray-600 text-gray-300 hover:bg-gray-700 rounded-lg transition-colors font-mono">
+              <button
+                onClick={() => navigate('/settings')}
+                className="flex items-center space-x-2 px-4 py-2 bg-gray-800 border border-gray-600 text-gray-300 hover:bg-gray-700 rounded-lg transition-colors font-mono"
+              >
                 <Settings className="w-4 h-4" />
                 <span>Settings</span>
               </button>


### PR DESCRIPTION
## Summary
- route DAOManagement settings button to Settings page using `useNavigate`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1b88d742c83208af15a3c6cf2605f