### PR TITLE
feat: add DAO-scoped treasury balances

### DIFF
--- a/src/dao_backend/shared/types.mo
+++ b/src/dao_backend/shared/types.mo
@@ -164,6 +164,7 @@ module {
 
     public type TreasuryTransaction = {
         id: Nat;
+        daoId: Principal;
         transactionType: TreasuryTransactionType;
         amount: TokenAmount;
         from: ?Principal;

--- a/src/dao_backend/treasury/main.mo
+++ b/src/dao_backend/treasury/main.mo
@@ -46,16 +46,14 @@ persistent actor TreasuryCanister {
 
     // Stable storage for upgrade persistence
     // Core financial data that must survive canister upgrades
-    private var totalBalance : TokenAmount = 0;
-    private var availableBalance : TokenAmount = 0;
-    private var lockedBalance : TokenAmount = 0;       // Funds locked for specific purposes
-    private var reservedBalance : TokenAmount = 0;     // Emergency reserves
+    private var balancesEntries : [(Principal, TreasuryBalance)] = [];
     private var nextTransactionId : Nat = 1;
     private var transactionsEntries : [(Nat, TreasuryTransaction)] = [];
     private var allowancesEntries : [(Principal, TokenAmount)] = [];
 
     // Runtime storage - rebuilt from stable storage after upgrades
     // HashMaps provide efficient transaction and allowance management
+    private transient var balances = HashMap.HashMap<Principal, TreasuryBalance>(10, Principal.equal, Principal.hash);
     private transient var transactions = HashMap.HashMap<Nat, TreasuryTransaction>(100, Nat.equal, func(n: Nat) : Nat32 { Nat32.fromNat(n) });
     private transient var allowances = HashMap.HashMap<Principal, TokenAmount>(10, Principal.equal, Principal.hash);
 
@@ -65,21 +63,28 @@ persistent actor TreasuryCanister {
 
     // System functions for upgrades
     system func preupgrade() {
+        balancesEntries := Iter.toArray(balances.entries());
         transactionsEntries := Iter.toArray(transactions.entries());
         allowancesEntries := Iter.toArray(allowances.entries());
     };
 
     system func postupgrade() {
+        balances := HashMap.fromIter<Principal, TreasuryBalance>(
+            balancesEntries.vals(),
+            balancesEntries.size(),
+            Principal.equal,
+            Principal.hash
+        );
         transactions := HashMap.fromIter<Nat, TreasuryTransaction>(
-            transactionsEntries.vals(), 
-            transactionsEntries.size(), 
-            Nat.equal, 
+            transactionsEntries.vals(),
+            transactionsEntries.size(),
+            Nat.equal,
             func(n: Nat) : Nat32 { Nat32.fromNat(n) }
         );
         allowances := HashMap.fromIter<Principal, TokenAmount>(
-            allowancesEntries.vals(), 
-            allowancesEntries.size(), 
-            Principal.equal, 
+            allowancesEntries.vals(),
+            allowancesEntries.size(),
+            Principal.equal,
             Principal.hash
         );
     };
@@ -87,7 +92,7 @@ persistent actor TreasuryCanister {
     // Public functions
 
     // Deposit tokens to treasury
-    public shared(msg) func deposit(amount: TokenAmount, description: Text) : async Result<Nat, Text> {
+    public shared(msg) func deposit(daoId: Principal, amount: TokenAmount, description: Text) : async Result<Nat, Text> {
         if (amount == 0) {
             return #err("Amount must be greater than 0");
         };
@@ -97,6 +102,7 @@ persistent actor TreasuryCanister {
 
         let transaction : TreasuryTransaction = {
             id = transactionId;
+            daoId = daoId;
             transactionType = #deposit;
             amount = amount;
             from = ?msg.caller;
@@ -108,16 +114,17 @@ persistent actor TreasuryCanister {
         };
 
         transactions.put(transactionId, transaction);
-        
+
         // Update balances
-        totalBalance += amount;
-        availableBalance += amount;
+        let bal = getBalanceInternal(daoId);
+        balances.put(daoId, { bal with total = bal.total + amount; available = bal.available + amount });
 
         #ok(transactionId)
     };
 
     // Withdraw tokens from treasury (requires authorization)
     public shared(msg) func withdraw(
+        daoId: Principal,
         recipient: Principal,
         amount: TokenAmount,
         description: Text,
@@ -131,7 +138,8 @@ persistent actor TreasuryCanister {
         };
 
         // Check available balance
-        if (amount > availableBalance) {
+        let bal = getBalanceInternal(daoId);
+        if (amount > bal.available) {
             return #err("Insufficient available balance");
         };
 
@@ -140,6 +148,7 @@ persistent actor TreasuryCanister {
 
         let transaction : TreasuryTransaction = {
             id = transactionId;
+            daoId = daoId;
             transactionType = #withdrawal;
             amount = amount;
             from = null;
@@ -156,8 +165,7 @@ persistent actor TreasuryCanister {
         switch (await executeWithdrawal(transactionId)) {
             case (#ok(_)) {
                 // Update balances
-                totalBalance -= amount;
-                availableBalance -= amount;
+                balances.put(daoId, { bal with total = bal.total - amount; available = bal.available - amount });
                 
                 let completedTransaction = {
                     id = transaction.id;
@@ -193,23 +201,24 @@ persistent actor TreasuryCanister {
     };
 
     // Lock tokens for specific purposes (e.g., staking rewards)
-    public shared(msg) func lockTokens(amount: TokenAmount, reason: Text) : async Result<(), Text> {
+    public shared(msg) func lockTokens(daoId: Principal, amount: TokenAmount, reason: Text) : async Result<(), Text> {
         if (not isAuthorized(msg.caller)) {
             return #err("Not authorized");
         };
 
-        if (amount > availableBalance) {
+        let bal = getBalanceInternal(daoId);
+        if (amount > bal.available) {
             return #err("Insufficient available balance");
         };
 
-        availableBalance -= amount;
-        lockedBalance += amount;
+        balances.put(daoId, { bal with available = bal.available - amount; locked = bal.locked + amount });
 
         let transactionId = nextTransactionId;
         nextTransactionId += 1;
 
         let transaction : TreasuryTransaction = {
             id = transactionId;
+            daoId = daoId;
             transactionType = #stakingReward;
             amount = amount;
             from = null;
@@ -225,23 +234,24 @@ persistent actor TreasuryCanister {
     };
 
     // Unlock tokens
-    public shared(msg) func unlockTokens(amount: TokenAmount, reason: Text) : async Result<(), Text> {
+    public shared(msg) func unlockTokens(daoId: Principal, amount: TokenAmount, reason: Text) : async Result<(), Text> {
         if (not isAuthorized(msg.caller)) {
             return #err("Not authorized");
         };
 
-        if (amount > lockedBalance) {
+        let bal = getBalanceInternal(daoId);
+        if (amount > bal.locked) {
             return #err("Insufficient locked balance");
         };
 
-        lockedBalance -= amount;
-        availableBalance += amount;
+        balances.put(daoId, { bal with locked = bal.locked - amount; available = bal.available + amount });
 
         let transactionId = nextTransactionId;
         nextTransactionId += 1;
 
         let transaction : TreasuryTransaction = {
             id = transactionId;
+            daoId = daoId;
             transactionType = #stakingReward;
             amount = amount;
             from = null;
@@ -257,23 +267,24 @@ persistent actor TreasuryCanister {
     };
 
     // Reserve tokens for future use
-    public shared(msg) func reserveTokens(amount: TokenAmount, reason: Text) : async Result<(), Text> {
+    public shared(msg) func reserveTokens(daoId: Principal, amount: TokenAmount, reason: Text) : async Result<(), Text> {
         if (not isAuthorized(msg.caller)) {
             return #err("Not authorized");
         };
 
-        if (amount > availableBalance) {
+        let bal = getBalanceInternal(daoId);
+        if (amount > bal.available) {
             return #err("Insufficient available balance");
         };
 
-        availableBalance -= amount;
-        reservedBalance += amount;
+        balances.put(daoId, { bal with available = bal.available - amount; reserved = bal.reserved + amount });
 
         let transactionId = nextTransactionId;
         nextTransactionId += 1;
 
         let transaction : TreasuryTransaction = {
             id = transactionId;
+            daoId = daoId;
             transactionType = #fee;
             amount = amount;
             from = null;
@@ -289,23 +300,24 @@ persistent actor TreasuryCanister {
     };
 
     // Release reserved tokens
-    public shared(msg) func releaseReservedTokens(amount: TokenAmount, reason: Text) : async Result<(), Text> {
+    public shared(msg) func releaseReservedTokens(daoId: Principal, amount: TokenAmount, reason: Text) : async Result<(), Text> {
         if (not isAuthorized(msg.caller)) {
             return #err("Not authorized");
         };
 
-        if (amount > reservedBalance) {
+        let bal = getBalanceInternal(daoId);
+        if (amount > bal.reserved) {
             return #err("Insufficient reserved balance");
         };
 
-        reservedBalance -= amount;
-        availableBalance += amount;
+        balances.put(daoId, { bal with reserved = bal.reserved - amount; available = bal.available + amount });
 
         let transactionId = nextTransactionId;
         nextTransactionId += 1;
 
         let transaction : TreasuryTransaction = {
             id = transactionId;
+            daoId = daoId;
             transactionType = #fee;
             amount = amount;
             from = null;
@@ -323,30 +335,44 @@ persistent actor TreasuryCanister {
     // Query functions
 
     // Get treasury balance
-    public query func getBalance() : async TreasuryBalance {
-        {
-            total = totalBalance;
-            available = availableBalance;
-            locked = lockedBalance;
-            reserved = reservedBalance;
+    public query func getBalance(daoId: Principal) : async TreasuryBalance {
+        switch (balances.get(daoId)) {
+            case (?bal) { bal };
+            case null {
+                {
+                    total = 0;
+                    available = 0;
+                    locked = 0;
+                    reserved = 0;
+                }
+            };
         }
     };
 
     // Get transaction by ID
-    public query func getTransaction(transactionId: Nat) : async ?TreasuryTransaction {
-        transactions.get(transactionId)
+    public query func getTransaction(transactionId: Nat, daoId: Principal) : async ?TreasuryTransaction {
+        switch (transactions.get(transactionId)) {
+            case (?tx) { if (tx.daoId == daoId) ?tx else null };
+            case null { null };
+        }
     };
 
     // Get all transactions
-    public query func getAllTransactions() : async [TreasuryTransaction] {
-        Iter.toArray(transactions.vals())
+    public query func getAllTransactions(daoId: Principal) : async [TreasuryTransaction] {
+        let filteredTransactions = Buffer.Buffer<TreasuryTransaction>(0);
+        for (transaction in transactions.vals()) {
+            if (transaction.daoId == daoId) {
+                filteredTransactions.add(transaction);
+            };
+        };
+        Buffer.toArray(filteredTransactions)
     };
 
     // Get transactions by type
-    public query func getTransactionsByType(transactionType: Types.TreasuryTransactionType) : async [TreasuryTransaction] {
+    public query func getTransactionsByType(daoId: Principal, transactionType: Types.TreasuryTransactionType) : async [TreasuryTransaction] {
         let filteredTransactions = Buffer.Buffer<TreasuryTransaction>(0);
         for (transaction in transactions.vals()) {
-            if (transaction.transactionType == transactionType) {
+            if (transaction.daoId == daoId and transaction.transactionType == transactionType) {
                 filteredTransactions.add(transaction);
             };
         };
@@ -354,14 +380,20 @@ persistent actor TreasuryCanister {
     };
 
     // Get recent transactions
-    public query func getRecentTransactions(limit: Nat) : async [TreasuryTransaction] {
-        let allTransactions = Iter.toArray(transactions.vals());
+    public query func getRecentTransactions(daoId: Principal, limit: Nat) : async [TreasuryTransaction] {
+        let buffer = Buffer.Buffer<TreasuryTransaction>(0);
+        for (transaction in transactions.vals()) {
+            if (transaction.daoId == daoId) {
+                buffer.add(transaction);
+            };
+        };
+        let allTransactions = Buffer.toArray(buffer);
         let sortedTransactions = Array.sort(allTransactions, func(a: TreasuryTransaction, b: TreasuryTransaction) : {#less; #equal; #greater} {
             if (a.timestamp > b.timestamp) #less
             else if (a.timestamp < b.timestamp) #greater
             else #equal
         });
-        
+
         if (sortedTransactions.size() <= limit) {
             sortedTransactions
         } else {
@@ -370,7 +402,7 @@ persistent actor TreasuryCanister {
     };
 
     // Get treasury statistics
-    public query func getTreasuryStats() : async {
+    public query func getTreasuryStats(daoId: Principal) : async {
         totalTransactions: Nat;
         totalDeposits: TokenAmount;
         totalWithdrawals: TokenAmount;
@@ -380,38 +412,44 @@ persistent actor TreasuryCanister {
         var totalDeposits : TokenAmount = 0;
         var totalWithdrawals : TokenAmount = 0;
         var totalAmount : TokenAmount = 0;
+        var txCount : Nat = 0;
 
         for (transaction in transactions.vals()) {
-            switch (transaction.transactionType) {
-                case (#deposit) {
-                    totalDeposits += transaction.amount;
-                    totalAmount += transaction.amount;
-                };
-                case (#withdrawal) {
-                    totalWithdrawals += transaction.amount;
-                    totalAmount += transaction.amount;
-                };
-                case (_) {
-                    totalAmount += transaction.amount;
+            if (transaction.daoId == daoId) {
+                txCount += 1;
+                switch (transaction.transactionType) {
+                    case (#deposit) {
+                        totalDeposits += transaction.amount;
+                        totalAmount += transaction.amount;
+                    };
+                    case (#withdrawal) {
+                        totalWithdrawals += transaction.amount;
+                        totalAmount += transaction.amount;
+                    };
+                    case (_) {
+                        totalAmount += transaction.amount;
+                    };
                 };
             };
         };
 
-        let averageAmount = if (transactions.size() > 0) {
-            Float.fromInt(totalAmount) / Float.fromInt(transactions.size())
+        let averageAmount = if (txCount > 0) {
+            Float.fromInt(totalAmount) / Float.fromInt(txCount)
         } else { 0.0 };
 
+        let bal = switch (balances.get(daoId)) {
+            case (?b) b;
+            case null {
+                { total = 0; available = 0; locked = 0; reserved = 0 };
+            };
+        };
+
         {
-            totalTransactions = transactions.size();
+            totalTransactions = txCount;
             totalDeposits = totalDeposits;
             totalWithdrawals = totalWithdrawals;
             averageTransactionAmount = averageAmount;
-            balance = {
-                total = totalBalance;
-                available = availableBalance;
-                locked = lockedBalance;
-                reserved = reservedBalance;
-            };
+            balance = bal;
         }
     };
 
@@ -439,6 +477,22 @@ persistent actor TreasuryCanister {
     };
 
     // Helper functions
+    private func getBalanceInternal(daoId: Principal) : TreasuryBalance {
+        switch (balances.get(daoId)) {
+            case (?bal) { bal };
+            case null {
+                let b : TreasuryBalance = {
+                    total = 0;
+                    available = 0;
+                    locked = 0;
+                    reserved = 0;
+                };
+                balances.put(daoId, b);
+                b
+            };
+        }
+    };
+
     private func isAuthorized(principal: Principal) : Bool {
         Array.find<Principal>(authorizedPrincipals, func(p) = p == principal) != null
     };

--- a/src/dao_frontend/src/components/Treasury.jsx
+++ b/src/dao_frontend/src/components/Treasury.jsx
@@ -34,14 +34,16 @@ const Treasury = () => {
   const [balance, setBalance] = useState(null);
   const [transactions, setTransactions] = useState([]);
   const [stats, setStats] = useState(null);
+  const [daoId, setDaoId] = useState('');
 
   const fetchData = async () => {
+    if (!daoId) return;
     try {
-      const bal = await getBalance();
+      const bal = await getBalance(daoId);
       setBalance(bal);
-      const txs = await getRecentTransactions(5);
+      const txs = await getRecentTransactions(daoId, 5);
       setTransactions(txs);
-      const s = await getTreasuryStats();
+      const s = await getTreasuryStats(daoId);
       setStats(s);
     } catch (e) {
       // error handled in hook
@@ -50,12 +52,12 @@ const Treasury = () => {
 
   useEffect(() => {
     fetchData();
-  }, []);
+  }, [daoId]);
 
   const handleDeposit = async (e) => {
     e.preventDefault();
     try {
-      const txId = await deposit(depositAmount, depositDesc);
+      const txId = await deposit(daoId, depositAmount, depositDesc);
       console.log('Deposit transaction:', txId);
       setDepositAmount('');
       setDepositDesc('');
@@ -68,7 +70,7 @@ const Treasury = () => {
   const handleWithdraw = async (e) => {
     e.preventDefault();
     try {
-      const txId = await withdraw(recipient, withdrawAmount, withdrawDesc);
+      const txId = await withdraw(daoId, recipient, withdrawAmount, withdrawDesc);
       console.log('Withdraw transaction:', txId);
       setRecipient('');
       setWithdrawAmount('');
@@ -81,7 +83,7 @@ const Treasury = () => {
 
   const handleLock = async (e) => {
     e.preventDefault();
-    await lockTokens(lockAmount, lockReason);
+    await lockTokens(daoId, lockAmount, lockReason);
     setLockAmount('');
     setLockReason('');
     await fetchData();
@@ -89,7 +91,7 @@ const Treasury = () => {
 
   const handleUnlock = async (e) => {
     e.preventDefault();
-    await unlockTokens(unlockAmount, unlockReason);
+    await unlockTokens(daoId, unlockAmount, unlockReason);
     setUnlockAmount('');
     setUnlockReason('');
     await fetchData();
@@ -97,7 +99,7 @@ const Treasury = () => {
 
   const handleReserve = async (e) => {
     e.preventDefault();
-    await reserveTokens(reserveAmount, reserveReason);
+    await reserveTokens(daoId, reserveAmount, reserveReason);
     setReserveAmount('');
     setReserveReason('');
     await fetchData();
@@ -105,7 +107,7 @@ const Treasury = () => {
 
   const handleRelease = async (e) => {
     e.preventDefault();
-    await releaseReservedTokens(releaseAmount, releaseReason);
+    await releaseReservedTokens(daoId, releaseAmount, releaseReason);
     setReleaseAmount('');
     setReleaseReason('');
     await fetchData();
@@ -113,7 +115,7 @@ const Treasury = () => {
 
   const handleFilter = async (e) => {
     e.preventDefault();
-    const txs = await getTransactionsByType(filterType);
+    const txs = await getTransactionsByType(daoId, filterType);
     setFilteredTransactions(txs);
   };
 
@@ -121,6 +123,12 @@ const Treasury = () => {
     <div className="p-4 space-y-8">
       <h1 className="text-2xl font-bold">Treasury</h1>
       {error && <p className="text-red-500">{error}</p>}
+      <input
+        className="border p-2 w-full"
+        placeholder="DAO Principal ID"
+        value={daoId}
+        onChange={(e) => setDaoId(e.target.value)}
+      />
 
       {balance && (
         <div className="space-y-1">

--- a/src/dao_frontend/src/components/management/ManagementTreasury.tsx
+++ b/src/dao_frontend/src/components/management/ManagementTreasury.tsx
@@ -77,11 +77,11 @@ const ManagementTreasury: React.FC = () => {
 
   const fetchData = async () => {
     try {
-      const bal = await getBalance();
+      const bal = await getBalance(dao.id);
       setBalance(bal);
-      const s = await getTreasuryStats();
+      const s = await getTreasuryStats(dao.id);
       setStats(s);
-      const txs = await getAllTransactions();
+      const txs = await getAllTransactions(dao.id);
       const formatted = txs.map((tx: any) => {
         const isInflow =
           'deposit' in tx.transactionType || 'stakingReward' in tx.transactionType;
@@ -104,14 +104,14 @@ const ManagementTreasury: React.FC = () => {
 
   useEffect(() => {
     fetchData();
-  }, []);
+  }, [dao.id]);
 
   const handleDeposit = async () => {
     const amount = prompt('Enter deposit amount');
     if (!amount) return;
     const description = prompt('Enter description') || '';
     try {
-      await deposit(amount, description);
+      await deposit(dao.id, amount, description);
       await fetchData();
     } catch (e) {
       console.error(e);
@@ -124,7 +124,7 @@ const ManagementTreasury: React.FC = () => {
     if (!recipient || !amount) return;
     const description = prompt('Enter description') || '';
     try {
-      await withdraw(recipient, amount, description);
+      await withdraw(dao.id, recipient, amount, description);
       await fetchData();
     } catch (e) {
       console.error(e);

--- a/src/dao_frontend/src/declarations/treasury/treasury.did
+++ b/src/dao_frontend/src/declarations/treasury/treasury.did
@@ -6,21 +6,22 @@ type TreasuryTransactionType =
    stakingReward;
    withdrawal;
  };
-type TreasuryTransaction = 
+type TreasuryTransaction =
  record {
-   amount: TokenAmount;
-   description: text;
-   from: opt Principal;
    id: nat;
+   daoId: Principal;
+   transactionType: TreasuryTransactionType;
+   amount: TokenAmount;
+   from: opt Principal;
+   to: opt Principal;
+   timestamp: Time;
    proposalId: opt ProposalId;
+   description: text;
    status: variant {
              completed;
              failed;
              pending;
            };
-   timestamp: Time;
-   to: opt Principal;
-   transactionType: TreasuryTransactionType;
  };
 type TreasuryBalance = 
  record {
@@ -45,15 +46,15 @@ type ProposalId = nat;
 type Principal = principal;
 service : {
   addAuthorizedPrincipal: ("principal": principal) -> (Result_1);
-  deposit: (amount: TokenAmount, description: text) -> (Result);
-  getAllTransactions: () -> (vec TreasuryTransaction) query;
+  deposit: (daoId: Principal, amount: TokenAmount, description: text) -> (Result);
+  getAllTransactions: (daoId: Principal) -> (vec TreasuryTransaction) query;
   getAuthorizedPrincipals: () -> (vec principal) query;
-  getBalance: () -> (TreasuryBalance) query;
-  getRecentTransactions: (limit: nat) -> (vec TreasuryTransaction) query;
-  getTransaction: (transactionId: nat) -> (opt TreasuryTransaction) query;
-  getTransactionsByType: (transactionType: TreasuryTransactionType) ->
+  getBalance: (daoId: Principal) -> (TreasuryBalance) query;
+  getRecentTransactions: (daoId: Principal, limit: nat) -> (vec TreasuryTransaction) query;
+  getTransaction: (transactionId: nat, daoId: Principal) -> (opt TreasuryTransaction) query;
+  getTransactionsByType: (daoId: Principal, transactionType: TreasuryTransactionType) ->
    (vec TreasuryTransaction) query;
-  getTreasuryStats: () ->
+  getTreasuryStats: (daoId: Principal) ->
    (record {
       averageTransactionAmount: float64;
       balance: TreasuryBalance;
@@ -61,11 +62,11 @@ service : {
       totalTransactions: nat;
       totalWithdrawals: TokenAmount;
     }) query;
-  lockTokens: (amount: TokenAmount, reason: text) -> (Result_1);
-  releaseReservedTokens: (amount: TokenAmount, reason: text) -> (Result_1);
+  lockTokens: (daoId: Principal, amount: TokenAmount, reason: text) -> (Result_1);
+  releaseReservedTokens: (daoId: Principal, amount: TokenAmount, reason: text) -> (Result_1);
   removeAuthorizedPrincipal: ("principal": principal) -> (Result_1);
-  reserveTokens: (amount: TokenAmount, reason: text) -> (Result_1);
-  unlockTokens: (amount: TokenAmount, reason: text) -> (Result_1);
-  withdraw: (recipient: principal, amount: TokenAmount, description: 
+  reserveTokens: (daoId: Principal, amount: TokenAmount, reason: text) -> (Result_1);
+  unlockTokens: (daoId: Principal, amount: TokenAmount, reason: text) -> (Result_1);
+  withdraw: (daoId: Principal, recipient: principal, amount: TokenAmount, description:
    text, proposalId: opt ProposalId) -> (Result);
 }

--- a/src/dao_frontend/src/declarations/treasury/treasury.did.d.ts
+++ b/src/dao_frontend/src/declarations/treasury/treasury.did.d.ts
@@ -18,16 +18,17 @@ export interface TreasuryBalance {
 }
 export interface TreasuryTransaction {
   'id' : bigint,
+  'daoId' : Principal,
+  'transactionType' : TreasuryTransactionType,
+  'amount' : TokenAmount,
+  'from' : [] | [Principal],
   'to' : [] | [Principal],
+  'timestamp' : Time,
+  'proposalId' : [] | [ProposalId],
+  'description' : string,
   'status' : { 'pending' : null } |
     { 'completed' : null } |
     { 'failed' : null },
-  'transactionType' : TreasuryTransactionType,
-  'from' : [] | [Principal],
-  'description' : string,
-  'timestamp' : Time,
-  'amount' : TokenAmount,
-  'proposalId' : [] | [ProposalId],
 }
 export type TreasuryTransactionType = { 'fee' : null } |
   { 'deposit' : null } |
@@ -36,18 +37,18 @@ export type TreasuryTransactionType = { 'fee' : null } |
   { 'proposalExecution' : null };
 export interface _SERVICE {
   'addAuthorizedPrincipal' : ActorMethod<[Principal], Result_1>,
-  'deposit' : ActorMethod<[TokenAmount, string], Result>,
-  'getAllTransactions' : ActorMethod<[], Array<TreasuryTransaction>>,
+  'deposit' : ActorMethod<[Principal, TokenAmount, string], Result>,
+  'getAllTransactions' : ActorMethod<[Principal], Array<TreasuryTransaction>>,
   'getAuthorizedPrincipals' : ActorMethod<[], Array<Principal>>,
-  'getBalance' : ActorMethod<[], TreasuryBalance>,
-  'getRecentTransactions' : ActorMethod<[bigint], Array<TreasuryTransaction>>,
-  'getTransaction' : ActorMethod<[bigint], [] | [TreasuryTransaction]>,
+  'getBalance' : ActorMethod<[Principal], TreasuryBalance>,
+  'getRecentTransactions' : ActorMethod<[Principal, bigint], Array<TreasuryTransaction>>,
+  'getTransaction' : ActorMethod<[bigint, Principal], [] | [TreasuryTransaction]>,
   'getTransactionsByType' : ActorMethod<
-    [TreasuryTransactionType],
+    [Principal, TreasuryTransactionType],
     Array<TreasuryTransaction>
   >,
   'getTreasuryStats' : ActorMethod<
-    [],
+    [Principal],
     {
       'balance' : TreasuryBalance,
       'totalWithdrawals' : TokenAmount,
@@ -56,13 +57,13 @@ export interface _SERVICE {
       'totalTransactions' : bigint,
     }
   >,
-  'lockTokens' : ActorMethod<[TokenAmount, string], Result_1>,
-  'releaseReservedTokens' : ActorMethod<[TokenAmount, string], Result_1>,
+  'lockTokens' : ActorMethod<[Principal, TokenAmount, string], Result_1>,
+  'releaseReservedTokens' : ActorMethod<[Principal, TokenAmount, string], Result_1>,
   'removeAuthorizedPrincipal' : ActorMethod<[Principal], Result_1>,
-  'reserveTokens' : ActorMethod<[TokenAmount, string], Result_1>,
-  'unlockTokens' : ActorMethod<[TokenAmount, string], Result_1>,
+  'reserveTokens' : ActorMethod<[Principal, TokenAmount, string], Result_1>,
+  'unlockTokens' : ActorMethod<[Principal, TokenAmount, string], Result_1>,
   'withdraw' : ActorMethod<
-    [Principal, TokenAmount, string, [] | [ProposalId]],
+    [Principal, Principal, TokenAmount, string, [] | [ProposalId]],
     Result
   >,
 }

--- a/src/dao_frontend/src/declarations/treasury/treasury.did.js
+++ b/src/dao_frontend/src/declarations/treasury/treasury.did.js
@@ -14,18 +14,19 @@ export const idlFactory = ({ IDL }) => {
   const ProposalId = IDL.Nat;
   const TreasuryTransaction = IDL.Record({
     'id' : IDL.Nat,
+    'daoId' : Principal,
+    'transactionType' : TreasuryTransactionType,
+    'amount' : TokenAmount,
+    'from' : IDL.Opt(Principal),
     'to' : IDL.Opt(Principal),
+    'timestamp' : Time,
+    'proposalId' : IDL.Opt(ProposalId),
+    'description' : IDL.Text,
     'status' : IDL.Variant({
       'pending' : IDL.Null,
       'completed' : IDL.Null,
       'failed' : IDL.Null,
     }),
-    'transactionType' : TreasuryTransactionType,
-    'from' : IDL.Opt(Principal),
-    'description' : IDL.Text,
-    'timestamp' : Time,
-    'amount' : TokenAmount,
-    'proposalId' : IDL.Opt(ProposalId),
   });
   const TreasuryBalance = IDL.Record({
     'total' : TokenAmount,
@@ -35,9 +36,9 @@ export const idlFactory = ({ IDL }) => {
   });
   return IDL.Service({
     'addAuthorizedPrincipal' : IDL.Func([IDL.Principal], [Result_1], []),
-    'deposit' : IDL.Func([TokenAmount, IDL.Text], [Result], []),
+    'deposit' : IDL.Func([Principal, TokenAmount, IDL.Text], [Result], []),
     'getAllTransactions' : IDL.Func(
-        [],
+        [Principal],
         [IDL.Vec(TreasuryTransaction)],
         ['query'],
       ),
@@ -46,24 +47,24 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Vec(IDL.Principal)],
         ['query'],
       ),
-    'getBalance' : IDL.Func([], [TreasuryBalance], ['query']),
+    'getBalance' : IDL.Func([Principal], [TreasuryBalance], ['query']),
     'getRecentTransactions' : IDL.Func(
-        [IDL.Nat],
+        [Principal, IDL.Nat],
         [IDL.Vec(TreasuryTransaction)],
         ['query'],
       ),
     'getTransaction' : IDL.Func(
-        [IDL.Nat],
+        [IDL.Nat, Principal],
         [IDL.Opt(TreasuryTransaction)],
         ['query'],
       ),
     'getTransactionsByType' : IDL.Func(
-        [TreasuryTransactionType],
+        [Principal, TreasuryTransactionType],
         [IDL.Vec(TreasuryTransaction)],
         ['query'],
       ),
     'getTreasuryStats' : IDL.Func(
-        [],
+        [Principal],
         [
           IDL.Record({
             'balance' : TreasuryBalance,
@@ -75,13 +76,13 @@ export const idlFactory = ({ IDL }) => {
         ],
         ['query'],
       ),
-    'lockTokens' : IDL.Func([TokenAmount, IDL.Text], [Result_1], []),
-    'releaseReservedTokens' : IDL.Func([TokenAmount, IDL.Text], [Result_1], []),
+    'lockTokens' : IDL.Func([Principal, TokenAmount, IDL.Text], [Result_1], []),
+    'releaseReservedTokens' : IDL.Func([Principal, TokenAmount, IDL.Text], [Result_1], []),
     'removeAuthorizedPrincipal' : IDL.Func([IDL.Principal], [Result_1], []),
-    'reserveTokens' : IDL.Func([TokenAmount, IDL.Text], [Result_1], []),
-    'unlockTokens' : IDL.Func([TokenAmount, IDL.Text], [Result_1], []),
+    'reserveTokens' : IDL.Func([Principal, TokenAmount, IDL.Text], [Result_1], []),
+    'unlockTokens' : IDL.Func([Principal, TokenAmount, IDL.Text], [Result_1], []),
     'withdraw' : IDL.Func(
-        [IDL.Principal, TokenAmount, IDL.Text, IDL.Opt(ProposalId)],
+        [Principal, IDL.Principal, TokenAmount, IDL.Text, IDL.Opt(ProposalId)],
         [Result],
         [],
       ),

--- a/src/dao_frontend/src/hooks/useTreasury.js
+++ b/src/dao_frontend/src/hooks/useTreasury.js
@@ -7,11 +7,16 @@ export const useTreasury = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
-  const deposit = async (amount, description) => {
+  const deposit = async (daoId, amount, description) => {
     setLoading(true);
     setError(null);
     try {
-      const res = await actors.treasury.deposit(BigInt(amount), description);
+      const daoPrincipal = Principal.fromText(daoId);
+      const res = await actors.treasury.deposit(
+        daoPrincipal,
+        BigInt(amount),
+        description
+      );
       if ('err' in res) throw new Error(res.err);
       return res.ok;
     } catch (err) {
@@ -22,12 +27,14 @@ export const useTreasury = () => {
     }
   };
 
-  const withdraw = async (recipient, amount, description) => {
+  const withdraw = async (daoId, recipient, amount, description) => {
     setLoading(true);
     setError(null);
     try {
       const principal = Principal.fromText(recipient);
+      const daoPrincipal = Principal.fromText(daoId);
       const res = await actors.treasury.withdraw(
+        daoPrincipal,
         principal,
         BigInt(amount),
         description,
@@ -43,11 +50,13 @@ export const useTreasury = () => {
     }
   };
 
-  const lockTokens = async (amount, reason) => {
+  const lockTokens = async (daoId, amount, reason) => {
     setLoading(true);
     setError(null);
     try {
+      const daoPrincipal = Principal.fromText(daoId);
       const result = await actors.treasury.lockTokens(
+        daoPrincipal,
         BigInt(amount),
         reason
       );
@@ -60,11 +69,13 @@ export const useTreasury = () => {
     }
   };
 
-  const unlockTokens = async (amount, reason) => {
+  const unlockTokens = async (daoId, amount, reason) => {
     setLoading(true);
     setError(null);
     try {
+      const daoPrincipal = Principal.fromText(daoId);
       const result = await actors.treasury.unlockTokens(
+        daoPrincipal,
         BigInt(amount),
         reason
       );
@@ -77,11 +88,13 @@ export const useTreasury = () => {
     }
   };
 
-  const reserveTokens = async (amount, reason) => {
+  const reserveTokens = async (daoId, amount, reason) => {
     setLoading(true);
     setError(null);
     try {
+      const daoPrincipal = Principal.fromText(daoId);
       const result = await actors.treasury.reserveTokens(
+        daoPrincipal,
         BigInt(amount),
         reason
       );
@@ -94,11 +107,13 @@ export const useTreasury = () => {
     }
   };
 
-  const releaseReservedTokens = async (amount, reason) => {
+  const releaseReservedTokens = async (daoId, amount, reason) => {
     setLoading(true);
     setError(null);
     try {
+      const daoPrincipal = Principal.fromText(daoId);
       const result = await actors.treasury.releaseReservedTokens(
+        daoPrincipal,
         BigInt(amount),
         reason
       );
@@ -111,11 +126,12 @@ export const useTreasury = () => {
     }
   };
 
-  const getBalance = async () => {
+  const getBalance = async (daoId) => {
     setLoading(true);
     setError(null);
     try {
-      const res = await actors.treasury.getBalance();
+      const daoPrincipal = Principal.fromText(daoId);
+      const res = await actors.treasury.getBalance(daoPrincipal);
       if ('err' in res) throw new Error(res.err);
       return 'ok' in res ? res.ok : res;
     } catch (err) {
@@ -126,11 +142,12 @@ export const useTreasury = () => {
     }
   };
 
-  const getAllTransactions = async () => {
+  const getAllTransactions = async (daoId) => {
     setLoading(true);
     setError(null);
     try {
-      const txs = await actors.treasury.getAllTransactions();
+      const daoPrincipal = Principal.fromText(daoId);
+      const txs = await actors.treasury.getAllTransactions(daoPrincipal);
       return txs;
     } catch (err) {
       setError(err.message);
@@ -140,11 +157,12 @@ export const useTreasury = () => {
     }
   };
 
-  const getTransactionsByType = async (type) => {
+  const getTransactionsByType = async (daoId, type) => {
     setLoading(true);
     setError(null);
     try {
-      const txs = await actors.treasury.getTransactionsByType({
+      const daoPrincipal = Principal.fromText(daoId);
+      const txs = await actors.treasury.getTransactionsByType(daoPrincipal, {
         [type]: null,
       });
       return txs;
@@ -156,11 +174,15 @@ export const useTreasury = () => {
     }
   };
 
-  const getRecentTransactions = async (limit) => {
+  const getRecentTransactions = async (daoId, limit) => {
     setLoading(true);
     setError(null);
     try {
-      const txs = await actors.treasury.getRecentTransactions(BigInt(limit));
+      const daoPrincipal = Principal.fromText(daoId);
+      const txs = await actors.treasury.getRecentTransactions(
+        daoPrincipal,
+        BigInt(limit)
+      );
       return txs;
     } catch (err) {
       setError(err.message);
@@ -170,11 +192,12 @@ export const useTreasury = () => {
     }
   };
 
-  const getTreasuryStats = async () => {
+  const getTreasuryStats = async (daoId) => {
     setLoading(true);
     setError(null);
     try {
-      const stats = await actors.treasury.getTreasuryStats();
+      const daoPrincipal = Principal.fromText(daoId);
+      const stats = await actors.treasury.getTreasuryStats(daoPrincipal);
       return stats;
     } catch (err) {
       setError(err.message);


### PR DESCRIPTION
## Summary
- track treasury balances per DAO using `HashMap<Principal, TreasuryBalance>`
- require `daoId` for deposit/withdraw/lock/reserve operations and queries
- update frontend hooks and declarations to work with DAO-scoped APIs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1bc73ac9483209554b93b64eba908