### PR TITLE
Add daoId scoping to DAO records and actions

### DIFF
--- a/src/dao_backend/governance/main.mo
+++ b/src/dao_backend/governance/main.mo
@@ -157,6 +157,7 @@ persistent actor GovernanceCanister {
 
     // Create a new proposal
     public shared(msg) func createProposal(
+        daoId: Principal,
         title: Text,
         description: Text,
         proposalType: Types.ProposalType,
@@ -184,6 +185,7 @@ persistent actor GovernanceCanister {
         };
 
         let proposal : Proposal = {
+            daoId = daoId;
             id = proposalId;
             proposer = caller;
             title = title;
@@ -206,6 +208,7 @@ persistent actor GovernanceCanister {
 
     // Cast a vote on a proposal
     public shared(msg) func vote(
+        daoId: Principal,
         proposalId: ProposalId,
         choice: Types.VoteChoice,
         reason: ?Text
@@ -250,6 +253,7 @@ persistent actor GovernanceCanister {
 
         // Create vote record
         let vote : Vote = {
+            daoId = daoId;
             voter = caller;
             proposalId = proposalId;
             choice = choice;
@@ -264,6 +268,7 @@ persistent actor GovernanceCanister {
         let updatedProposal = switch (choice) {
             case (#inFavor) {
                 {
+                    daoId = proposal.daoId;
                     id = proposal.id;
                     proposer = proposal.proposer;
                     title = proposal.title;
@@ -282,6 +287,7 @@ persistent actor GovernanceCanister {
             };
             case (#against) {
                 {
+                    daoId = proposal.daoId;
                     id = proposal.id;
                     proposer = proposal.proposer;
                     title = proposal.title;
@@ -300,6 +306,7 @@ persistent actor GovernanceCanister {
             };
             case (#abstain) {
                 {
+                    daoId = proposal.daoId;
                     id = proposal.id;
                     proposer = proposal.proposer;
                     title = proposal.title;
@@ -341,6 +348,7 @@ persistent actor GovernanceCanister {
         // Check quorum
         if (proposal.totalVotingPower < proposal.quorumThreshold) {
             let failedProposal = {
+                daoId = proposal.daoId;
                 id = proposal.id;
                 proposer = proposal.proposer;
                 title = proposal.title;
@@ -372,6 +380,7 @@ persistent actor GovernanceCanister {
         };
 
         let updatedProposal = {
+            daoId = proposal.daoId;
             id = proposal.id;
             proposer = proposal.proposer;
             title = proposal.title;
@@ -393,6 +402,7 @@ persistent actor GovernanceCanister {
             // Here you would implement the actual execution logic
             // For now, we just mark it as executed
             let executedProposal = {
+                daoId = updatedProposal.daoId;
                 id = updatedProposal.id;
                 proposer = updatedProposal.proposer;
                 title = updatedProposal.title;

--- a/src/dao_backend/main.mo
+++ b/src/dao_backend/main.mo
@@ -175,6 +175,7 @@ persistent actor DAOMain {
         };
 
         let userProfile : UserProfile = {
+            daoId = Principal.fromActor(DAOMain);
             id = caller;
             displayName = displayName;
             bio = bio;
@@ -202,6 +203,7 @@ persistent actor DAOMain {
         };
 
         let userProfile : UserProfile = {
+            daoId = Principal.fromActor(DAOMain);
             id = newUser;
             displayName = displayName;
             bio = bio;
@@ -225,6 +227,7 @@ persistent actor DAOMain {
             case null return #err("User not found");
             case (?profile) {
                 let updatedProfile = {
+                    daoId = profile.daoId;
                     id = profile.id;
                     displayName = displayName;
                     bio = bio;

--- a/src/dao_backend/proposals/main.mo
+++ b/src/dao_backend/proposals/main.mo
@@ -182,6 +182,7 @@ persistent actor ProposalsCanister {
 
     // Create a new proposal
     public shared(msg) func createProposal(
+        daoId: Principal,
         title: Text,
         description: Text,
         proposalType: Types.ProposalType,
@@ -210,6 +211,7 @@ persistent actor ProposalsCanister {
         };
 
         let proposal : Proposal = {
+            daoId = daoId;
             id = proposalId;
             proposer = caller;
             title = title;
@@ -232,6 +234,7 @@ persistent actor ProposalsCanister {
 
     // Create proposal from template
     public shared(_msg) func createProposalFromTemplate(
+        daoId: Principal,
         templateId: Nat,
         title: Text,
         parameters: [(Text, Text)],
@@ -258,6 +261,7 @@ persistent actor ProposalsCanister {
 
         // Create proposal with text type for now
         await createProposal(
+            daoId,
             title,
             description,
             #textProposal(description),
@@ -268,12 +272,13 @@ persistent actor ProposalsCanister {
 
     // Batch vote on multiple proposals
     public shared(_msg) func batchVote(
+        daoId: Principal,
         votes: [(ProposalId, Types.VoteChoice, ?Text)]
     ) : async [Result<(), Text>] {
         let results = Buffer.Buffer<Result<(), Text>>(votes.size());
 
         for ((proposalId, choice, reason) in votes.vals()) {
-            let result = await vote(proposalId, choice, reason);
+            let result = await vote(daoId, proposalId, choice, reason);
             results.add(result);
         };
         
@@ -282,6 +287,7 @@ persistent actor ProposalsCanister {
 
     // Cast a vote on a proposal
     public shared(msg) func vote(
+        daoId: Principal,
         proposalId: ProposalId,
         choice: Types.VoteChoice,
         reason: ?Text
@@ -323,6 +329,7 @@ persistent actor ProposalsCanister {
 
         // Create vote record
         let vote : Vote = {
+            daoId = daoId;
             voter = caller;
             proposalId = proposalId;
             choice = choice;
@@ -337,6 +344,7 @@ persistent actor ProposalsCanister {
         let updatedProposal = switch (choice) {
             case (#inFavor) {
                 {
+                    daoId = proposal.daoId;
                     id = proposal.id;
                     proposer = proposal.proposer;
                     title = proposal.title;
@@ -355,6 +363,7 @@ persistent actor ProposalsCanister {
             };
             case (#against) {
                 {
+                    daoId = proposal.daoId;
                     id = proposal.id;
                     proposer = proposal.proposer;
                     title = proposal.title;
@@ -373,6 +382,7 @@ persistent actor ProposalsCanister {
             };
             case (#abstain) {
                 {
+                    daoId = proposal.daoId;
                     id = proposal.id;
                     proposer = proposal.proposer;
                     title = proposal.title;

--- a/src/dao_backend/shared/types.mo
+++ b/src/dao_backend/shared/types.mo
@@ -14,6 +14,7 @@ module {
     public type UserId = Principal;
     
     public type UserProfile = {
+        daoId: Principal;
         id: UserId;
         displayName: Text;
         bio: Text;
@@ -97,6 +98,7 @@ module {
     };
 
     public type Proposal = {
+        daoId: Principal;
         id: ProposalId;
         proposer: Principal;
         title: Text;
@@ -117,6 +119,7 @@ module {
     public type VoteChoice = { #inFavor; #against; #abstain };
     
     public type Vote = {
+        daoId: Principal;
         voter: Principal;
         proposalId: ProposalId;
         choice: VoteChoice;
@@ -137,6 +140,7 @@ module {
     };
 
     public type Stake = {
+        daoId: Principal;
         id: StakeId;
         staker: Principal;
         amount: TokenAmount;
@@ -163,6 +167,7 @@ module {
     };
 
     public type TreasuryTransaction = {
+        daoId: Principal;
         id: Nat;
         transactionType: TreasuryTransactionType;
         amount: TokenAmount;

--- a/src/dao_backend/staking/main.mo
+++ b/src/dao_backend/staking/main.mo
@@ -89,7 +89,7 @@ persistent actor StakingCanister {
     // Public functions
 
     // Stake tokens
-    public shared(msg) func stake(amount: TokenAmount, period: StakingPeriod) : async Result<StakeId, Text> {
+    public shared(msg) func stake(daoId: Principal, amount: TokenAmount, period: StakingPeriod) : async Result<StakeId, Text> {
         let caller = msg.caller;
 
         if (not stakingEnabled) {
@@ -111,6 +111,7 @@ persistent actor StakingCanister {
         let unlockTime = calculateUnlockTime(now, period);
 
         let newStake : Stake = {
+            daoId = daoId;
             id = stakeId;
             staker = caller;
             amount = amount;
@@ -138,7 +139,7 @@ persistent actor StakingCanister {
     };
 
     // Unstake tokens
-    public shared(msg) func unstake(stakeId: StakeId) : async Result<TokenAmount, Text> {
+    public shared(msg) func unstake(daoId: Principal, stakeId: StakeId) : async Result<TokenAmount, Text> {
         let caller = msg.caller;
 
         let stake = switch (stakes.get(stakeId)) {
@@ -170,6 +171,7 @@ persistent actor StakingCanister {
 
         // Deactivate stake
         let updatedStake = {
+            daoId = stake.daoId;
             id = stake.id;
             staker = stake.staker;
             amount = stake.amount;
@@ -189,7 +191,7 @@ persistent actor StakingCanister {
     };
 
     // Claim rewards without unstaking (for instant staking)
-    public shared(msg) func claimRewards(stakeId: StakeId) : async Result<TokenAmount, Text> {
+    public shared(msg) func claimRewards(daoId: Principal, stakeId: StakeId) : async Result<TokenAmount, Text> {
         let caller = msg.caller;
 
         let stake = switch (stakes.get(stakeId)) {
@@ -222,6 +224,7 @@ persistent actor StakingCanister {
 
         // Update stake with claimed rewards
         let updatedStake = {
+            daoId = stake.daoId;
             id = stake.id;
             staker = stake.staker;
             amount = stake.amount;
@@ -239,7 +242,7 @@ persistent actor StakingCanister {
     };
 
     // Extend staking period
-    public shared(msg) func extendStakingPeriod(stakeId: StakeId, newPeriod: StakingPeriod) : async Result<(), Text> {
+    public shared(msg) func extendStakingPeriod(daoId: Principal, stakeId: StakeId, newPeriod: StakingPeriod) : async Result<(), Text> {
         let caller = msg.caller;
 
         let stake = switch (stakes.get(stakeId)) {
@@ -262,6 +265,7 @@ persistent actor StakingCanister {
 
         let newUnlockTime = calculateUnlockTime(Time.now(), newPeriod);
         let updatedStake = {
+            daoId = stake.daoId;
             id = stake.id;
             staker = stake.staker;
             amount = stake.amount;

--- a/src/dao_backend/treasury/main.mo
+++ b/src/dao_backend/treasury/main.mo
@@ -87,7 +87,7 @@ persistent actor TreasuryCanister {
     // Public functions
 
     // Deposit tokens to treasury
-    public shared(msg) func deposit(amount: TokenAmount, description: Text) : async Result<Nat, Text> {
+    public shared(msg) func deposit(daoId: Principal, amount: TokenAmount, description: Text) : async Result<Nat, Text> {
         if (amount == 0) {
             return #err("Amount must be greater than 0");
         };
@@ -96,6 +96,7 @@ persistent actor TreasuryCanister {
         nextTransactionId += 1;
 
         let transaction : TreasuryTransaction = {
+            daoId = daoId;
             id = transactionId;
             transactionType = #deposit;
             amount = amount;
@@ -118,6 +119,7 @@ persistent actor TreasuryCanister {
 
     // Withdraw tokens from treasury (requires authorization)
     public shared(msg) func withdraw(
+        daoId: Principal,
         recipient: Principal,
         amount: TokenAmount,
         description: Text,
@@ -139,6 +141,7 @@ persistent actor TreasuryCanister {
         nextTransactionId += 1;
 
         let transaction : TreasuryTransaction = {
+            daoId = daoId;
             id = transactionId;
             transactionType = #withdrawal;
             amount = amount;
@@ -160,6 +163,7 @@ persistent actor TreasuryCanister {
                 availableBalance -= amount;
                 
                 let completedTransaction = {
+                    daoId = transaction.daoId;
                     id = transaction.id;
                     transactionType = transaction.transactionType;
                     amount = transaction.amount;
@@ -176,6 +180,7 @@ persistent actor TreasuryCanister {
             };
             case (#err(error)) {
                 let failedTransaction = {
+                    daoId = transaction.daoId;
                     id = transaction.id;
                     transactionType = transaction.transactionType;
                     amount = transaction.amount;
@@ -193,7 +198,7 @@ persistent actor TreasuryCanister {
     };
 
     // Lock tokens for specific purposes (e.g., staking rewards)
-    public shared(msg) func lockTokens(amount: TokenAmount, reason: Text) : async Result<(), Text> {
+    public shared(msg) func lockTokens(daoId: Principal, amount: TokenAmount, reason: Text) : async Result<(), Text> {
         if (not isAuthorized(msg.caller)) {
             return #err("Not authorized");
         };
@@ -209,6 +214,7 @@ persistent actor TreasuryCanister {
         nextTransactionId += 1;
 
         let transaction : TreasuryTransaction = {
+            daoId = daoId;
             id = transactionId;
             transactionType = #stakingReward;
             amount = amount;
@@ -225,7 +231,7 @@ persistent actor TreasuryCanister {
     };
 
     // Unlock tokens
-    public shared(msg) func unlockTokens(amount: TokenAmount, reason: Text) : async Result<(), Text> {
+    public shared(msg) func unlockTokens(daoId: Principal, amount: TokenAmount, reason: Text) : async Result<(), Text> {
         if (not isAuthorized(msg.caller)) {
             return #err("Not authorized");
         };
@@ -241,6 +247,7 @@ persistent actor TreasuryCanister {
         nextTransactionId += 1;
 
         let transaction : TreasuryTransaction = {
+            daoId = daoId;
             id = transactionId;
             transactionType = #stakingReward;
             amount = amount;
@@ -257,7 +264,7 @@ persistent actor TreasuryCanister {
     };
 
     // Reserve tokens for future use
-    public shared(msg) func reserveTokens(amount: TokenAmount, reason: Text) : async Result<(), Text> {
+    public shared(msg) func reserveTokens(daoId: Principal, amount: TokenAmount, reason: Text) : async Result<(), Text> {
         if (not isAuthorized(msg.caller)) {
             return #err("Not authorized");
         };
@@ -273,6 +280,7 @@ persistent actor TreasuryCanister {
         nextTransactionId += 1;
 
         let transaction : TreasuryTransaction = {
+            daoId = daoId;
             id = transactionId;
             transactionType = #fee;
             amount = amount;
@@ -289,7 +297,7 @@ persistent actor TreasuryCanister {
     };
 
     // Release reserved tokens
-    public shared(msg) func releaseReservedTokens(amount: TokenAmount, reason: Text) : async Result<(), Text> {
+    public shared(msg) func releaseReservedTokens(daoId: Principal, amount: TokenAmount, reason: Text) : async Result<(), Text> {
         if (not isAuthorized(msg.caller)) {
             return #err("Not authorized");
         };
@@ -305,6 +313,7 @@ persistent actor TreasuryCanister {
         nextTransactionId += 1;
 
         let transaction : TreasuryTransaction = {
+            daoId = daoId;
             id = transactionId;
             transactionType = #fee;
             amount = amount;

--- a/src/dao_frontend/src/declarations/dao_backend/dao_backend.did
+++ b/src/dao_frontend/src/declarations/dao_backend/dao_backend.did
@@ -1,12 +1,13 @@
-type UserProfile = 
+type UserProfile =
  record {
-   bio: text;
-   displayName: text;
-   id: UserId;
-   joinedAt: Time;
-   reputation: nat;
-   totalStaked: nat;
-   votingPower: nat;
+  daoId: principal;
+  bio: text;
+  displayName: text;
+  id: UserId;
+  joinedAt: Time;
+  reputation: nat;
+  totalStaked: nat;
+  votingPower: nat;
  };
 type UserId = principal;
 type TokenAmount = nat;

--- a/src/dao_frontend/src/declarations/dao_backend/dao_backend.did.d.ts
+++ b/src/dao_frontend/src/declarations/dao_backend/dao_backend.did.d.ts
@@ -47,6 +47,7 @@ export type Time = bigint;
 export type TokenAmount = bigint;
 export type UserId = Principal;
 export interface UserProfile {
+  'daoId' : Principal,
   'id' : UserId,
   'bio' : string,
   'displayName' : string,

--- a/src/dao_frontend/src/declarations/dao_backend/dao_backend.did.js
+++ b/src/dao_frontend/src/declarations/dao_backend/dao_backend.did.js
@@ -4,6 +4,7 @@ export const idlFactory = ({ IDL }) => {
   const UserId = IDL.Principal;
   const Time = IDL.Int;
   const UserProfile = IDL.Record({
+    'daoId' : IDL.Principal,
     'id' : UserId,
     'bio' : IDL.Text,
     'displayName' : IDL.Text,


### PR DESCRIPTION
## Summary
- Add `daoId` field to shared records like `UserProfile`, `Proposal`, `Vote`, `Stake`, and `TreasuryTransaction`
- Update staking, treasury, governance, and proposals modules to accept and propagate `daoId`
- Adjust DAO backend user profile handling for new `daoId`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1bc6c523483209365455614b24318