### PR TITLE
Wire up DAO overview quick action buttons

### DIFF
--- a/src/dao_frontend/src/components/management/Overview.tsx
+++ b/src/dao_frontend/src/components/management/Overview.tsx
@@ -1,6 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { useOutletContext } from 'react-router-dom';
+import { useProposals } from '../../hooks/useProposals';
+import { useStaking } from '../../hooks/useStaking';
+import { useTreasury } from '../../hooks/useTreasury';
+import { useNavigate } from 'react-router-dom';
 import { 
   Users, 
   DollarSign, 
@@ -29,6 +33,10 @@ interface Activity {
 const Overview: React.FC = () => {
   const { dao } = useOutletContext<{ dao: DAO }>();
   const { daoBackend } = useActors();
+  const { createProposal } = useProposals();
+  const { stake } = useStaking();
+  const { getBalance } = useTreasury();
+  const navigate = useNavigate();
 
   const [recentActivity, setRecentActivity] = useState<Activity[]>([]);
 
@@ -262,15 +270,24 @@ const Overview: React.FC = () => {
           >
             <h3 className="text-lg font-bold text-white mb-4 font-mono">QUICK ACTIONS</h3>
             <div className="space-y-3">
-              <button className="w-full flex items-center justify-between p-3 bg-blue-500/20 border border-blue-500/30 text-blue-400 rounded-lg hover:bg-blue-500/30 transition-colors">
+              <button
+                className="w-full flex items-center justify-between p-3 bg-blue-500/20 border border-blue-500/30 text-blue-400 rounded-lg hover:bg-blue-500/30 transition-colors"
+                onClick={() => navigate(`/dao/${dao.id}/manage/proposals`)}
+              >
                 <span className="font-mono">Create Proposal</span>
                 <ArrowUpRight className="w-4 h-4" />
               </button>
-              <button className="w-full flex items-center justify-between p-3 bg-purple-500/20 border border-purple-500/30 text-purple-400 rounded-lg hover:bg-purple-500/30 transition-colors">
+              <button
+                className="w-full flex items-center justify-between p-3 bg-purple-500/20 border border-purple-500/30 text-purple-400 rounded-lg hover:bg-purple-500/30 transition-colors"
+                onClick={() => navigate(`/dao/${dao.id}/manage/staking`)}
+              >
                 <span className="font-mono">Stake Tokens</span>
                 <ArrowUpRight className="w-4 h-4" />
               </button>
-              <button className="w-full flex items-center justify-between p-3 bg-green-500/20 border border-green-500/30 text-green-400 rounded-lg hover:bg-green-500/30 transition-colors">
+              <button
+                className="w-full flex items-center justify-between p-3 bg-green-500/20 border border-green-500/30 text-green-400 rounded-lg hover:bg-green-500/30 transition-colors"
+                onClick={() => navigate(`/dao/${dao.id}/manage/treasury`)}
+              >
                 <span className="font-mono">View Treasury</span>
                 <ArrowUpRight className="w-4 h-4" />
               </button>


### PR DESCRIPTION
## Summary
- use proposals, staking, and treasury hooks
- add navigation handlers to quick action buttons in management overview

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1b89c1b5c8320ba7aaed560d609ad