### PR TITLE
Add DAO-specific asset handling

### DIFF
--- a/src/dao_backend/assets/main.mo
+++ b/src/dao_backend/assets/main.mo
@@ -17,10 +17,17 @@ persistent actor AssetCanister {
 
     // Asset types
     public type AssetId = Nat;
+    public type DaoId = Nat;
     public type AssetData = Blob;
-    
+
+    public type AssetKey = {
+        daoId: DaoId;
+        assetId: AssetId;
+    };
+
     public type Asset = {
         id: AssetId;
+        daoId: DaoId;
         name: Text;
         contentType: Text;
         size: Nat;
@@ -33,6 +40,7 @@ persistent actor AssetCanister {
 
     public type AssetMetadata = {
         id: AssetId;
+        daoId: DaoId;
         name: Text;
         contentType: Text;
         size: Nat;
@@ -53,7 +61,7 @@ persistent actor AssetCanister {
 
     // Stable storage for upgrades
     private var nextAssetId : Nat = 1;
-    private var assetsEntries : [(AssetId, Asset)] = [];
+    private var assetsEntries : [(AssetKey, Asset)] = [];
     private var authorizedUploaders : [Principal] = [];
     private var maxFileSize : Nat = 10_000_000; // 10MB default
     private var maxTotalStorage : Nat = 1_000_000_000; // 1GB default
@@ -61,8 +69,29 @@ persistent actor AssetCanister {
     private var allowOpenUploads : Bool = false; // permit uploads with empty authorizedUploaders
 
     // Runtime storage
-    private transient var assets = HashMap.HashMap<AssetId, Asset>(100, Nat.equal, func(n: Nat) : Nat32 { Nat32.fromNat(n) });
-    private transient var uploaderAssets = HashMap.HashMap<Principal, [AssetId]>(50, Principal.equal, Principal.hash);
+    private func assetKeyEqual(a: AssetKey, b: AssetKey) : Bool {
+        a.daoId == b.daoId and a.assetId == b.assetId
+    };
+
+    private func assetKeyHash(k: AssetKey) : Nat32 {
+        Nat32.fromNat(k.daoId * 1_000_003 + k.assetId)
+    };
+
+    private type UploaderKey = {
+        daoId: DaoId;
+        uploader: Principal;
+    };
+
+    private func uploaderKeyEqual(a: UploaderKey, b: UploaderKey) : Bool {
+        a.daoId == b.daoId and a.uploader == b.uploader
+    };
+
+    private func uploaderKeyHash(k: UploaderKey) : Nat32 {
+        Nat32.xor(Nat32.fromNat(k.daoId), Principal.hash(k.uploader))
+    };
+
+    private transient var assets = HashMap.HashMap<AssetKey, Asset>(100, assetKeyEqual, assetKeyHash);
+    private transient var uploaderAssets = HashMap.HashMap<UploaderKey, [AssetId]>(50, uploaderKeyEqual, uploaderKeyHash);
 
     // Supported content types
     private transient let supportedTypes = [
@@ -94,21 +123,22 @@ persistent actor AssetCanister {
     };
 
     system func postupgrade() {
-        assets := HashMap.fromIter<AssetId, Asset>(
-            assetsEntries.vals(), 
-            assetsEntries.size(), 
-            Nat.equal, 
-            func(n: Nat) : Nat32 { Nat32.fromNat(n) }
+        assets := HashMap.fromIter<AssetKey, Asset>(
+            assetsEntries.vals(),
+            assetsEntries.size(),
+            assetKeyEqual,
+            assetKeyHash
         );
-        
+
         // Rebuild uploader assets mapping
-        for ((assetId, asset) in assets.entries()) {
-            let currentAssets = switch (uploaderAssets.get(asset.uploadedBy)) {
+        for ((key, asset) in assets.entries()) {
+            let uKey : UploaderKey = { daoId = key.daoId; uploader = asset.uploadedBy };
+            let currentAssets = switch (uploaderAssets.get(uKey)) {
                 case (?assets) assets;
                 case null [];
             };
-            let updatedAssets = Array.append<AssetId>(currentAssets, [assetId]);
-            uploaderAssets.put(asset.uploadedBy, updatedAssets);
+            let updatedAssets = Array.append<AssetId>(currentAssets, [key.assetId]);
+            uploaderAssets.put(uKey, updatedAssets);
         };
     };
 
@@ -118,6 +148,7 @@ persistent actor AssetCanister {
     // If no uploaders have been authorized, the upload will be rejected unless
     // `allowOpenUploads` was set to true during deployment.
     public shared(msg) func uploadAsset(
+        daoId: DaoId,
         name: Text,
         contentType: Text,
         data: AssetData,
@@ -160,8 +191,10 @@ persistent actor AssetCanister {
         let assetId = nextAssetId;
         nextAssetId += 1;
 
+        let key : AssetKey = { daoId = daoId; assetId = assetId };
         let asset : Asset = {
             id = assetId;
+            daoId = daoId;
             name = name;
             contentType = contentType;
             size = dataSize;
@@ -172,26 +205,28 @@ persistent actor AssetCanister {
             tags = tags;
         };
 
-        assets.put(assetId, asset);
+        assets.put(key, asset);
         currentStorageUsed += dataSize;
 
         // Update uploader assets mapping
-        let currentAssets = switch (uploaderAssets.get(caller)) {
+        let uKey : UploaderKey = { daoId = daoId; uploader = caller };
+        let currentAssets = switch (uploaderAssets.get(uKey)) {
             case (?assets) assets;
             case null [];
         };
         let updatedAssets = Array.append<AssetId>(currentAssets, [assetId]);
-        uploaderAssets.put(caller, updatedAssets);
+        uploaderAssets.put(uKey, updatedAssets);
 
         Debug.print("Asset uploaded: " # name # " (ID: " # Nat.toText(assetId) # ")");
         #ok(assetId)
     };
 
     // Get asset data
-    public shared(msg) func getAsset(assetId: AssetId) : async Result<Asset, Text> {
+    public shared(msg) func getAsset(daoId: DaoId, assetId: AssetId) : async Result<Asset, Text> {
         let caller = msg.caller;
-        
-        switch (assets.get(assetId)) {
+        let key : AssetKey = { daoId = daoId; assetId = assetId };
+
+        switch (assets.get(key)) {
             case (?asset) {
                 // Check access permissions
                 if (asset.isPublic or asset.uploadedBy == caller or isAuthorized(caller)) {
@@ -205,11 +240,13 @@ persistent actor AssetCanister {
     };
 
     // Get asset metadata only (without data)
-    public query func getAssetMetadata(assetId: AssetId) : async ?AssetMetadata {
-        switch (assets.get(assetId)) {
+    public query func getAssetMetadata(daoId: DaoId, assetId: AssetId) : async ?AssetMetadata {
+        let key : AssetKey = { daoId = daoId; assetId = assetId };
+        switch (assets.get(key)) {
             case (?asset) {
                 ?{
                     id = asset.id;
+                    daoId = asset.daoId;
                     name = asset.name;
                     contentType = asset.contentType;
                     size = asset.size;
@@ -224,12 +261,13 @@ persistent actor AssetCanister {
     };
 
     // Get public assets
-    public query func getPublicAssets() : async [AssetMetadata] {
+    public query func getPublicAssets(daoId: DaoId) : async [AssetMetadata] {
         let publicAssets = Buffer.Buffer<AssetMetadata>(0);
-        for (asset in assets.vals()) {
-            if (asset.isPublic) {
+        for ((key, asset) in assets.entries()) {
+            if (key.daoId == daoId and asset.isPublic) {
                 publicAssets.add({
                     id = asset.id;
+                    daoId = asset.daoId;
                     name = asset.name;
                     contentType = asset.contentType;
                     size = asset.size;
@@ -244,19 +282,22 @@ persistent actor AssetCanister {
     };
 
     // Get user's assets
-    public shared(msg) func getUserAssets() : async [AssetMetadata] {
+    public shared(msg) func getUserAssets(daoId: DaoId) : async [AssetMetadata] {
         let caller = msg.caller;
-        let userAssetIds = switch (uploaderAssets.get(caller)) {
+        let uKey : UploaderKey = { daoId = daoId; uploader = caller };
+        let userAssetIds = switch (uploaderAssets.get(uKey)) {
             case (?ids) ids;
             case null return [];
         };
 
         let userAssets = Buffer.Buffer<AssetMetadata>(0);
         for (assetId in userAssetIds.vals()) {
-            switch (assets.get(assetId)) {
+            let key : AssetKey = { daoId = daoId; assetId = assetId };
+            switch (assets.get(key)) {
                 case (?asset) {
                     userAssets.add({
                         id = asset.id;
+                        daoId = asset.daoId;
                         name = asset.name;
                         contentType = asset.contentType;
                         size = asset.size;
@@ -273,14 +314,15 @@ persistent actor AssetCanister {
     };
 
     // Search assets by tags
-    public query func searchAssetsByTag(tag: Text) : async [AssetMetadata] {
+    public query func searchAssetsByTag(daoId: DaoId, tag: Text) : async [AssetMetadata] {
         let matchingAssets = Buffer.Buffer<AssetMetadata>(0);
-        for (asset in assets.vals()) {
-            if (asset.isPublic) {
+        for ((key, asset) in assets.entries()) {
+            if (key.daoId == daoId and asset.isPublic) {
                 let hasTag = Array.find<Text>(asset.tags, func(t) = t == tag);
                 if (hasTag != null) {
                     matchingAssets.add({
                         id = asset.id;
+                        daoId = asset.daoId;
                         name = asset.name;
                         contentType = asset.contentType;
                         size = asset.size;
@@ -296,24 +338,26 @@ persistent actor AssetCanister {
     };
 
     // Delete asset
-    public shared(msg) func deleteAsset(assetId: AssetId) : async Result<(), Text> {
+    public shared(msg) func deleteAsset(daoId: DaoId, assetId: AssetId) : async Result<(), Text> {
         let caller = msg.caller;
-        
-        switch (assets.get(assetId)) {
+        let key : AssetKey = { daoId = daoId; assetId = assetId };
+
+        switch (assets.get(key)) {
             case (?asset) {
                 // Check if user owns the asset or is authorized
                 if (asset.uploadedBy == caller or isAuthorized(caller)) {
-                    assets.delete(assetId);
+                    assets.delete(key);
                     currentStorageUsed -= asset.size;
-                    
+
                     // Update uploader assets mapping
-                    let currentAssets = switch (uploaderAssets.get(asset.uploadedBy)) {
+                    let uKey : UploaderKey = { daoId = daoId; uploader = asset.uploadedBy };
+                    let currentAssets = switch (uploaderAssets.get(uKey)) {
                         case (?assets) assets;
                         case null [];
                     };
                     let updatedAssets = Array.filter<AssetId>(currentAssets, func(id) = id != assetId);
-                    uploaderAssets.put(asset.uploadedBy, updatedAssets);
-                    
+                    uploaderAssets.put(uKey, updatedAssets);
+
                     Debug.print("Asset deleted: " # asset.name # " (ID: " # Nat.toText(assetId) # ")");
                     #ok()
                 } else {
@@ -326,18 +370,21 @@ persistent actor AssetCanister {
 
     // Update asset metadata
     public shared(msg) func updateAssetMetadata(
+        daoId: DaoId,
         assetId: AssetId,
         name: ?Text,
         isPublic: ?Bool,
         tags: ?[Text]
     ) : async Result<(), Text> {
         let caller = msg.caller;
-        
-        switch (assets.get(assetId)) {
+        let key : AssetKey = { daoId = daoId; assetId = assetId };
+
+        switch (assets.get(key)) {
             case (?asset) {
                 if (asset.uploadedBy == caller or isAuthorized(caller)) {
                     let updatedAsset = {
                         id = asset.id;
+                        daoId = asset.daoId;
                         name = switch (name) { case (?n) n; case null asset.name };
                         contentType = asset.contentType;
                         size = asset.size;
@@ -347,7 +394,7 @@ persistent actor AssetCanister {
                         isPublic = switch (isPublic) { case (?p) p; case null asset.isPublic };
                         tags = switch (tags) { case (?t) t; case null asset.tags };
                     };
-                    assets.put(assetId, updatedAsset);
+                    assets.put(key, updatedAsset);
                     #ok()
                 } else {
                     #err("Not authorized to update this asset")
@@ -358,21 +405,28 @@ persistent actor AssetCanister {
     };
 
     // Get storage statistics
-    public query func getStorageStats() : async {
+    public query func getStorageStats(daoId: DaoId) : async {
         totalAssets: Nat;
         storageUsed: Nat;
         storageLimit: Nat;
         storageAvailable: Nat;
         averageFileSize: Nat;
     } {
-        let totalAssets = assets.size();
+        var totalAssets : Nat = 0;
+        var daoStorage : Nat = 0;
+        for ((key, asset) in assets.entries()) {
+            if (key.daoId == daoId) {
+                totalAssets += 1;
+                daoStorage += asset.size;
+            };
+        };
         let averageSize = if (totalAssets > 0) {
-            currentStorageUsed / totalAssets
+            daoStorage / totalAssets
         } else { 0 };
 
         {
             totalAssets = totalAssets;
-            storageUsed = currentStorageUsed;
+            storageUsed = daoStorage;
             storageLimit = maxTotalStorage;
             storageAvailable = maxTotalStorage - currentStorageUsed;
             averageFileSize = averageSize;
@@ -464,11 +518,12 @@ persistent actor AssetCanister {
     };
 
     // Get asset by name (for convenience)
-    public query func getAssetByName(name: Text) : async ?AssetMetadata {
-        for (asset in assets.vals()) {
-            if (asset.name == name and asset.isPublic) {
+    public query func getAssetByName(daoId: DaoId, name: Text) : async ?AssetMetadata {
+        for ((key, asset) in assets.entries()) {
+            if (key.daoId == daoId and asset.name == name and asset.isPublic) {
                 return ?{
                     id = asset.id;
+                    daoId = asset.daoId;
                     name = asset.name;
                     contentType = asset.contentType;
                     size = asset.size;
@@ -484,15 +539,16 @@ persistent actor AssetCanister {
 
     // Batch upload assets
     public shared(_msg) func batchUploadAssets(
+        daoId: DaoId,
         assets_data: [(Text, Text, AssetData, Bool, [Text])]
     ) : async [Result<AssetId, Text>] {
         let results = Buffer.Buffer<Result<AssetId, Text>>(assets_data.size());
-        
+
         for ((name, contentType, data, isPublic, tags) in assets_data.vals()) {
-            let result = await uploadAsset(name, contentType, data, isPublic, tags);
+            let result = await uploadAsset(daoId, name, contentType, data, isPublic, tags);
             results.add(result);
         };
-        
+
         Buffer.toArray(results)
     };
 }

--- a/src/dao_backend/assets/main.test.mo
+++ b/src/dao_backend/assets/main.test.mo
@@ -13,7 +13,7 @@ actor {
 
         // Upload should fail while no authorized uploaders exist.
         let data = Blob.fromArray([1,2,3]);
-        let uploadBefore = await Asset.uploadAsset("test", "image/png", data, true, []);
+        let uploadBefore = await Asset.uploadAsset(1, "test", "image/png", data, true, []);
         assert uploadBefore == #err("Uploads are disabled until an uploader is authorized or open uploads are enabled");
 
         // Anyone can authorize the first uploader.
@@ -24,7 +24,7 @@ actor {
         assert Array.find<Principal>(uploaders, func(p) = p == selfPrincipal) != null;
 
         // After authorization, upload succeeds.
-        let uploadAfter = await Asset.uploadAsset("test2", "image/png", data, true, []);
+        let uploadAfter = await Asset.uploadAsset(1, "test2", "image/png", data, true, []);
         switch uploadAfter { case (#ok(_)) {}; case (_) { assert false } };
 
         let duplicateRes = await Asset.addAuthorizedUploader(selfPrincipal);

--- a/src/dao_frontend/src/components/Assets.jsx
+++ b/src/dao_frontend/src/components/Assets.jsx
@@ -16,6 +16,7 @@ const Assets = () => {
     loading,
     error,
   } = useAssets();
+  const daoId = 1;
   const [file, setFile] = useState(null);
   const [batchFiles, setBatchFiles] = useState([]);
   const [assets, setAssets] = useState([]);
@@ -30,7 +31,7 @@ const Assets = () => {
 
   const fetchStats = async () => {
     try {
-      const s = await getStorageStats();
+      const s = await getStorageStats(daoId);
       setStats(s);
     } catch (err) {
       console.error(err);
@@ -39,7 +40,9 @@ const Assets = () => {
 
   const fetchAssets = async (t = '') => {
     try {
-      const list = t ? await searchAssetsByTag(t) : await getPublicAssets();
+      const list = t
+        ? await searchAssetsByTag(daoId, t)
+        : await getPublicAssets(daoId);
       setAssets(list);
     } catch (err) {
       console.error(err);
@@ -61,7 +64,7 @@ const Assets = () => {
         setMessage(`Unsupported file type: ${file.type}`);
         return;
       }
-      await uploadAsset(file, true, []);
+      await uploadAsset(daoId, file, true, []);
       setFile(null);
       setMessage('File uploaded');
       fetchAssets(tag);
@@ -81,7 +84,7 @@ const Assets = () => {
     if (!name) return;
     setMessage('');
     try {
-      const res = await getAssetByName(name);
+      const res = await getAssetByName(daoId, name);
       if (res.length === 0) {
         setAssets([]);
         setMessage('No asset found');
@@ -104,7 +107,7 @@ const Assets = () => {
         setMessage(`Unsupported file types: ${unsupported.map((f) => f.name).join(', ')}`);
         return;
       }
-      await batchUploadAssets(batchFiles.map((f) => ({ file: f, isPublic: true, tags: [] })));
+      await batchUploadAssets(daoId, batchFiles.map((f) => ({ file: f, isPublic: true, tags: [] })));
       setBatchFiles([]);
       setMessage('Batch upload successful');
       fetchAssets(tag);
@@ -116,7 +119,7 @@ const Assets = () => {
 
   const handleView = async (id) => {
     try {
-      const asset = await getAsset(id);
+      const asset = await getAsset(daoId, id);
       const blob = new Blob([new Uint8Array(asset.data)], { type: asset.contentType });
       const url = URL.createObjectURL(blob);
       window.open(url, '_blank');
@@ -127,7 +130,7 @@ const Assets = () => {
 
   const handleDelete = async (id) => {
     try {
-      await deleteAsset(id);
+      await deleteAsset(daoId, id);
       fetchAssets(tag);
       fetchStats();
     } catch (err) {
@@ -149,7 +152,7 @@ const Assets = () => {
       .map((t) => t.trim())
       .filter((t) => t.length > 0);
     try {
-      await updateAssetMetadata(id, {
+      await updateAssetMetadata(daoId, id, {
         name: editName,
         isPublic: editPublic,
         tags: tagsArray,

--- a/src/dao_frontend/src/components/management/ManagementAssets.tsx
+++ b/src/dao_frontend/src/components/management/ManagementAssets.tsx
@@ -10,6 +10,7 @@ const ManagementAssets: React.FC = () => {
   const { dao } = useOutletContext<{ dao: DAO }>();
 
   const { getUserAssets, getPublicAssets, uploadAsset, getAsset } = useAssets();
+  const daoId = dao.id;
   const [assets, setAssets] = useState<any[]>([]);
   const [uploadProgress, setUploadProgress] = useState(0);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -17,8 +18,8 @@ const ManagementAssets: React.FC = () => {
   const fetchAssets = async () => {
     try {
       const [userAssets, publicAssets] = await Promise.all([
-        getUserAssets(),
-        getPublicAssets(),
+        getUserAssets(daoId),
+        getPublicAssets(daoId),
       ]);
       const userIds = new Set(userAssets.map((a: any) => Number(a.id)));
       const combined = [
@@ -47,7 +48,7 @@ const ManagementAssets: React.FC = () => {
       setUploadProgress((p) => (p < 90 ? p + 10 : p));
     }, 200);
     try {
-      await uploadAsset(file, true, []);
+      await uploadAsset(daoId, file, true, []);
       setUploadProgress(100);
       await fetchAssets();
     } catch (err) {
@@ -63,7 +64,7 @@ const ManagementAssets: React.FC = () => {
 
   const handleDownload = async (id: bigint) => {
     try {
-      const asset = await getAsset(id);
+      const asset = await getAsset(daoId, id);
       const blob = new Blob([new Uint8Array(asset.data)], {
         type: asset.contentType,
       });

--- a/src/dao_frontend/src/components/management/ManagementAssetsAdmin.tsx
+++ b/src/dao_frontend/src/components/management/ManagementAssetsAdmin.tsx
@@ -1,8 +1,12 @@
 import React, { useEffect, useState } from 'react';
+import { useOutletContext } from 'react-router-dom';
+import { DAO } from '../../types/dao';
 import { useAssets } from '../../hooks/useAssets';
 import { Plus, Trash2 } from 'lucide-react';
 
 const ManagementAssetsAdmin: React.FC = () => {
+  const { dao } = useOutletContext<{ dao: DAO }>();
+
   const {
     getAuthorizedUploaders,
     addAuthorizedUploader,
@@ -10,6 +14,7 @@ const ManagementAssetsAdmin: React.FC = () => {
     getStorageStats,
     updateStorageLimits,
   } = useAssets();
+  const daoId = dao.id;
 
   const [uploaders, setUploaders] = useState<string[]>([]);
   const [newUploader, setNewUploader] = useState('');
@@ -23,7 +28,7 @@ const ManagementAssetsAdmin: React.FC = () => {
     try {
       const [uploaderList, storageStats] = await Promise.all([
         getAuthorizedUploaders(),
-        getStorageStats(),
+        getStorageStats(daoId),
       ]);
       setUploaders(uploaderList);
       setStats(storageStats);

--- a/src/dao_frontend/src/hooks/useAssets.js
+++ b/src/dao_frontend/src/hooks/useAssets.js
@@ -7,13 +7,14 @@ export const useAssets = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
-  const uploadAsset = async (file, isPublic = true, tags = []) => {
+  const uploadAsset = async (daoId, file, isPublic = true, tags = []) => {
     setLoading(true);
     setError(null);
     try {
       const arrayBuffer = await file.arrayBuffer();
       const data = Array.from(new Uint8Array(arrayBuffer));
       const result = await actors.assets.uploadAsset(
+        BigInt(daoId),
         file.name,
         file.type,
         data,
@@ -32,11 +33,11 @@ export const useAssets = () => {
     }
   };
 
-  const getAsset = async (assetId) => {
+  const getAsset = async (daoId, assetId) => {
     setLoading(true);
     setError(null);
     try {
-      const res = await actors.assets.getAsset(BigInt(assetId));
+      const res = await actors.assets.getAsset(BigInt(daoId), BigInt(assetId));
       if (res.err) {
         throw new Error(res.err);
       }
@@ -49,11 +50,11 @@ export const useAssets = () => {
     }
   };
 
-  const getAssetMetadata = async (assetId) => {
+  const getAssetMetadata = async (daoId, assetId) => {
     setLoading(true);
     setError(null);
     try {
-      return await actors.assets.getAssetMetadata(BigInt(assetId));
+      return await actors.assets.getAssetMetadata(BigInt(daoId), BigInt(assetId));
     } catch (err) {
       setError(err.message);
       throw err;
@@ -62,11 +63,11 @@ export const useAssets = () => {
     }
   };
 
-  const getPublicAssets = async () => {
+  const getPublicAssets = async (daoId) => {
     setLoading(true);
     setError(null);
     try {
-      return await actors.assets.getPublicAssets();
+      return await actors.assets.getPublicAssets(BigInt(daoId));
     } catch (err) {
       setError(err.message);
       throw err;
@@ -75,11 +76,11 @@ export const useAssets = () => {
     }
   };
 
-  const getUserAssets = async () => {
+  const getUserAssets = async (daoId) => {
     setLoading(true);
     setError(null);
     try {
-      return await actors.assets.getUserAssets();
+      return await actors.assets.getUserAssets(BigInt(daoId));
     } catch (err) {
       setError(err.message);
       throw err;
@@ -88,11 +89,11 @@ export const useAssets = () => {
     }
   };
 
-  const searchAssetsByTag = async (tag) => {
+  const searchAssetsByTag = async (daoId, tag) => {
     setLoading(true);
     setError(null);
     try {
-      return await actors.assets.searchAssetsByTag(tag);
+      return await actors.assets.searchAssetsByTag(BigInt(daoId), tag);
     } catch (err) {
       setError(err.message);
       throw err;
@@ -101,11 +102,11 @@ export const useAssets = () => {
     }
   };
 
-  const deleteAsset = async (assetId) => {
+  const deleteAsset = async (daoId, assetId) => {
     setLoading(true);
     setError(null);
     try {
-      const res = await actors.assets.deleteAsset(BigInt(assetId));
+      const res = await actors.assets.deleteAsset(BigInt(daoId), BigInt(assetId));
       if (res.err) {
         throw new Error(res.err);
       }
@@ -118,11 +119,12 @@ export const useAssets = () => {
     }
   };
 
-  const updateAssetMetadata = async (assetId, { name = null, isPublic = null, tags = null }) => {
+  const updateAssetMetadata = async (daoId, assetId, { name = null, isPublic = null, tags = null }) => {
     setLoading(true);
     setError(null);
     try {
       const res = await actors.assets.updateAssetMetadata(
+        BigInt(daoId),
         BigInt(assetId),
         name === null ? [] : [name],
         isPublic === null ? [] : [isPublic],
@@ -140,11 +142,11 @@ export const useAssets = () => {
     }
   };
 
-  const getStorageStats = async () => {
+  const getStorageStats = async (daoId) => {
     setLoading(true);
     setError(null);
     try {
-      return await actors.assets.getStorageStats();
+      return await actors.assets.getStorageStats(BigInt(daoId));
     } catch (err) {
       setError(err.message);
       throw err;
@@ -241,11 +243,11 @@ export const useAssets = () => {
     }
   };
 
-  const getAssetByName = async (name) => {
+  const getAssetByName = async (daoId, name) => {
     setLoading(true);
     setError(null);
     try {
-      return await actors.assets.getAssetByName(name);
+      return await actors.assets.getAssetByName(BigInt(daoId), name);
     } catch (err) {
       setError(err.message);
       throw err;
@@ -254,7 +256,7 @@ export const useAssets = () => {
     }
   };
 
-  const batchUploadAssets = async (files) => {
+  const batchUploadAssets = async (daoId, files) => {
     setLoading(true);
     setError(null);
     try {
@@ -265,7 +267,7 @@ export const useAssets = () => {
           return [file.name, file.type, data, isPublic, tags];
         })
       );
-      return await actors.assets.batchUploadAssets(formatted);
+      return await actors.assets.batchUploadAssets(BigInt(daoId), formatted);
     } catch (err) {
       setError(err.message);
       throw err;


### PR DESCRIPTION
## Summary
- track DAO id in asset records and keys
- scope asset queries and storage to a DAO
- update frontend hooks and components to pass DAO id

## Testing
- `npm test`
- `moc --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1bc6c6a548320a4f9b6df52846ed6