### PR TITLE
Refactor backend for multi-DAO support

### DIFF
--- a/src/dao_backend/governance/main.mo
+++ b/src/dao_backend/governance/main.mo
@@ -45,8 +45,8 @@ persistent actor GovernanceCanister {
     // Inter-canister communication setup
     // These actor references enable cross-canister calls for governance functionality
     var dao : actor {
-        getUserProfile: shared query (Principal) -> async ?Types.UserProfile;
-        checkIsAdmin: shared query (Principal) -> async Bool;
+        getUserProfile: shared query (Types.DAOId, Principal) -> async ?Types.UserProfile;
+        checkIsAdmin: shared query (Types.DAOId, Principal) -> async Bool;
     } = actor("aaaaa-aa");
 
     var staking : actor {
@@ -66,6 +66,7 @@ persistent actor GovernanceCanister {
     private var configEntries : [(Text, GovernanceConfig)] = [];
     private var daoId : Principal = Principal.fromText("aaaaa-aa");
     private var stakingId : Principal = Principal.fromText("aaaaa-aa");
+    private var daoInstance : Types.DAOId = "";
     private var initialized : Bool = false;
 
     // Runtime storage - rebuilt from stable storage after upgrades
@@ -74,7 +75,7 @@ persistent actor GovernanceCanister {
     private transient var votes = HashMap.HashMap<Text, Vote>(100, Text.equal, Text.hash);
     private transient var config = HashMap.HashMap<Text, GovernanceConfig>(1, Text.equal, Text.hash);
 
-    public shared(msg) func init(newDaoId: Principal, newStakingId: Principal) : async () {
+    public shared(msg) func init(newDaoId: Principal, newStakingId: Principal, daoInstanceId: Types.DAOId) : async () {
         if (initialized) {
             Debug.print("Initialization already completed");
             throw Error.reject("Governance canister already initialized");
@@ -84,10 +85,10 @@ persistent actor GovernanceCanister {
         let caller = msg.caller;
         let self = Principal.fromActor(GovernanceCanister);
         let daoTemp : actor {
-            getUserProfile: shared query (Principal) -> async ?Types.UserProfile;
-            checkIsAdmin: shared query (Principal) -> async Bool;
+            getUserProfile: shared query (Types.DAOId, Principal) -> async ?Types.UserProfile;
+            checkIsAdmin: shared query (Types.DAOId, Principal) -> async Bool;
         } = actor(Principal.toText(newDaoId));
-        let isAdmin = await daoTemp.checkIsAdmin(caller);
+        let isAdmin = await daoTemp.checkIsAdmin(daoInstanceId, caller);
         if (caller != self and not isAdmin) {
             Debug.print("Unauthorized init attempt by " # Principal.toText(caller));
             throw Error.reject("Caller is not authorized to initialize");
@@ -95,6 +96,7 @@ persistent actor GovernanceCanister {
 
         daoId := newDaoId;
         stakingId := newStakingId;
+        daoInstance := daoInstanceId;
         dao := daoTemp;
         staking := actor(Principal.toText(newStakingId));
         initialized := true;
@@ -235,7 +237,7 @@ persistent actor GovernanceCanister {
         };
 
         // Verify voter registration
-        let profileOpt = await dao.getUserProfile(caller);
+        let profileOpt = await dao.getUserProfile(daoInstance, caller);
         switch (profileOpt) {
             case null return #err("User not registered");
             case (?_) {};

--- a/src/dao_backend/governance/main.test.mo
+++ b/src/dao_backend/governance/main.test.mo
@@ -8,8 +8,8 @@ actor {
         let admin = Principal.fromActor(this);
 
         let daoStub = actor {
-            public shared query func getUserProfile(_: Principal) -> async ?Types.UserProfile { null };
-            public query func checkIsAdmin(p: Principal) : async Bool { p == admin };
+            public shared query func getUserProfile(_: Types.DAOId, _: Principal) -> async ?Types.UserProfile { null };
+            public query func checkIsAdmin(_: Types.DAOId, p: Principal) : async Bool { p == admin };
         };
         let stakingStub = actor {
             public shared query func getUserStakingSummary(_: Principal) -> async {
@@ -22,12 +22,12 @@ actor {
             };
         };
 
-        await Governance.init(Principal.fromActor(daoStub), Principal.fromActor(stakingStub));
+        await Governance.init(Principal.fromActor(daoStub), Principal.fromActor(stakingStub), "default");
 
         let malicious = actor {
             public func attemptReinit() : async Bool {
                 try {
-                    await Governance.init(Principal.fromActor(daoStub), Principal.fromActor(stakingStub));
+                    await Governance.init(Principal.fromActor(daoStub), Principal.fromActor(stakingStub), "default");
                     false
                 } catch (_) {
                     true

--- a/src/dao_backend/main.mo
+++ b/src/dao_backend/main.mo
@@ -6,6 +6,7 @@ import Principal "mo:base/Principal";
 import Debug "mo:base/Debug";
 import Nat "mo:base/Nat";
 import Text "mo:base/Text";
+import Array "mo:base/Array";
 
 import Types "shared/types";
 
@@ -35,28 +36,41 @@ persistent actor DAOMain {
     type DAOStats = Types.DAOStats;
     type DAOConfig = Types.DAOConfig;
     type Activity = Types.Activity;
+    type DAOId = Types.DAOId;
 
-    // Stable storage for upgrades - persists across canister upgrades
-    // These variables maintain their state when the canister is upgraded
-    private var initialized : Bool = false;
-    private var daoName : Text = "DAO Launcher";
-    private var daoDescription : Text = "A decentralized autonomous organization for community governance";
-    private var totalMembers : Nat = 0;
-    private var userProfilesEntries : [(Principal, UserProfile)] = [];
-    private var adminPrincipalsEntries : [Principal] = [];
-    private var daoConfig : ?DAOConfig = null;
+    // Stable storage for upgrades - persisted per DAO
+    private type DAOStable = {
+        initialized: Bool;
+        name: Text;
+        description: Text;
+        totalMembers: Nat;
+        userProfilesEntries: [(Principal, UserProfile)];
+        adminPrincipalsEntries: [Principal];
+        daoConfig: ?DAOConfig;
+        governanceCanister: ?Principal;
+        stakingCanister: ?Principal;
+        treasuryCanister: ?Principal;
+        proposalsCanister: ?Principal;
+    };
+
+    private var daoStatesEntries : [(DAOId, DAOStable)] = [];
 
     // Runtime storage - recreated after upgrades from stable storage
-    // These HashMaps provide efficient O(1) lookup for user data and admin permissions
-    private transient var userProfiles = HashMap.HashMap<Principal, UserProfile>(100, Principal.equal, Principal.hash);
-    private transient var adminPrincipals = HashMap.HashMap<Principal, Bool>(10, Principal.equal, Principal.hash);
+    private type DAOState = {
+        var initialized: Bool;
+        var daoName: Text;
+        var daoDescription: Text;
+        var totalMembers: Nat;
+        var userProfiles: HashMap.HashMap<Principal, UserProfile>;
+        var adminPrincipals: HashMap.HashMap<Principal, Bool>;
+        var daoConfig: ?DAOConfig;
+        var governanceCanister: ?Principal;
+        var stakingCanister: ?Principal;
+        var treasuryCanister: ?Principal;
+        var proposalsCanister: ?Principal;
+    };
 
-    // Canister references for modular architecture
-    // These maintain connections to other specialized canisters in the DAO ecosystem
-    private transient var governanceCanister : ?Principal = null;
-    private transient var stakingCanister : ?Principal = null;
-    private transient var treasuryCanister : ?Principal = null;
-    private transient var proposalsCanister : ?Principal = null;
+    private transient var daoStates = HashMap.HashMap<DAOId, DAOState>(10, Text.equal, Text.hash);
 
     // System functions for upgrades
     /**
@@ -64,8 +78,27 @@ persistent actor DAOMain {
      * Called automatically before canister upgrade to preserve data
      */
     system func preupgrade() {
-        userProfilesEntries := Iter.toArray(userProfiles.entries());
-        adminPrincipalsEntries := Iter.toArray(adminPrincipals.keys());
+        daoStatesEntries := Iter.toArray(
+            Iter.map<(DAOId, DAOState),(DAOId, DAOStable)>(
+                daoStates.entries(),
+                func (entry: (DAOId, DAOState)) : (DAOId, DAOStable) {
+                    let (id, state) = entry;
+                    (id, {
+                        initialized = state.initialized;
+                        name = state.daoName;
+                        description = state.daoDescription;
+                        totalMembers = state.totalMembers;
+                        userProfilesEntries = Iter.toArray(state.userProfiles.entries());
+                        adminPrincipalsEntries = Iter.toArray(state.adminPrincipals.keys());
+                        daoConfig = state.daoConfig;
+                        governanceCanister = state.governanceCanister;
+                        stakingCanister = state.stakingCanister;
+                        treasuryCanister = state.treasuryCanister;
+                        proposalsCanister = state.proposalsCanister;
+                    })
+                }
+            )
+        );
     };
 
     /**
@@ -73,52 +106,89 @@ persistent actor DAOMain {
      * Called automatically after canister upgrade to restore functionality
      */
     system func postupgrade() {
-        userProfiles := HashMap.fromIter<Principal, UserProfile>(
-            userProfilesEntries.vals(), 
-            userProfilesEntries.size(), 
-            Principal.equal, 
-            Principal.hash
-        );
-        
-        // Restore admin permissions from stable storage
-        for (admin in adminPrincipalsEntries.vals()) {
-            adminPrincipals.put(admin, true);
+        daoStates := HashMap.HashMap<DAOId, DAOState>(daoStatesEntries.size(), Text.equal, Text.hash);
+        for ((id, stableState) in daoStatesEntries.vals()) {
+            let userMap = HashMap.fromIter<Principal, UserProfile>(
+                stableState.userProfilesEntries.vals(),
+                stableState.userProfilesEntries.size(),
+                Principal.equal,
+                Principal.hash
+            );
+            let adminMap = HashMap.HashMap<Principal, Bool>(stableState.adminPrincipalsEntries.size(), Principal.equal, Principal.hash);
+            for (admin in stableState.adminPrincipalsEntries.vals()) {
+                adminMap.put(admin, true);
+            };
+            daoStates.put(id, {
+                initialized = stableState.initialized;
+                daoName = stableState.name;
+                daoDescription = stableState.description;
+                totalMembers = stableState.totalMembers;
+                userProfiles = userMap;
+                adminPrincipals = adminMap;
+                daoConfig = stableState.daoConfig;
+                governanceCanister = stableState.governanceCanister;
+                stakingCanister = stableState.stakingCanister;
+                treasuryCanister = stableState.treasuryCanister;
+                proposalsCanister = stableState.proposalsCanister;
+            });
         };
+    };
+
+    private func ensureDAO(daoId: DAOId) : DAOState {
+        switch (daoStates.get(daoId)) {
+            case (?state) state;
+            case null {
+                let newState : DAOState = {
+                    initialized = false;
+                    daoName = "";
+                    daoDescription = "";
+                    totalMembers = 0;
+                    userProfiles = HashMap.HashMap<Principal, UserProfile>(100, Principal.equal, Principal.hash);
+                    adminPrincipals = HashMap.HashMap<Principal, Bool>(10, Principal.equal, Principal.hash);
+                    daoConfig = null;
+                    governanceCanister = null;
+                    stakingCanister = null;
+                    treasuryCanister = null;
+                    proposalsCanister = null;
+                };
+                daoStates.put(daoId, newState);
+                newState
+            };
+        }
     };
 
     /**
      * Initialize the DAO with basic configuration
-     * 
+     *
      * This is the first function called when setting up a new DAO.
      * It establishes the foundational parameters and admin structure.
-     * 
+     *
+     * @param daoId - Unique identifier for the DAO
      * @param name - Human-readable name for the DAO
      * @param description - Brief description of the DAO's purpose
      * @param initialAdmins - Array of Principal IDs who will have admin privileges
      * @returns Result indicating success or failure with error message
      */
     public shared(msg) func initialize(
+        daoId: DAOId,
         name: Text,
         description: Text,
         initialAdmins: [Principal]
     ) : async Result<(), Text> {
-        // Prevent double initialization
-        if (initialized) {
+        let state = ensureDAO(daoId);
+        if (state.initialized) {
             return #err("DAO already initialized");
         };
 
-        daoName := name;
-        daoDescription := description;
-        
-        // Set initial admins - these users can manage DAO configuration
+        state.daoName := name;
+        state.daoDescription := description;
+
         for (admin in initialAdmins.vals()) {
-            adminPrincipals.put(admin, true);
+            state.adminPrincipals.put(admin, true);
         };
+        state.adminPrincipals.put(msg.caller, true);
 
-        // Always add the deployer as an admin for initial setup
-        adminPrincipals.put(msg.caller, true);
-
-        initialized := true;
+        state.initialized := true;
         Debug.print("DAO initialized: " # name);
         #ok()
     };
@@ -136,40 +206,43 @@ persistent actor DAOMain {
      * @returns Result indicating success or failure
      */
     public shared(msg) func setCanisterReferences(
+        daoId: DAOId,
         governance: Principal,
         staking: Principal,
         treasury: Principal,
         proposals: Principal
     ) : async Result<(), Text> {
-        // Only admins can modify the canister architecture
-        if (not isAdmin(msg.caller)) {
+        if (not isAdmin(daoId, msg.caller)) {
             return #err("Only admins can set canister references");
         };
 
-        governanceCanister := ?governance;
-        stakingCanister := ?staking;
-        treasuryCanister := ?treasury;
-        proposalsCanister := ?proposals;
+        let state = ensureDAO(daoId);
+        state.governanceCanister := ?governance;
+        state.stakingCanister := ?staking;
+        state.treasuryCanister := ?treasury;
+        state.proposalsCanister := ?proposals;
 
         Debug.print("Canister references set successfully");
         #ok()
     };
 
     // DAO configuration
-    public shared(msg) func setDAOConfig(config: DAOConfig) : async Result<(), Text> {
-        if (not isAdmin(msg.caller)) {
+    public shared(msg) func setDAOConfig(daoId: DAOId, config: DAOConfig) : async Result<(), Text> {
+        if (not isAdmin(daoId, msg.caller)) {
             return #err("Only admins can set DAO configuration");
         };
-        daoConfig := ?config;
+        let state = ensureDAO(daoId);
+        state.daoConfig := ?config;
         Debug.print("DAO configuration saved");
         #ok()
     };
 
     // User management
-    public shared(msg) func registerUser(displayName: Text, bio: Text) : async Result<(), Text> {
+    public shared(msg) func registerUser(daoId: DAOId, displayName: Text, bio: Text) : async Result<(), Text> {
         let caller = msg.caller;
-        
-        switch (userProfiles.get(caller)) {
+        let state = ensureDAO(daoId);
+
+        switch (state.userProfiles.get(caller)) {
             case (?_) return #err("User already registered");
             case null {};
         };
@@ -184,19 +257,21 @@ persistent actor DAOMain {
             votingPower = 0;
         };
 
-        userProfiles.put(caller, userProfile);
-        totalMembers += 1;
+        state.userProfiles.put(caller, userProfile);
+        state.totalMembers += 1;
 
         Debug.print("User registered: " # displayName);
         #ok()
     };
 
-    public shared(msg) func adminRegisterUser(newUser: Principal, displayName: Text, bio: Text) : async Result<(), Text> {
-        if (not isAdmin(msg.caller)) {
+    public shared(msg) func adminRegisterUser(daoId: DAOId, newUser: Principal, displayName: Text, bio: Text) : async Result<(), Text> {
+        if (not isAdmin(daoId, msg.caller)) {
             return #err("Only admins can register users");
         };
 
-        switch (userProfiles.get(newUser)) {
+        let state = ensureDAO(daoId);
+
+        switch (state.userProfiles.get(newUser)) {
             case (?_) return #err("User already registered");
             case null {};
         };
@@ -211,17 +286,18 @@ persistent actor DAOMain {
             votingPower = 0;
         };
 
-        userProfiles.put(newUser, userProfile);
-        totalMembers += 1;
+        state.userProfiles.put(newUser, userProfile);
+        state.totalMembers += 1;
 
         Debug.print("User registered by admin: " # displayName);
         #ok()
     };
 
-    public shared(msg) func updateUserProfile(displayName: Text, bio: Text) : async Result<(), Text> {
+    public shared(msg) func updateUserProfile(daoId: DAOId, displayName: Text, bio: Text) : async Result<(), Text> {
         let caller = msg.caller;
-        
-        switch (userProfiles.get(caller)) {
+        let state = ensureDAO(daoId);
+
+        switch (state.userProfiles.get(caller)) {
             case null return #err("User not found");
             case (?profile) {
                 let updatedProfile = {
@@ -233,61 +309,108 @@ persistent actor DAOMain {
                     totalStaked = profile.totalStaked;
                     votingPower = profile.votingPower;
                 };
-                userProfiles.put(caller, updatedProfile);
+                state.userProfiles.put(caller, updatedProfile);
                 #ok()
             };
         };
     };
 
     // Query functions
-    public query func getDAOInfo() : async {
+    public query func getDAOInfo(daoId: DAOId) : async {
         name: Text;
         description: Text;
         totalMembers: Nat;
         initialized: Bool;
     } {
-        {
-            name = daoName;
-            description = daoDescription;
-            totalMembers = totalMembers;
-            initialized = initialized;
+        switch (daoStates.get(daoId)) {
+            case (?state) {
+                {
+                    name = state.daoName;
+                    description = state.daoDescription;
+                    totalMembers = state.totalMembers;
+                    initialized = state.initialized;
+                }
+            };
+            case null {
+                {
+                    name = "";
+                    description = "";
+                    totalMembers = 0;
+                    initialized = false;
+                }
+            }
         }
     };
 
-    public query func getDAOConfig() : async ?DAOConfig {
-        daoConfig
+    public query func getDAOConfig(daoId: DAOId) : async ?DAOConfig {
+        switch (daoStates.get(daoId)) {
+            case (?state) state.daoConfig;
+            case null null;
+        }
     };
 
-    public query func getUserProfile(userId: Principal) : async ?UserProfile {
-        userProfiles.get(userId)
+    public query func getUserProfile(daoId: DAOId, userId: Principal) : async ?UserProfile {
+        switch (daoStates.get(daoId)) {
+            case (?state) state.userProfiles.get(userId);
+            case null null;
+        }
     };
 
-    public query func getAllUsers() : async [UserProfile] {
-        Iter.toArray(userProfiles.vals())
+    public query func getAllUsers(daoId: DAOId) : async [UserProfile] {
+        switch (daoStates.get(daoId)) {
+            case (?state) Iter.toArray(state.userProfiles.vals());
+            case null [];
+        }
     };
 
-    public query func getCanisterReferences() : async {
+    public query func getCanisterReferences(daoId: DAOId) : async {
         governance: ?Principal;
         staking: ?Principal;
         treasury: ?Principal;
         proposals: ?Principal;
     } {
-        {
-            governance = governanceCanister;
-            staking = stakingCanister;
-            treasury = treasuryCanister;
-            proposals = proposalsCanister;
+        switch (daoStates.get(daoId)) {
+            case (?state) {
+                {
+                    governance = state.governanceCanister;
+                    staking = state.stakingCanister;
+                    treasury = state.treasuryCanister;
+                    proposals = state.proposalsCanister;
+                }
+            };
+            case null {
+                {
+                    governance = null;
+                    staking = null;
+                    treasury = null;
+                    proposals = null;
+                }
+            }
         }
     };
 
-    public query func getDAOStats() : async DAOStats {
-        {
-            totalMembers = totalMembers;
-            totalProposals = 0; // Will be fetched from governance canister
-            activeProposals = 0; // Will be fetched from governance canister
-            totalStaked = 0; // Will be fetched from staking canister
-            treasuryBalance = 0; // Will be fetched from treasury canister
-            totalVotingPower = 0; // Will be calculated from staking data
+    public query func getDAOStats(daoId: DAOId) : async DAOStats {
+        switch (daoStates.get(daoId)) {
+            case (?state) {
+                {
+                    totalMembers = state.totalMembers;
+                    totalProposals = 0;
+                    activeProposals = 0;
+                    totalStaked = 0;
+                    treasuryBalance = 0;
+                    totalVotingPower = 0;
+                }
+            };
+            case null {
+                {
+                    totalMembers = 0;
+                    totalProposals = 0;
+                    activeProposals = 0;
+                    totalStaked = 0;
+                    treasuryBalance = 0;
+                    totalVotingPower = 0;
+                }
+            }
         }
     };
 
@@ -316,11 +439,12 @@ persistent actor DAOMain {
 
     // Temporary proposal creation (will delegate to proposals canister later)
     public shared(msg) func createProposal(
+        daoId: DAOId,
         title: Text,
         _description: Text,
         _proposalType: Text
     ) : async Result<Nat, Text> {
-        if (not isRegisteredUser(msg.caller)) {
+        if (not isRegisteredUser(daoId, msg.caller)) {
             return #err("Only registered users can create proposals");
         };
         
@@ -332,11 +456,12 @@ persistent actor DAOMain {
 
     // Temporary voting function (will delegate to proposals canister later)
     public shared(msg) func vote(
+        daoId: DAOId,
         proposalId: Nat,
         choice: Text,
         _reason: ?Text
     ) : async Result<(), Text> {
-        if (not isRegisteredUser(msg.caller)) {
+        if (not isRegisteredUser(daoId, msg.caller)) {
             return #err("Only registered users can vote");
         };
         
@@ -347,37 +472,48 @@ persistent actor DAOMain {
     };
 
     // Utility functions
-    private func isAdmin(principal: Principal) : Bool {
-        switch (adminPrincipals.get(principal)) {
-            case (?_) true;
+    private func isAdmin(daoId: DAOId, principal: Principal) : Bool {
+        switch (daoStates.get(daoId)) {
+            case (?state) {
+                switch (state.adminPrincipals.get(principal)) {
+                    case (?_) true;
+                    case null false;
+                }
+            };
             case null false;
         }
     };
 
-    private func isRegisteredUser(principal: Principal) : Bool {
-        switch (userProfiles.get(principal)) {
-            case (?_) true;
+    private func isRegisteredUser(daoId: DAOId, principal: Principal) : Bool {
+        switch (daoStates.get(daoId)) {
+            case (?state) {
+                switch (state.userProfiles.get(principal)) {
+                    case (?_) true;
+                    case null false;
+                }
+            };
             case null false;
         }
     };
 
-    public query func checkIsAdmin(principal: Principal) : async Bool {
-        isAdmin(principal)
+    public query func checkIsAdmin(daoId: DAOId, principal: Principal) : async Bool {
+        isAdmin(daoId, principal)
     };
 
     // Admin functions
-    public shared(msg) func addAdmin(newAdmin: Principal) : async Result<(), Text> {
-        if (not isAdmin(msg.caller)) {
+    public shared(msg) func addAdmin(daoId: DAOId, newAdmin: Principal) : async Result<(), Text> {
+        if (not isAdmin(daoId, msg.caller)) {
             return #err("Only admins can add other admins");
         };
 
-        adminPrincipals.put(newAdmin, true);
+        let state = ensureDAO(daoId);
+        state.adminPrincipals.put(newAdmin, true);
         Debug.print("New admin added: " # Principal.toText(newAdmin));
         #ok()
     };
 
-    public shared(msg) func removeAdmin(adminToRemove: Principal) : async Result<(), Text> {
-        if (not isAdmin(msg.caller)) {
+    public shared(msg) func removeAdmin(daoId: DAOId, adminToRemove: Principal) : async Result<(), Text> {
+        if (not isAdmin(daoId, msg.caller)) {
             return #err("Only admins can remove other admins");
         };
 
@@ -385,7 +521,8 @@ persistent actor DAOMain {
             return #err("Cannot remove yourself as admin");
         };
 
-        adminPrincipals.delete(adminToRemove);
+        let state = ensureDAO(daoId);
+        state.adminPrincipals.delete(adminToRemove);
         Debug.print("Admin removed: " # Principal.toText(adminToRemove));
         #ok()
     };
@@ -399,7 +536,11 @@ persistent actor DAOMain {
     };
 
     // Greet function (keeping for compatibility)
-    public query func greet(name : Text) : async Text {
+    public query func greet(daoId: DAOId, name : Text) : async Text {
+        let daoName = switch (daoStates.get(daoId)) {
+            case (?state) state.daoName;
+            case null "DAO";
+        };
         return "Hello, " # name # "! Welcome to " # daoName;
     };
 };

--- a/src/dao_backend/shared/types.mo
+++ b/src/dao_backend/shared/types.mo
@@ -10,6 +10,9 @@ module {
     public type Time = Time.Time;
     public type Principal = Principal.Principal;
 
+    // Identifier used for addressing individual DAOs
+    public type DAOId = Text;
+
     // User and Identity types
     public type UserId = Principal;
     

--- a/src/dao_frontend/src/declarations/dao_backend/dao_backend.did
+++ b/src/dao_frontend/src/declarations/dao_backend/dao_backend.did
@@ -63,69 +63,50 @@ record {
    website: text;
  };
 service : {
-  addAdmin: (newAdmin: principal) -> (Result);
-  adminRegisterUser: (newUser: principal, displayName: text, bio: text) ->
+  addAdmin: (daoId: text, newAdmin: principal) -> (Result);
+  adminRegisterUser: (daoId: text, newUser: principal, displayName: text, bio: text) ->
    (Result);
-  checkIsAdmin: ("principal": principal) -> (bool) query;
-  createProposal: (title: text, _description: text, _proposalType: text) ->
+  checkIsAdmin: (daoId: text, "principal": principal) -> (bool) query;
+  createProposal: (daoId: text, title: text, _description: text, _proposalType: text) ->
    (Result_1);
-  getAllUsers: () -> (vec UserProfile) query;
-  getCanisterReferences: () ->
+  getAllUsers: (daoId: text) -> (vec UserProfile) query;
+  getCanisterReferences: (daoId: text) ->
    (record {
       governance: opt principal;
       proposals: opt principal;
       staking: opt principal;
       treasury: opt principal;
     }) query;
-  getDAOConfig: () -> (opt DAOConfig) query;
-  getDAOInfo: () ->
+  getDAOConfig: (daoId: text) -> (opt DAOConfig) query;
+  getDAOInfo: (daoId: text) ->
    (record {
       description: text;
       initialized: bool;
       name: text;
       totalMembers: nat;
     }) query;
-  getDAOStats: () -> (DAOStats) query;
-  getRecentActivity: () -> (vec Activity) query;
-  getGovernanceStats: () ->
+  getDAOStats: (daoId: text) -> (DAOStats) query;
+  getRecentActivity: (daoId: text) -> (vec Activity) query;
+  getGovernanceStats: (daoId: text) ->
    (record {
       activeProposals: nat;
       passedProposals: nat;
       totalProposals: nat;
       totalVotingPower: nat;
     });
-  getUserProfile: (userId: principal) -> (opt UserProfile) query;
-  greet: (name: text) -> (text) query;
+  getUserProfile: (daoId: text, userId: principal) -> (opt UserProfile) query;
+  greet: (daoId: text, name: text) -> (text) query;
   health: () -> (record {
                    status: text;
                    timestamp: int;
                  }) query;
-  /// * Initialize the DAO with basic configuration
-  ///      * 
-  ///      * This is the first function called when setting up a new DAO.
-  ///      * It establishes the foundational parameters and admin structure.
-  ///      * 
-  ///      * @param name - Human-readable name for the DAO
-  ///      * @param description - Brief description of the DAO's purpose
-  ///      * @param initialAdmins - Array of Principal IDs who will have admin privileges
-  ///      * @returns Result indicating success or failure with error message
-  initialize: (name: text, description: text, initialAdmins:
+  initialize: (daoId: text, name: text, description: text, initialAdmins:
    vec principal) -> (Result);
-  registerUser: (displayName: text, bio: text) -> (Result);
-  removeAdmin: (adminToRemove: principal) -> (Result);
-  /// * Set references to other canisters in the DAO ecosystem
-  ///      * 
-  ///      * This establishes the microservices architecture by connecting
-  ///      * the main canister to specialized function canisters.
-  ///      * 
-  ///      * @param governance - Principal ID of the governance canister
-  ///      * @param staking - Principal ID of the staking canister  
-  ///      * @param treasury - Principal ID of the treasury canister
-  ///      * @param proposals - Principal ID of the proposals canister
-  ///      * @returns Result indicating success or failure
-  setCanisterReferences: (governance: principal, staking: principal,
+  registerUser: (daoId: text, displayName: text, bio: text) -> (Result);
+  removeAdmin: (daoId: text, adminToRemove: principal) -> (Result);
+  setCanisterReferences: (daoId: text, governance: principal, staking: principal,
    treasury: principal, proposals: principal) -> (Result);
-  setDAOConfig: (config: DAOConfig) -> (Result);
-  updateUserProfile: (displayName: text, bio: text) -> (Result);
-  vote: (proposalId: nat, choice: text, _reason: opt text) -> (Result);
+  setDAOConfig: (daoId: text, config: DAOConfig) -> (Result);
+  updateUserProfile: (daoId: text, displayName: text, bio: text) -> (Result);
+  vote: (daoId: text, proposalId: nat, choice: text, _reason: opt text) -> (Result);
 }

--- a/src/dao_frontend/src/declarations/dao_backend/dao_backend.did.d.ts
+++ b/src/dao_frontend/src/declarations/dao_backend/dao_backend.did.d.ts
@@ -56,13 +56,13 @@ export interface UserProfile {
   'totalStaked' : bigint,
 }
 export interface _SERVICE {
-  'addAdmin' : ActorMethod<[Principal], Result>,
-  'adminRegisterUser' : ActorMethod<[Principal, string, string], Result>,
-  'checkIsAdmin' : ActorMethod<[Principal], boolean>,
-  'createProposal' : ActorMethod<[string, string, string], Result_1>,
-  'getAllUsers' : ActorMethod<[], Array<UserProfile>>,
+  'addAdmin' : ActorMethod<[string, Principal], Result>,
+  'adminRegisterUser' : ActorMethod<[string, Principal, string, string], Result>,
+  'checkIsAdmin' : ActorMethod<[string, Principal], boolean>,
+  'createProposal' : ActorMethod<[string, string, string, string], Result_1>,
+  'getAllUsers' : ActorMethod<[string], Array<UserProfile>>,
   'getCanisterReferences' : ActorMethod<
-    [],
+    [string],
     {
       'staking' : [] | [Principal],
       'governance' : [] | [Principal],
@@ -70,9 +70,9 @@ export interface _SERVICE {
       'treasury' : [] | [Principal],
     }
   >,
-  'getDAOConfig' : ActorMethod<[], [] | [DAOConfig]>,
+  'getDAOConfig' : ActorMethod<[string], [] | [DAOConfig]>,
   'getDAOInfo' : ActorMethod<
-    [],
+    [string],
     {
       'initialized' : boolean,
       'name' : string,
@@ -80,10 +80,10 @@ export interface _SERVICE {
       'totalMembers' : bigint,
     }
   >,
-  'getDAOStats' : ActorMethod<[], DAOStats>,
-  'getRecentActivity' : ActorMethod<[], Array<Activity>>,
+  'getDAOStats' : ActorMethod<[string], DAOStats>,
+  'getRecentActivity' : ActorMethod<[string], Array<Activity>>,
   'getGovernanceStats' : ActorMethod<
-    [],
+    [string],
     {
       'passedProposals' : bigint,
       'totalVotingPower' : bigint,
@@ -91,19 +91,19 @@ export interface _SERVICE {
       'activeProposals' : bigint,
     }
   >,
-  'getUserProfile' : ActorMethod<[Principal], [] | [UserProfile]>,
-  'greet' : ActorMethod<[string], string>,
+  'getUserProfile' : ActorMethod<[string, Principal], [] | [UserProfile]>,
+  'greet' : ActorMethod<[string, string], string>,
   'health' : ActorMethod<[], { 'status' : string, 'timestamp' : bigint }>,
-  'initialize' : ActorMethod<[string, string, Array<Principal>], Result>,
-  'registerUser' : ActorMethod<[string, string], Result>,
-  'removeAdmin' : ActorMethod<[Principal], Result>,
+  'initialize' : ActorMethod<[string, string, string, Array<Principal>], Result>,
+  'registerUser' : ActorMethod<[string, string, string], Result>,
+  'removeAdmin' : ActorMethod<[string, Principal], Result>,
   'setCanisterReferences' : ActorMethod<
-    [Principal, Principal, Principal, Principal],
+    [string, Principal, Principal, Principal, Principal],
     Result
   >,
-  'setDAOConfig' : ActorMethod<[DAOConfig], Result>,
-  'updateUserProfile' : ActorMethod<[string, string], Result>,
-  'vote' : ActorMethod<[bigint, string, [] | [string]], Result>,
+  'setDAOConfig' : ActorMethod<[string, DAOConfig], Result>,
+  'updateUserProfile' : ActorMethod<[string, string, string], Result>,
+  'vote' : ActorMethod<[string, bigint, string, [] | [string]], Result>,
 }
 export declare const idlFactory: IDL.InterfaceFactory;
 export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/src/dao_frontend/src/declarations/dao_backend/dao_backend.did.js
+++ b/src/dao_frontend/src/declarations/dao_backend/dao_backend.did.js
@@ -51,17 +51,17 @@ export const idlFactory = ({ IDL }) => {
     'status' : IDL.Text,
   });
   return IDL.Service({
-    'addAdmin' : IDL.Func([IDL.Principal], [Result], []),
+    'addAdmin' : IDL.Func([IDL.Text, IDL.Principal], [Result], []),
     'adminRegisterUser' : IDL.Func(
-        [IDL.Principal, IDL.Text, IDL.Text],
+        [IDL.Text, IDL.Principal, IDL.Text, IDL.Text],
         [Result],
         [],
       ),
-    'checkIsAdmin' : IDL.Func([IDL.Principal], [IDL.Bool], ['query']),
-    'createProposal' : IDL.Func([IDL.Text, IDL.Text, IDL.Text], [Result_1], []),
-    'getAllUsers' : IDL.Func([], [IDL.Vec(UserProfile)], ['query']),
+    'checkIsAdmin' : IDL.Func([IDL.Text, IDL.Principal], [IDL.Bool], ['query']),
+    'createProposal' : IDL.Func([IDL.Text, IDL.Text, IDL.Text, IDL.Text], [Result_1], []),
+    'getAllUsers' : IDL.Func([IDL.Text], [IDL.Vec(UserProfile)], ['query']),
     'getCanisterReferences' : IDL.Func(
-        [],
+        [IDL.Text],
         [
           IDL.Record({
             'staking' : IDL.Opt(IDL.Principal),
@@ -72,9 +72,9 @@ export const idlFactory = ({ IDL }) => {
         ],
         ['query'],
       ),
-    'getDAOConfig' : IDL.Func([], [IDL.Opt(DAOConfig)], ['query']),
+    'getDAOConfig' : IDL.Func([IDL.Text], [IDL.Opt(DAOConfig)], ['query']),
     'getDAOInfo' : IDL.Func(
-        [],
+        [IDL.Text],
         [
           IDL.Record({
             'initialized' : IDL.Bool,
@@ -85,10 +85,10 @@ export const idlFactory = ({ IDL }) => {
         ],
         ['query'],
       ),
-    'getDAOStats' : IDL.Func([], [DAOStats], ['query']),
-    'getRecentActivity' : IDL.Func([], [IDL.Vec(Activity)], ['query']),
+    'getDAOStats' : IDL.Func([IDL.Text], [DAOStats], ['query']),
+    'getRecentActivity' : IDL.Func([IDL.Text], [IDL.Vec(Activity)], ['query']),
     'getGovernanceStats' : IDL.Func(
-        [],
+        [IDL.Text],
         [
           IDL.Record({
             'passedProposals' : IDL.Nat,
@@ -100,31 +100,31 @@ export const idlFactory = ({ IDL }) => {
         [],
       ),
     'getUserProfile' : IDL.Func(
-        [IDL.Principal],
+        [IDL.Text, IDL.Principal],
         [IDL.Opt(UserProfile)],
         ['query'],
       ),
-    'greet' : IDL.Func([IDL.Text], [IDL.Text], ['query']),
+    'greet' : IDL.Func([IDL.Text, IDL.Text], [IDL.Text], ['query']),
     'health' : IDL.Func(
         [],
         [IDL.Record({ 'status' : IDL.Text, 'timestamp' : IDL.Int })],
         ['query'],
       ),
     'initialize' : IDL.Func(
-        [IDL.Text, IDL.Text, IDL.Vec(IDL.Principal)],
+        [IDL.Text, IDL.Text, IDL.Text, IDL.Vec(IDL.Principal)],
         [Result],
         [],
       ),
-    'registerUser' : IDL.Func([IDL.Text, IDL.Text], [Result], []),
-    'removeAdmin' : IDL.Func([IDL.Principal], [Result], []),
+    'registerUser' : IDL.Func([IDL.Text, IDL.Text, IDL.Text], [Result], []),
+    'removeAdmin' : IDL.Func([IDL.Text, IDL.Principal], [Result], []),
     'setCanisterReferences' : IDL.Func(
-        [IDL.Principal, IDL.Principal, IDL.Principal, IDL.Principal],
+        [IDL.Text, IDL.Principal, IDL.Principal, IDL.Principal, IDL.Principal],
         [Result],
         [],
       ),
-    'setDAOConfig' : IDL.Func([DAOConfig], [Result], []),
-    'updateUserProfile' : IDL.Func([IDL.Text, IDL.Text], [Result], []),
-    'vote' : IDL.Func([IDL.Nat, IDL.Text, IDL.Opt(IDL.Text)], [Result], []),
+    'setDAOConfig' : IDL.Func([IDL.Text, DAOConfig], [Result], []),
+    'updateUserProfile' : IDL.Func([IDL.Text, IDL.Text, IDL.Text], [Result], []),
+    'vote' : IDL.Func([IDL.Text, IDL.Nat, IDL.Text, IDL.Opt(IDL.Text)], [Result], []),
   });
 };
 export const init = ({ IDL }) => { return []; };

--- a/src/dao_frontend/src/utils/daoAPI.js
+++ b/src/dao_frontend/src/utils/daoAPI.js
@@ -43,109 +43,124 @@ export class DAOAPIWrapper {
     }
 
     // DAO Management APIs
-    async initializeDAO(name, description, initialAdmins) {
+    async initializeDAO(daoId, name, description, initialAdmins) {
+        const id = daoId ?? 'default';
         return this.callAPI(
-            () => this.actors.daoBackend.initialize(name, description, initialAdmins),
+            () => this.actors.daoBackend.initialize(id, name, description, initialAdmins),
             'Initialize DAO'
         );
     }
 
-    async setCanisterReferences(governance, staking, treasury, proposals) {
+    async setCanisterReferences(daoId, governance, staking, treasury, proposals) {
+        const id = daoId ?? 'default';
         return this.callAPI(
-            () => this.actors.daoBackend.setCanisterReferences(governance, staking, treasury, proposals),
+            () => this.actors.daoBackend.setCanisterReferences(id, governance, staking, treasury, proposals),
             'Set Canister References'
         );
     }
 
-    async getCanisterReferences() {
+    async getCanisterReferences(daoId) {
+        const id = daoId ?? 'default';
         return this.callAPI(
-            () => this.actors.daoBackend.getCanisterReferences(),
+            () => this.actors.daoBackend.getCanisterReferences(id),
             'Get Canister References'
         );
     }
 
-    async setDAOConfig(config) {
+    async setDAOConfig(daoId, config) {
+        const id = daoId ?? 'default';
         return this.callAPI(
-            () => this.actors.daoBackend.setDAOConfig(config),
+            () => this.actors.daoBackend.setDAOConfig(id, config),
             'Set DAO Configuration'
         );
     }
 
-    async getDAOInfo() {
+    async getDAOInfo(daoId) {
+        const id = daoId ?? 'default';
         return this.callAPI(
-            () => this.actors.daoBackend.getDAOInfo(),
+            () => this.actors.daoBackend.getDAOInfo(id),
             'Get DAO Info'
         );
     }
 
-    async getDAOConfig() {
+    async getDAOConfig(daoId) {
+        const id = daoId ?? 'default';
         return this.callAPI(
-            () => this.actors.daoBackend.getDAOConfig(),
+            () => this.actors.daoBackend.getDAOConfig(id),
             'Get DAO Configuration'
         );
     }
 
-    async getDAOStats() {
+    async getDAOStats(daoId) {
+        const id = daoId ?? 'default';
         return this.callAPI(
-            () => this.actors.daoBackend.getDAOStats(),
+            () => this.actors.daoBackend.getDAOStats(id),
             'Get DAO Statistics'
         );
     }
 
     // User Management APIs
-    async registerUser(displayName, bio) {
+    async registerUser(daoId, displayName, bio) {
+        const id = daoId ?? 'default';
         return this.callAPI(
-            () => this.actors.daoBackend.registerUser(displayName, bio),
+            () => this.actors.daoBackend.registerUser(id, displayName, bio),
             'Register User'
         );
     }
 
-    async adminRegisterUser(userPrincipal, displayName, bio) {
+    async adminRegisterUser(daoId, userPrincipal, displayName, bio) {
+        const id = daoId ?? 'default';
         return this.callAPI(
-            () => this.actors.daoBackend.adminRegisterUser(userPrincipal, displayName, bio),
+            () => this.actors.daoBackend.adminRegisterUser(id, userPrincipal, displayName, bio),
             'Admin Register User'
         );
     }
 
-    async updateUserProfile(displayName, bio) {
+    async updateUserProfile(daoId, displayName, bio) {
+        const id = daoId ?? 'default';
         return this.callAPI(
-            () => this.actors.daoBackend.updateUserProfile(displayName, bio),
+            () => this.actors.daoBackend.updateUserProfile(id, displayName, bio),
             'Update User Profile'
         );
     }
 
-    async getUserProfile(userId) {
+    async getUserProfile(daoId, userId) {
+        const id = daoId ?? 'default';
         return this.callAPI(
-            () => this.actors.daoBackend.getUserProfile(userId),
+            () => this.actors.daoBackend.getUserProfile(id, userId),
             'Get User Profile'
         );
     }
 
-    async getAllUsers() {
+    async getAllUsers(daoId) {
+        const id = daoId ?? 'default';
         return this.callAPI(
-            () => this.actors.daoBackend.getAllUsers(),
+            () => this.actors.daoBackend.getAllUsers(id),
             'Get All Users'
         );
     }
 
     // Admin Management APIs
-    async addAdmin(newAdmin) {
+    async addAdmin(daoId, newAdmin) {
+        const id = daoId ?? 'default';
         return this.callAPI(
-            () => this.actors.daoBackend.addAdmin(newAdmin),
+            () => this.actors.daoBackend.addAdmin(id, newAdmin),
             'Add Admin'
         );
     }
 
-    async removeAdmin(adminToRemove) {
+    async removeAdmin(daoId, adminToRemove) {
+        const id = daoId ?? 'default';
         return this.callAPI(
-            () => this.actors.daoBackend.removeAdmin(adminToRemove),
+            () => this.actors.daoBackend.removeAdmin(id, adminToRemove),
             'Remove Admin'
         );
     }
 
-    async checkIsAdmin(principal) {
+    async checkIsAdmin(daoId, principal) {
+        const id = daoId ?? 'default';
         return this.callAPI(
-            () => this.actors.daoBackend.checkIsAdmin(principal),
+            () => this.actors.daoBackend.checkIsAdmin(id, principal),
             'Check Is Admin'
         );
     }
@@ -158,16 +173,18 @@ export class DAOAPIWrapper {
         );
     }
 
-    async createProposal(title, description, proposalType) {
+    async createProposal(daoId, title, description, proposalType) {
+        const id = daoId ?? 'default';
         return this.callAPI(
-            () => this.actors.daoBackend.createProposal(title, description, proposalType),
+            () => this.actors.daoBackend.createProposal(id, title, description, proposalType),
             'Create Proposal'
         );
     }
 
-    async vote(proposalId, choice, reason) {
+    async vote(daoId, proposalId, choice, reason) {
+        const id = daoId ?? 'default';
         return this.callAPI(
-            () => this.actors.daoBackend.vote(proposalId, choice, reason),
+            () => this.actors.daoBackend.vote(id, proposalId, choice, reason),
             'Cast Vote'
         );
     }


### PR DESCRIPTION
## Summary
- Support multiple DAOs in backend by introducing `DAOId` and per-DAO state maps
- Extend API surface to accept `daoId` across user and admin operations
- Add default `daoId` handling in frontend API wrapper and update declarations

## Testing
- `npm test` *(fails: dfx not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a1bc7578108320b9e87dcf90345780