### PR TITLE
Scope governance records by DAO

### DIFF
--- a/src/dao_backend/governance/main.mo
+++ b/src/dao_backend/governance/main.mo
@@ -42,13 +42,28 @@ persistent actor GovernanceCanister {
     type GovernanceError = Types.GovernanceError;
     type CommonError = Types.CommonError;
 
-    // Inter-canister communication setup
-    // These actor references enable cross-canister calls for governance functionality
-    var dao : actor {
-        getUserProfile: shared query (Principal) -> async ?Types.UserProfile;
-        checkIsAdmin: shared query (Principal) -> async Bool;
-    } = actor("aaaaa-aa");
+    // Key types for multi-DAO support
+    type ProposalKey = (Principal, ProposalId);
+    type VoteKey = (Principal, ProposalId, Principal);
 
+    private func proposalKeyEqual(a: ProposalKey, b: ProposalKey) : Bool {
+        Principal.equal(a.0, b.0) and a.1 == b.1
+    };
+
+    private func proposalKeyHash(k: ProposalKey) : Nat32 {
+        Principal.hash(k.0) + Nat32.fromNat(k.1)
+    };
+
+    private func voteKeyEqual(a: VoteKey, b: VoteKey) : Bool {
+        Principal.equal(a.0, b.0) and a.1 == b.1 and Principal.equal(a.2, b.2)
+    };
+
+    private func voteKeyHash(k: VoteKey) : Nat32 {
+        Principal.hash(k.0) + Nat32.fromNat(k.1) + Principal.hash(k.2)
+    };
+
+    // Inter-canister communication setup
+    // Actor reference for staking canister
     var staking : actor {
         getUserStakingSummary: shared query (Principal) -> async {
             totalStaked: Nat;
@@ -61,18 +76,17 @@ persistent actor GovernanceCanister {
     // Stable storage for upgrade persistence
     // These arrays store serialized data that survives canister upgrades
     private var nextProposalId : Nat = 1;
-    private var proposalsEntries : [(ProposalId, Proposal)] = [];
-    private var votesEntries : [(Text, Vote)] = []; // Key format: "proposalId_voterPrincipal"
-    private var configEntries : [(Text, GovernanceConfig)] = [];
-    private var daoId : Principal = Principal.fromText("aaaaa-aa");
+    private var proposalsEntries : [(ProposalKey, Proposal)] = [];
+    private var votesEntries : [(VoteKey, Vote)] = [];
+    private var configEntries : [(Principal, GovernanceConfig)] = [];
     private var stakingId : Principal = Principal.fromText("aaaaa-aa");
     private var initialized : Bool = false;
 
     // Runtime storage - rebuilt from stable storage after upgrades
     // HashMaps provide O(1) lookup performance for governance operations
-    private transient var proposals = HashMap.HashMap<ProposalId, Proposal>(10, Nat.equal, func(n: Nat) : Nat32 { Nat32.fromNat(n) });
-    private transient var votes = HashMap.HashMap<Text, Vote>(100, Text.equal, Text.hash);
-    private transient var config = HashMap.HashMap<Text, GovernanceConfig>(1, Text.equal, Text.hash);
+    private transient var proposals = HashMap.HashMap<ProposalKey, Proposal>(10, proposalKeyEqual, proposalKeyHash);
+    private transient var votes = HashMap.HashMap<VoteKey, Vote>(100, voteKeyEqual, voteKeyHash);
+    private transient var config = HashMap.HashMap<Principal, GovernanceConfig>(1, Principal.equal, Principal.hash);
 
     public shared(msg) func init(newDaoId: Principal, newStakingId: Principal) : async () {
         if (initialized) {
@@ -93,24 +107,32 @@ persistent actor GovernanceCanister {
             throw Error.reject("Caller is not authorized to initialize");
         };
 
-        daoId := newDaoId;
         stakingId := newStakingId;
-        dao := daoTemp;
         staking := actor(Principal.toText(newStakingId));
         initialized := true;
         Debug.print("Initialization complete");
     };
 
-    // Initialize default configuration
-    private func initializeConfig() {
-        let defaultConfig : GovernanceConfig = {
+    // Default configuration and helper
+    private func defaultConfig() : GovernanceConfig {
+        {
             votingPeriod = 7 * 24 * 60 * 60 * 1_000_000_000; // 7 days in nanoseconds
             quorumThreshold = 1000; // Minimum 1000 voting power
             approvalThreshold = 51; // 51% approval needed
             proposalDeposit = 100; // 100 tokens required
             maxProposalsPerUser = 3; // Max 3 active proposals per user
-        };
-        config.put("default", defaultConfig);
+        }
+    };
+
+    private func getConfigForDao(daoId: Principal) : GovernanceConfig {
+        switch (config.get(daoId)) {
+            case (?c) c;
+            case null {
+                let c = defaultConfig();
+                config.put(daoId, c);
+                c
+            };
+        }
     };
 
     // System functions for upgrades
@@ -121,55 +143,43 @@ persistent actor GovernanceCanister {
     };
 
     system func postupgrade() {
-        proposals := HashMap.fromIter<ProposalId, Proposal>(
-            proposalsEntries.vals(), 
-            proposalsEntries.size(), 
-            Nat.equal, 
-            func(n: Nat) : Nat32 { Nat32.fromNat(n) }
+        proposals := HashMap.fromIter<ProposalKey, Proposal>(
+            proposalsEntries.vals(),
+            proposalsEntries.size(),
+            proposalKeyEqual,
+            proposalKeyHash
         );
-        votes := HashMap.fromIter<Text, Vote>(
-            votesEntries.vals(), 
-            votesEntries.size(), 
-            Text.equal, 
-            Text.hash
+        votes := HashMap.fromIter<VoteKey, Vote>(
+            votesEntries.vals(),
+            votesEntries.size(),
+            voteKeyEqual,
+            voteKeyHash
         );
-        config := HashMap.fromIter<Text, GovernanceConfig>(
+        config := HashMap.fromIter<Principal, GovernanceConfig>(
             configEntries.vals(),
             configEntries.size(),
-            Text.equal,
-            Text.hash
+            Principal.equal,
+            Principal.hash
         );
 
-        dao := actor(Principal.toText(daoId));
         staking := actor(Principal.toText(stakingId));
-
-        if (config.size() == 0) {
-            initializeConfig();
-        };
-    };
-
-    // Initialize on first deployment
-    if (config.size() == 0) {
-        initializeConfig();
     };
 
     // Public functions
 
     // Create a new proposal
     public shared(msg) func createProposal(
+        daoId: Principal,
         title: Text,
         description: Text,
         proposalType: Types.ProposalType,
         votingPeriod: ?Nat
     ) : async Result<ProposalId, Text> {
         let caller = msg.caller;
-        
-        // Check if user has too many active proposals
-        let activeProposals = getActiveProposalsByUser(caller);
-        let currentConfig = switch (config.get("default")) {
-            case (?c) c;
-            case null return #err("Configuration not found");
-        };
+
+        // Check if user has too many active proposals in this DAO
+        let activeProposals = getActiveProposalsByUser(daoId, caller);
+        let currentConfig = getConfigForDao(daoId);
         
         if (Array.size(activeProposals) >= currentConfig.maxProposalsPerUser) {
             return #err("Maximum active proposals limit reached");
@@ -184,6 +194,7 @@ persistent actor GovernanceCanister {
         };
 
         let proposal : Proposal = {
+            daoId = daoId;
             id = proposalId;
             proposer = caller;
             title = title;
@@ -195,23 +206,24 @@ persistent actor GovernanceCanister {
             totalVotingPower = 0;
             createdAt = Time.now();
             votingDeadline = Time.now() + period;
-            executionDeadline = ?(Time.now() + period + (24 * 60 * 60 * 1_000_000_000)); // 1 day after voting
+            executionDeadline = ?(Time.now() + period + (24 * 60 * 60 * 1_000_000_000));
             quorumThreshold = currentConfig.quorumThreshold;
             approvalThreshold = currentConfig.approvalThreshold;
         };
 
-        proposals.put(proposalId, proposal);
+        proposals.put((daoId, proposalId), proposal);
         #ok(proposalId)
     };
 
     // Cast a vote on a proposal
     public shared(msg) func vote(
+        daoId: Principal,
         proposalId: ProposalId,
         choice: Types.VoteChoice,
         reason: ?Text
     ) : async Result<(), Text> {
         let caller = msg.caller;
-        let voteKey = Nat.toText(proposalId) # "_" # Principal.toText(caller);
+        let voteKey : VoteKey = (daoId, proposalId, caller);
 
         // Check if already voted
         switch (votes.get(voteKey)) {
@@ -220,7 +232,7 @@ persistent actor GovernanceCanister {
         };
 
         // Get proposal
-        let proposal = switch (proposals.get(proposalId)) {
+        let proposal = switch (proposals.get((daoId, proposalId))) {
             case (?p) p;
             case null return #err("Proposal not found");
         };
@@ -235,7 +247,8 @@ persistent actor GovernanceCanister {
         };
 
         // Verify voter registration
-        let profileOpt = await dao.getUserProfile(caller);
+        let daoActor : actor { getUserProfile: shared query (Principal) -> async ?Types.UserProfile } = actor(Principal.toText(daoId));
+        let profileOpt = await daoActor.getUserProfile(caller);
         switch (profileOpt) {
             case null return #err("User not registered");
             case (?_) {};
@@ -250,6 +263,7 @@ persistent actor GovernanceCanister {
 
         // Create vote record
         let vote : Vote = {
+            daoId = daoId;
             voter = caller;
             proposalId = proposalId;
             choice = choice;
@@ -264,6 +278,7 @@ persistent actor GovernanceCanister {
         let updatedProposal = switch (choice) {
             case (#inFavor) {
                 {
+                    daoId = proposal.daoId;
                     id = proposal.id;
                     proposer = proposal.proposer;
                     title = proposal.title;
@@ -282,6 +297,7 @@ persistent actor GovernanceCanister {
             };
             case (#against) {
                 {
+                    daoId = proposal.daoId;
                     id = proposal.id;
                     proposer = proposal.proposer;
                     title = proposal.title;
@@ -300,6 +316,7 @@ persistent actor GovernanceCanister {
             };
             case (#abstain) {
                 {
+                    daoId = proposal.daoId;
                     id = proposal.id;
                     proposer = proposal.proposer;
                     title = proposal.title;
@@ -318,13 +335,13 @@ persistent actor GovernanceCanister {
             };
         };
 
-        proposals.put(proposalId, updatedProposal);
+        proposals.put((daoId, proposalId), updatedProposal);
         #ok()
     };
 
     // Execute a proposal
-    public shared(_msg) func executeProposal(proposalId: ProposalId) : async Result<(), Text> {
-        let proposal = switch (proposals.get(proposalId)) {
+    public shared(_msg) func executeProposal(daoId: Principal, proposalId: ProposalId) : async Result<(), Text> {
+        let proposal = switch (proposals.get((daoId, proposalId))) {
             case (?p) p;
             case null return #err("Proposal not found");
         };
@@ -341,6 +358,7 @@ persistent actor GovernanceCanister {
         // Check quorum
         if (proposal.totalVotingPower < proposal.quorumThreshold) {
             let failedProposal = {
+                daoId = proposal.daoId;
                 id = proposal.id;
                 proposer = proposal.proposer;
                 title = proposal.title;
@@ -356,7 +374,7 @@ persistent actor GovernanceCanister {
                 quorumThreshold = proposal.quorumThreshold;
                 approvalThreshold = proposal.approvalThreshold;
             };
-            proposals.put(proposalId, failedProposal);
+            proposals.put((daoId, proposalId), failedProposal);
             return #err("Quorum not met");
         };
 
@@ -372,6 +390,7 @@ persistent actor GovernanceCanister {
         };
 
         let updatedProposal = {
+            daoId = proposal.daoId;
             id = proposal.id;
             proposer = proposal.proposer;
             title = proposal.title;
@@ -387,12 +406,13 @@ persistent actor GovernanceCanister {
             quorumThreshold = proposal.quorumThreshold;
             approvalThreshold = proposal.approvalThreshold;
         };
-        proposals.put(proposalId, updatedProposal);
+        proposals.put((daoId, proposalId), updatedProposal);
 
         if (newStatus == #succeeded) {
             // Here you would implement the actual execution logic
             // For now, we just mark it as executed
             let executedProposal = {
+                daoId = updatedProposal.daoId;
                 id = updatedProposal.id;
                 proposer = updatedProposal.proposer;
                 title = updatedProposal.title;
@@ -408,7 +428,7 @@ persistent actor GovernanceCanister {
                 quorumThreshold = updatedProposal.quorumThreshold;
                 approvalThreshold = updatedProposal.approvalThreshold;
             };
-            proposals.put(proposalId, executedProposal);
+            proposals.put((daoId, proposalId), executedProposal);
         };
 
         #ok()
@@ -417,31 +437,37 @@ persistent actor GovernanceCanister {
     // Query functions
 
     // Get proposal by ID
-    public query func getProposal(proposalId: ProposalId) : async ?Proposal {
-        proposals.get(proposalId)
+    public query func getProposal(daoId: Principal, proposalId: ProposalId) : async ?Proposal {
+        proposals.get((daoId, proposalId))
     };
 
-    // Get all proposals
-    public query func getAllProposals() : async [Proposal] {
-        Iter.toArray(proposals.vals())
+    // Get all proposals for a DAO
+    public query func getAllProposals(daoId: Principal) : async [Proposal] {
+        let buffer = Buffer.Buffer<Proposal>(0);
+        for (proposal in proposals.vals()) {
+            if (proposal.daoId == daoId) {
+                buffer.add(proposal);
+            };
+        };
+        Buffer.toArray(buffer)
     };
 
-    // Get active proposals
-    public query func getActiveProposals() : async [Proposal] {
+    // Get active proposals for a DAO
+    public query func getActiveProposals(daoId: Principal) : async [Proposal] {
         let activeProposals = Buffer.Buffer<Proposal>(0);
         for (proposal in proposals.vals()) {
-            if (proposal.status == #active and Time.now() <= proposal.votingDeadline) {
+            if (proposal.daoId == daoId and proposal.status == #active and Time.now() <= proposal.votingDeadline) {
                 activeProposals.add(proposal);
             };
         };
         Buffer.toArray(activeProposals)
     };
 
-    // Get proposals by status
-    public query func getProposalsByStatus(status: Types.ProposalStatus) : async [Proposal] {
+    // Get proposals by status for a DAO
+    public query func getProposalsByStatus(daoId: Principal, status: Types.ProposalStatus) : async [Proposal] {
         let filteredProposals = Buffer.Buffer<Proposal>(0);
         for (proposal in proposals.vals()) {
-            if (proposal.status == status) {
+            if (proposal.daoId == daoId and proposal.status == status) {
                 filteredProposals.add(proposal);
             };
         };
@@ -449,47 +475,46 @@ persistent actor GovernanceCanister {
     };
 
     // Get user's vote on a proposal
-    public query func getUserVote(proposalId: ProposalId, user: Principal) : async ?Vote {
-        let voteKey = Nat.toText(proposalId) # "_" # Principal.toText(user);
-        votes.get(voteKey)
+    public query func getUserVote(daoId: Principal, proposalId: ProposalId, user: Principal) : async ?Vote {
+        votes.get((daoId, proposalId, user))
     };
 
     // Get all votes for a proposal
-    public query func getProposalVotes(proposalId: ProposalId) : async [Vote] {
+    public query func getProposalVotes(daoId: Principal, proposalId: ProposalId) : async [Vote] {
         let proposalVotes = Buffer.Buffer<Vote>(0);
         for (vote in votes.vals()) {
-            if (vote.proposalId == proposalId) {
+            if (vote.daoId == daoId and vote.proposalId == proposalId) {
                 proposalVotes.add(vote);
             };
         };
         Buffer.toArray(proposalVotes)
     };
 
-    // Get governance configuration
-    public query func getConfig() : async ?GovernanceConfig {
-        config.get("default")
+    // Get governance configuration for a DAO
+    public query func getConfig(daoId: Principal) : async ?GovernanceConfig {
+        config.get(daoId)
     };
 
     // Update governance configuration (admin only)
-    public shared(_msg) func updateConfig(newConfig: GovernanceConfig) : async Result<(), Text> {
+    public shared(_msg) func updateConfig(daoId: Principal, newConfig: GovernanceConfig) : async Result<(), Text> {
         // In a real implementation, you'd check if the caller is an admin
-        config.put("default", newConfig);
+        config.put(daoId, newConfig);
         #ok()
     };
 
     // Helper functions
-    private func getActiveProposalsByUser(user: Principal) : [Proposal] {
+    private func getActiveProposalsByUser(daoId: Principal, user: Principal) : [Proposal] {
         let userProposals = Buffer.Buffer<Proposal>(0);
         for (proposal in proposals.vals()) {
-            if (proposal.proposer == user and proposal.status == #active) {
+            if (proposal.daoId == daoId and proposal.proposer == user and proposal.status == #active) {
                 userProposals.add(proposal);
             };
         };
         Buffer.toArray(userProposals)
     };
 
-    // Get governance statistics
-    public query func getGovernanceStats() : async {
+    // Get governance statistics for a DAO
+    public query func getGovernanceStats(daoId: Principal) : async {
         totalProposals: Nat;
         activeProposals: Nat;
         succeededProposals: Nat;
@@ -499,23 +524,34 @@ persistent actor GovernanceCanister {
         var activeCount = 0;
         var succeededCount = 0;
         var failedCount = 0;
+        var totalCount = 0;
+        var voteCount = 0;
 
         for (proposal in proposals.vals()) {
-            switch (proposal.status) {
-                case (#active) activeCount += 1;
-                case (#succeeded) succeededCount += 1;
-                case (#executed) succeededCount += 1;
-                case (#failed) failedCount += 1;
-                case (_) {};
+            if (proposal.daoId == daoId) {
+                totalCount += 1;
+                switch (proposal.status) {
+                    case (#active) activeCount += 1;
+                    case (#succeeded) succeededCount += 1;
+                    case (#executed) succeededCount += 1;
+                    case (#failed) failedCount += 1;
+                    case (_) {};
+                };
+            };
+        };
+
+        for (vote in votes.vals()) {
+            if (vote.daoId == daoId) {
+                voteCount += 1;
             };
         };
 
         {
-            totalProposals = proposals.size();
+            totalProposals = totalCount;
             activeProposals = activeCount;
             succeededProposals = succeededCount;
             failedProposals = failedCount;
-            totalVotes = votes.size();
+            totalVotes = voteCount;
         }
     };
 }

--- a/src/dao_backend/shared/types.mo
+++ b/src/dao_backend/shared/types.mo
@@ -97,6 +97,7 @@ module {
     };
 
     public type Proposal = {
+        daoId: Principal;
         id: ProposalId;
         proposer: Principal;
         title: Text;
@@ -115,8 +116,9 @@ module {
 
     // Voting types
     public type VoteChoice = { #inFavor; #against; #abstain };
-    
+
     public type Vote = {
+        daoId: Principal;
         voter: Principal;
         proposalId: ProposalId;
         choice: VoteChoice;

--- a/src/dao_frontend/src/declarations/governance/governance.did
+++ b/src/dao_frontend/src/declarations/governance/governance.did
@@ -4,8 +4,9 @@ type VoteChoice =
    against;
    inFavor;
  };
-type Vote = 
+type Vote =
  record {
+   daoId: Principal;
    choice: VoteChoice;
    proposalId: ProposalId;
    reason: opt text;
@@ -48,8 +49,9 @@ type ProposalStatus =
    succeeded;
  };
 type ProposalId = nat;
-type Proposal = 
+type Proposal =
  record {
+   daoId: Principal;
    approvalThreshold: nat;
    createdAt: Time;
    description: text;
@@ -90,13 +92,13 @@ type GovernanceConfig =
    votingPeriod: nat;
  };
 service : {
-  createProposal: (title: text, description: text, proposalType:
+  createProposal: (daoId: principal, title: text, description: text, proposalType:
    ProposalType, votingPeriod: opt nat) -> (Result_1);
-  executeProposal: (proposalId: ProposalId) -> (Result);
-  getActiveProposals: () -> (vec Proposal) query;
-  getAllProposals: () -> (vec Proposal) query;
-  getConfig: () -> (opt GovernanceConfig) query;
-  getGovernanceStats: () ->
+  executeProposal: (daoId: principal, proposalId: ProposalId) -> (Result);
+  getActiveProposals: (daoId: principal) -> (vec Proposal) query;
+  getAllProposals: (daoId: principal) -> (vec Proposal) query;
+  getConfig: (daoId: principal) -> (opt GovernanceConfig) query;
+  getGovernanceStats: (daoId: principal) ->
    (record {
       activeProposals: nat;
       failedProposals: nat;
@@ -104,12 +106,12 @@ service : {
       totalProposals: nat;
       totalVotes: nat;
     }) query;
-  getProposal: (proposalId: ProposalId) -> (opt Proposal) query;
-  getProposalVotes: (proposalId: ProposalId) -> (vec Vote) query;
-  getProposalsByStatus: (status: ProposalStatus) -> (vec Proposal) query;
-  getUserVote: (proposalId: ProposalId, user: principal) -> (opt Vote) query;
+  getProposal: (daoId: principal, proposalId: ProposalId) -> (opt Proposal) query;
+  getProposalVotes: (daoId: principal, proposalId: ProposalId) -> (vec Vote) query;
+  getProposalsByStatus: (daoId: principal, status: ProposalStatus) -> (vec Proposal) query;
+  getUserVote: (daoId: principal, proposalId: ProposalId, user: principal) -> (opt Vote) query;
   init: (newDaoId: principal, newStakingId: principal) -> ();
-  updateConfig: (newConfig: GovernanceConfig) -> (Result);
-  vote: (proposalId: ProposalId, choice: VoteChoice, reason: opt text) ->
+  updateConfig: (daoId: principal, newConfig: GovernanceConfig) -> (Result);
+  vote: (daoId: principal, proposalId: ProposalId, choice: VoteChoice, reason: opt text) ->
    (Result);
 }

--- a/src/dao_frontend/src/declarations/governance/governance.did.d.ts
+++ b/src/dao_frontend/src/declarations/governance/governance.did.d.ts
@@ -22,6 +22,7 @@ export interface ParameterChangeProposal {
 }
 export type Principal = Principal;
 export interface Proposal {
+  'daoId' : Principal,
   'id' : ProposalId,
   'status' : ProposalStatus,
   'title' : string,
@@ -60,6 +61,7 @@ export interface TreasuryTransferProposal {
   'reason' : string,
 }
 export interface Vote {
+  'daoId' : Principal,
   'votingPower' : bigint,
   'voter' : Principal,
   'timestamp' : Time,
@@ -72,15 +74,15 @@ export type VoteChoice = { 'against' : null } |
   { 'inFavor' : null };
 export interface _SERVICE {
   'createProposal' : ActorMethod<
-    [string, string, ProposalType, [] | [bigint]],
+    [Principal, string, string, ProposalType, [] | [bigint]],
     Result_1
   >,
-  'executeProposal' : ActorMethod<[ProposalId], Result>,
-  'getActiveProposals' : ActorMethod<[], Array<Proposal>>,
-  'getAllProposals' : ActorMethod<[], Array<Proposal>>,
-  'getConfig' : ActorMethod<[], [] | [GovernanceConfig]>,
+  'executeProposal' : ActorMethod<[Principal, ProposalId], Result>,
+  'getActiveProposals' : ActorMethod<[Principal], Array<Proposal>>,
+  'getAllProposals' : ActorMethod<[Principal], Array<Proposal>>,
+  'getConfig' : ActorMethod<[Principal], [] | [GovernanceConfig]>,
   'getGovernanceStats' : ActorMethod<
-    [],
+    [Principal],
     {
       'succeededProposals' : bigint,
       'totalVotes' : bigint,
@@ -89,13 +91,13 @@ export interface _SERVICE {
       'activeProposals' : bigint,
     }
   >,
-  'getProposal' : ActorMethod<[ProposalId], [] | [Proposal]>,
-  'getProposalVotes' : ActorMethod<[ProposalId], Array<Vote>>,
-  'getProposalsByStatus' : ActorMethod<[ProposalStatus], Array<Proposal>>,
-  'getUserVote' : ActorMethod<[ProposalId, Principal], [] | [Vote]>,
+  'getProposal' : ActorMethod<[Principal, ProposalId], [] | [Proposal]>,
+  'getProposalVotes' : ActorMethod<[Principal, ProposalId], Array<Vote>>,
+  'getProposalsByStatus' : ActorMethod<[Principal, ProposalStatus], Array<Proposal>>,
+  'getUserVote' : ActorMethod<[Principal, ProposalId, Principal], [] | [Vote]>,
   'init' : ActorMethod<[Principal, Principal], undefined>,
-  'updateConfig' : ActorMethod<[GovernanceConfig], Result>,
-  'vote' : ActorMethod<[ProposalId, VoteChoice, [] | [string]], Result>,
+  'updateConfig' : ActorMethod<[Principal, GovernanceConfig], Result>,
+  'vote' : ActorMethod<[Principal, ProposalId, VoteChoice, [] | [string]], Result>,
 }
 export declare const idlFactory: IDL.InterfaceFactory;
 export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/src/dao_frontend/src/declarations/governance/governance.did.js
+++ b/src/dao_frontend/src/declarations/governance/governance.did.js
@@ -35,6 +35,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const Time = IDL.Int;
   const Proposal = IDL.Record({
+    'daoId' : Principal,
     'id' : ProposalId,
     'status' : ProposalStatus,
     'title' : IDL.Text,
@@ -63,6 +64,7 @@ export const idlFactory = ({ IDL }) => {
     'inFavor' : IDL.Null,
   });
   const Vote = IDL.Record({
+    'daoId' : Principal,
     'votingPower' : IDL.Nat,
     'voter' : Principal,
     'timestamp' : Time,
@@ -72,16 +74,16 @@ export const idlFactory = ({ IDL }) => {
   });
   return IDL.Service({
     'createProposal' : IDL.Func(
-        [IDL.Text, IDL.Text, ProposalType, IDL.Opt(IDL.Nat)],
+        [Principal, IDL.Text, IDL.Text, ProposalType, IDL.Opt(IDL.Nat)],
         [Result_1],
         [],
       ),
-    'executeProposal' : IDL.Func([ProposalId], [Result], []),
-    'getActiveProposals' : IDL.Func([], [IDL.Vec(Proposal)], ['query']),
-    'getAllProposals' : IDL.Func([], [IDL.Vec(Proposal)], ['query']),
-    'getConfig' : IDL.Func([], [IDL.Opt(GovernanceConfig)], ['query']),
+    'executeProposal' : IDL.Func([Principal, ProposalId], [Result], []),
+    'getActiveProposals' : IDL.Func([Principal], [IDL.Vec(Proposal)], ['query']),
+    'getAllProposals' : IDL.Func([Principal], [IDL.Vec(Proposal)], ['query']),
+    'getConfig' : IDL.Func([Principal], [IDL.Opt(GovernanceConfig)], ['query']),
     'getGovernanceStats' : IDL.Func(
-        [],
+        [Principal],
         [
           IDL.Record({
             'succeededProposals' : IDL.Nat,
@@ -93,22 +95,22 @@ export const idlFactory = ({ IDL }) => {
         ],
         ['query'],
       ),
-    'getProposal' : IDL.Func([ProposalId], [IDL.Opt(Proposal)], ['query']),
-    'getProposalVotes' : IDL.Func([ProposalId], [IDL.Vec(Vote)], ['query']),
+    'getProposal' : IDL.Func([Principal, ProposalId], [IDL.Opt(Proposal)], ['query']),
+    'getProposalVotes' : IDL.Func([Principal, ProposalId], [IDL.Vec(Vote)], ['query']),
     'getProposalsByStatus' : IDL.Func(
-        [ProposalStatus],
+        [Principal, ProposalStatus],
         [IDL.Vec(Proposal)],
         ['query'],
       ),
     'getUserVote' : IDL.Func(
-        [ProposalId, IDL.Principal],
+        [Principal, ProposalId, IDL.Principal],
         [IDL.Opt(Vote)],
         ['query'],
       ),
     'init' : IDL.Func([IDL.Principal, IDL.Principal], [], []),
-    'updateConfig' : IDL.Func([GovernanceConfig], [Result], []),
+    'updateConfig' : IDL.Func([Principal, GovernanceConfig], [Result], []),
     'vote' : IDL.Func(
-        [ProposalId, VoteChoice, IDL.Opt(IDL.Text)],
+        [Principal, ProposalId, VoteChoice, IDL.Opt(IDL.Text)],
         [Result],
         [],
       ),


### PR DESCRIPTION
## Summary
- add `daoId` to `Proposal` and `Vote` records
- key governance storage by `(daoId, proposalId)` and require `daoId` across APIs
- scope configuration and stats retrieval to specific DAOs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1bc71ee888320ba3ab1d20b55a8c7