### PR TITLE
feat: load actors per DAO

### DIFF
--- a/src/dao_frontend/src/App.jsx
+++ b/src/dao_frontend/src/App.jsx
@@ -11,7 +11,6 @@ import Diagnostics from './components/Diagnostics';
 import Navbar from './components/Navbar';
 import UserRegistrationHandler from './components/UserRegistrationHandler';
 import ErrorBoundary from './components/ErrorBoundary';
-import { DAOManagementProvider } from './context/DAOManagementContext';
 import Overview from './components/management/Overview';
 import ManagementGovernance from './components/management/ManagementGovernance';
 import ManagementStaking from './components/management/ManagementStaking';
@@ -25,33 +24,31 @@ function App() {
   
   return (
     <ErrorBoundary>
-      <DAOManagementProvider>
-        <Router>
-          <UserRegistrationHandler />
-          <div className="App">
-            <Navbar />
-            <Routes>
-              <Route path="/" element={<LandingPage />} />
-              <Route path="/dashboard" element={<DAODashboard />} />
-              <Route path="/status" element={<DAOStatus />} />
-              <Route path="/admin/diagnostics" element={<Diagnostics />} />
-              <Route path="/signin" element={<SignIn />} />
-              <Route path="/launch" element={<LaunchDAO />} />
-              <Route path="/settings" element={<Settings />} />
-              <Route path="/dao/:daoId/manage" element={<DAOManagement />}>
-                <Route index element={<Overview />} />
-                <Route path="overview" element={<Overview />} />
-                <Route path="governance" element={<ManagementGovernance />} />
-                <Route path="staking" element={<ManagementStaking />} />
-                <Route path="treasury" element={<ManagementTreasury />} />
-                <Route path="proposals" element={<ManagementProposals />} />
-                <Route path="assets" element={<ManagementAssets />} />
-                <Route path="admins" element={<ManagementAdmins />} />
-              </Route>
-            </Routes>
-          </div>
-        </Router>
-      </DAOManagementProvider>
+      <Router>
+        <UserRegistrationHandler />
+        <div className="App">
+          <Navbar />
+          <Routes>
+            <Route path="/" element={<LandingPage />} />
+            <Route path="/dashboard" element={<DAODashboard />} />
+            <Route path="/status" element={<DAOStatus />} />
+            <Route path="/admin/diagnostics" element={<Diagnostics />} />
+            <Route path="/signin" element={<SignIn />} />
+            <Route path="/launch" element={<LaunchDAO />} />
+            <Route path="/settings" element={<Settings />} />
+            <Route path="/dao/:daoId/manage" element={<DAOManagement />}> 
+              <Route index element={<Overview />} />
+              <Route path="overview" element={<Overview />} />
+              <Route path="governance" element={<ManagementGovernance />} />
+              <Route path="staking" element={<ManagementStaking />} />
+              <Route path="treasury" element={<ManagementTreasury />} />
+              <Route path="proposals" element={<ManagementProposals />} />
+              <Route path="assets" element={<ManagementAssets />} />
+              <Route path="admins" element={<ManagementAdmins />} />
+            </Route>
+          </Routes>
+        </div>
+      </Router>
     </ErrorBoundary>
   );
 }

--- a/src/dao_frontend/src/config/agent.ts
+++ b/src/dao_frontend/src/config/agent.ts
@@ -54,6 +54,15 @@ if (typeof window !== "undefined") {
   window.global = window;
 }
 
+export interface CanisterIds {
+  daoBackend: string;
+  governance?: string;
+  staking?: string;
+  treasury?: string;
+  proposals?: string;
+  assets?: string;
+}
+
 const createActor = async <T>(
   canisterId: string,
   idlFactory: IDL.InterfaceFactory,
@@ -108,119 +117,99 @@ const createActor = async <T>(
   }
 };
 
+export interface Actors {
+  daoBackend: ActorSubclass<DaoBackendServiceExtended>;
+  governance: ActorSubclass<GovernanceService>;
+  staking: ActorSubclass<StakingService>;
+  treasury: ActorSubclass<TreasuryService>;
+  proposals: ActorSubclass<ProposalsService>;
+  assets: ActorSubclass<AssetsService>;
+}
 
-export const initializeAgents = async (identity?: Identity) => {
-  if (import.meta.env.DEV) {
-    console.log("=== DEBUGGING ENVIRONMENT VARIABLES ===");
-    console.log("All import.meta.env:", import.meta.env);
+const createMockActor = <T>(): ActorSubclass<T> => {
+  return new Proxy({} as ActorSubclass<T>, {
+    get: (target, prop) => {
+      if (typeof prop === 'string') {
+        return async (...args: any[]) => {
+          console.warn(`Mock actor method called: ${prop}`, args);
+          if (prop.includes('get') || prop.includes('fetch') || prop.includes('list')) {
+            return null;
+          }
+          return { ok: true } as unknown as T;
+        };
+      }
+      return target[prop as keyof ActorSubclass<T>];
+    }
+  });
+};
 
-    const envVars = {
-      'VITE_CANISTER_ID_DAO_BACKEND': import.meta.env.VITE_CANISTER_ID_DAO_BACKEND,
-      'VITE_CANISTER_ID_GOVERNANCE': import.meta.env.VITE_CANISTER_ID_GOVERNANCE,
-      'VITE_CANISTER_ID_STAKING': import.meta.env.VITE_CANISTER_ID_STAKING,
-      'VITE_CANISTER_ID_TREASURY': import.meta.env.VITE_CANISTER_ID_TREASURY,
-      'VITE_CANISTER_ID_PROPOSALS': import.meta.env.VITE_CANISTER_ID_PROPOSALS,
-      'VITE_CANISTER_ID_ASSETS': import.meta.env.VITE_CANISTER_ID_ASSETS,
-      'VITE_CANISTER_ID_INTERNET_IDENTITY': import.meta.env.VITE_CANISTER_ID_INTERNET_IDENTITY,
-    };
-
-    Object.entries(envVars).forEach(([key, value]) => {
-      console.log(`${key}:`, value);
-      console.log(`  Type: ${typeof value}`);
-      console.log(`  Length: ${value ? value.length : 'N/A'}`);
-      console.log(`  Contains underscore: ${value ? value.includes('_') : 'N/A'}`);
-      console.log(
-        `  Raw characters:`,
-        value ? [...value].map(c => `${c}(${c.charCodeAt(0)})`).join(' ') : 'N/A'
-      );
-    });
+const handleOptionalActor = async <T>(
+  canisterId: string | undefined,
+  idl: IDL.InterfaceFactory,
+  name: string,
+  identity?: Identity
+): Promise<ActorSubclass<T>> => {
+  if (!canisterId) {
+    if (import.meta.env.DEV) {
+      return createMockActor<T>();
+    }
+    throw new Error(`Missing canister ID for ${name}`);
   }
-
-
   try {
-    // Create actors for required canisters
+    return await createActor<T>(canisterId, idl, identity);
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn(`Failed to create ${name.toLowerCase()} actor, using mock:`, error);
+      return createMockActor<T>();
+    }
+    throw error;
+  }
+};
+
+export const initializeAgents = async (
+  canisterIds: CanisterIds,
+  identity?: Identity
+): Promise<Actors> => {
+  try {
     const daoBackend = await createActor<DaoBackendServiceExtended>(
-      import.meta.env.VITE_CANISTER_ID_DAO_BACKEND,
+      canisterIds.daoBackend,
       daoBackendIdl,
       identity
     );
 
-    const assets = await createActor<AssetsService>(
-      import.meta.env.VITE_CANISTER_ID_ASSETS,
+    const assets = await handleOptionalActor<AssetsService>(
+      canisterIds.assets,
       assetsIdl,
+      "ASSETS",
       identity
     );
 
-    // Create mock actors for optional canisters during development if they don't exist
-    // In production, missing canister IDs will throw an error instead of creating mocks
-    const createMockActor = <T>(): ActorSubclass<T> => {
-      return new Proxy({} as ActorSubclass<T>, {
-        get: (target, prop) => {
-          if (typeof prop === 'string') {
-            return async (...args: any[]) => {
-              console.warn(`Mock actor method called: ${prop}`, args);
-              if (prop.includes('get') || prop.includes('fetch') || prop.includes('list')) {
-                return null;
-              }
-              return { ok: true };
-            };
-          }
-          return target[prop as keyof ActorSubclass<T>];
-        }
-      });
-    };
-
-    // Helper to handle optional canisters
-    const handleOptionalActor = async <T>(
-      canisterId: string | undefined,
-      idl: IDL.InterfaceFactory,
-      name: string
-    ): Promise<ActorSubclass<T>> => {
-      if (!canisterId) {
-        if (import.meta.env.DEV) {
-          return createMockActor<T>();
-        }
-        throw new Error(`Missing environment variable: VITE_CANISTER_ID_${name}`);
-      }
-      try {
-        return await createActor<T>(canisterId, idl, identity);
-      } catch (error) {
-        if (import.meta.env.DEV) {
-          console.warn(`Failed to create ${name.toLowerCase()} actor, using mock:`, error);
-          return createMockActor<T>();
-        }
-        throw error;
-      }
-    };
-
-    // Create actors, using mocks only in development
-    let governance: ActorSubclass<GovernanceService>;
-    let staking: ActorSubclass<StakingService>;
-    let treasury: ActorSubclass<TreasuryService>;
-    let proposals: ActorSubclass<ProposalsService>;
-
-    governance = await handleOptionalActor<GovernanceService>(
-      import.meta.env.VITE_CANISTER_ID_GOVERNANCE,
+    const governance = await handleOptionalActor<GovernanceService>(
+      canisterIds.governance,
       governanceIdl,
-      "GOVERNANCE"
+      "GOVERNANCE",
+      identity
     );
 
-    staking = await handleOptionalActor<StakingService>(
-      import.meta.env.VITE_CANISTER_ID_STAKING,
+    const staking = await handleOptionalActor<StakingService>(
+      canisterIds.staking,
       stakingIdl,
-      "STAKING"
+      "STAKING",
+      identity
     );
 
-    treasury = await handleOptionalActor<TreasuryService>(
-      import.meta.env.VITE_CANISTER_ID_TREASURY,
+    const treasury = await handleOptionalActor<TreasuryService>(
+      canisterIds.treasury,
       treasuryIdl,
-      "TREASURY"
+      "TREASURY",
+      identity
     );
 
-    proposals = await handleOptionalActor<ProposalsService>(
-      import.meta.env.VITE_CANISTER_ID_PROPOSALS,
+    const proposals = await handleOptionalActor<ProposalsService>(
+      canisterIds.proposals,
       proposalsIdl,
-      "PROPOSALS"
+      "PROPOSALS",
+      identity
     );
 
     return {

--- a/src/dao_frontend/src/context/ActorContext.tsx
+++ b/src/dao_frontend/src/context/ActorContext.tsx
@@ -5,11 +5,10 @@ import {
   useEffect,
   ReactNode,
 } from "react";
-import { initializeAgents } from "../config/agent";
+import { initializeAgents, type Actors } from "../config/agent";
 // @ts-ignore - AuthContext is a .jsx file, ignore TypeScript error
 import { useAuth } from "./AuthContext";
-
-type Actors = Awaited<ReturnType<typeof initializeAgents>>;
+import { useDAOManagement } from "./DAOManagementContext";
 
 const ActorContext = createContext<Actors | null>(null);
 
@@ -22,13 +21,30 @@ export const ActorProvider = ({ children }: ActorProviderProps) => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const { identity } = useAuth();
+  const { selectedDAO, daoActors, setActorsForDAO } = useDAOManagement();
 
   useEffect(() => {
     const setup = async () => {
+      if (!selectedDAO) {
+        setActors(null);
+        return;
+      }
       setLoading(true);
       try {
-        const initializedActors = await initializeAgents(identity);
-        setActors(initializedActors);
+        const existing = daoActors[selectedDAO.id];
+        if (existing) {
+          setActors(existing);
+        } else {
+          if (!selectedDAO.canisterIds?.daoBackend) {
+            throw new Error("Selected DAO is missing canister IDs");
+          }
+          const initializedActors = await initializeAgents(
+            selectedDAO.canisterIds,
+            identity
+          );
+          setActors(initializedActors);
+          setActorsForDAO(selectedDAO.id, initializedActors);
+        }
       } catch (err) {
         console.error("Failed to initialize actors:", err);
         setError((err as Error).message);
@@ -37,7 +53,7 @@ export const ActorProvider = ({ children }: ActorProviderProps) => {
       }
     };
     setup();
-  }, [identity]);
+  }, [identity, selectedDAO, daoActors, setActorsForDAO]);
 
   return (
     <ActorContext.Provider value={actors}>

--- a/src/dao_frontend/src/context/AuthContext.test.jsx
+++ b/src/dao_frontend/src/context/AuthContext.test.jsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { AuthProvider, useAuth } from './AuthContext';
 import { ActorProvider } from './ActorContext';
+import { DAOManagementProvider } from './DAOManagementContext';
 import { initializeAgents } from '../config/agent';
 
 // Mock AuthClient from DFINITY
@@ -21,29 +22,36 @@ vi.mock('@dfinity/auth-client', () => ({
   },
 }));
 
-vi.mock('./ActorContext', async () => {
-  const actual = await vi.importActual('./ActorContext');
-  return {
-    ...actual,
-    useActors: () => ({
-      daoBackend: { registerUser: vi.fn(async () => ({ ok: null })) },
-    }),
-  };
-});
-
 vi.mock('../config/agent', () => ({
   initializeAgents: vi.fn(async () => ({})),
 }));
 
+const mockDAO = {
+  id: 'dao1',
+  name: 'Test DAO',
+  description: 'desc',
+  tokenSymbol: 'TST',
+  memberCount: 0,
+  totalValueLocked: '0',
+  createdAt: new Date().toISOString(),
+  category: 'Test',
+  status: 'active',
+  governance: { totalProposals: 0, activeProposals: 0 },
+  treasury: { balance: '0', monthlyInflow: '0' },
+  staking: { totalStaked: '0', apr: '0%' },
+  canisterIds: { daoBackend: 'aaaaa-aa' }
+};
+
 describe('AuthContext', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    global.fetch = vi.fn(async () => ({ ok: true, json: async () => [mockDAO] }));
   });
 
   it('updates identity and principal after login', async () => {
     const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
 
-    await waitFor(() => expect(result.current.authClient).toBeDefined());
+    await waitFor(() => expect(result.current?.authClient).toBeDefined());
 
     await act(async () => {
       await result.current.login();
@@ -56,20 +64,23 @@ describe('AuthContext', () => {
   it('ActorProvider receives authenticated identity', async () => {
     const wrapper = ({ children }) => (
       <AuthProvider>
-        <ActorProvider>{children}</ActorProvider>
+        <DAOManagementProvider>
+          <ActorProvider>{null}</ActorProvider>
+          {children}
+        </DAOManagementProvider>
       </AuthProvider>
     );
 
     const { result } = renderHook(() => useAuth(), { wrapper });
 
-    await waitFor(() => expect(result.current.authClient).toBeDefined());
+    await waitFor(() => expect(result.current?.authClient).toBeDefined());
 
     await act(async () => {
       await result.current.login();
     });
 
     await waitFor(() => {
-      expect(initializeAgents).toHaveBeenCalledWith(mockIdentity);
+      expect(initializeAgents).toHaveBeenCalledWith(mockDAO.canisterIds, mockIdentity);
     });
   });
 });

--- a/src/dao_frontend/src/context/DAOContext.jsx
+++ b/src/dao_frontend/src/context/DAOContext.jsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import { useAuth } from './AuthContext';
-import { useActors } from './ActorContext';
+import { useDAOManagement } from './DAOManagementContext';
 import { safeJsonStringify, safeJsonParse } from '../utils/jsonUtils';
 
 // Create the DAO Context
@@ -9,7 +9,8 @@ const DAOContext = createContext();
 // DAO Provider component
 export const DAOProvider = ({ children }) => {
   const { isAuthenticated, principal } = useAuth();
-  const actors = useActors();
+  const { selectedDAO, daoActors } = useDAOManagement();
+  const [actors, setActors] = useState(null);
   const daoBackend = actors?.daoBackend;
   const [activeDAO, setActiveDAO] = useState(null);
   const [userDAOs, setUserDAOs] = useState([]);
@@ -107,11 +108,21 @@ export const DAOProvider = ({ children }) => {
 
   const hasActiveDAO = activeDAO !== null;
 
+  // Update actors when selectedDAO changes
+  useEffect(() => {
+    if (selectedDAO) {
+      setActors(daoActors[selectedDAO.id] || null);
+    } else {
+      setActors(null);
+    }
+  }, [selectedDAO, daoActors]);
+
   const value = {
     activeDAO,
     userDAOs,
     hasActiveDAO,
     loading,
+    actors,
     selectDAO,
     addUserDAO,
     removeUserDAO,

--- a/src/dao_frontend/src/context/DAOManagementContext.tsx
+++ b/src/dao_frontend/src/context/DAOManagementContext.tsx
@@ -1,84 +1,9 @@
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { useAuth } from './AuthContext';
 import { DAO, DAOContextType } from '../types/dao';
+import type { Actors } from '../config/agent';
 
 const DAOManagementContext = createContext<DAOContextType | undefined>(undefined);
-
-// Mock data for demonstration
-const mockDAOs: DAO[] = [
-  {
-    id: 'defi-protocol-1',
-    name: 'DeFi Protocol Alpha',
-    description: 'A revolutionary decentralized finance protocol focused on yield optimization and automated market making strategies.',
-    tokenSymbol: 'DPA',
-    logo: 'https://images.pexels.com/photos/730547/pexels-photo-730547.jpeg?auto=compress&cs=tinysrgb&w=400',
-    memberCount: 1247,
-    totalValueLocked: '$2.4M',
-    createdAt: new Date('2024-01-15'),
-    category: 'DeFi',
-    status: 'active',
-    governance: {
-      totalProposals: 23,
-      activeProposals: 3
-    },
-    treasury: {
-      balance: '$850K',
-      monthlyInflow: '+$45K'
-    },
-    staking: {
-      totalStaked: '$1.2M',
-      apr: '18.5%'
-    }
-  },
-  {
-    id: 'gaming-dao-2',
-    name: 'MetaVerse Gaming DAO',
-    description: 'Community-owned gaming ecosystem with play-to-earn mechanics and NFT integration for the next generation of gamers.',
-    tokenSymbol: 'MVG',
-    logo: 'https://images.pexels.com/photos/442576/pexels-photo-442576.jpeg?auto=compress&cs=tinysrgb&w=400',
-    memberCount: 3456,
-    totalValueLocked: '$5.7M',
-    createdAt: new Date('2024-02-20'),
-    category: 'Gaming',
-    status: 'active',
-    governance: {
-      totalProposals: 45,
-      activeProposals: 7
-    },
-    treasury: {
-      balance: '$2.1M',
-      monthlyInflow: '+$120K'
-    },
-    staking: {
-      totalStaked: '$3.6M',
-      apr: '22.3%'
-    }
-  },
-  {
-    id: 'social-dao-3',
-    name: 'Creator Economy DAO',
-    description: 'Empowering content creators through decentralized governance and fair revenue sharing mechanisms.',
-    tokenSymbol: 'CED',
-    logo: 'https://images.pexels.com/photos/1181671/pexels-photo-1181671.jpeg?auto=compress&cs=tinysrgb&w=400',
-    memberCount: 892,
-    totalValueLocked: '$1.8M',
-    createdAt: new Date('2024-03-10'),
-    category: 'Social',
-    status: 'active',
-    governance: {
-      totalProposals: 12,
-      activeProposals: 2
-    },
-    treasury: {
-      balance: '$650K',
-      monthlyInflow: '+$28K'
-    },
-    staking: {
-      totalStaked: '$1.1M',
-      apr: '15.7%'
-    }
-  }
-];
 
 interface DAOManagementProviderProps {
   children: ReactNode;
@@ -89,26 +14,36 @@ export const DAOManagementProvider: React.FC<DAOManagementProviderProps> = ({ ch
   const [selectedDAO, setSelectedDAO] = useState<DAO | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [daoActors, setDAOActors] = useState<Record<string, Actors>>({});
   const { isAuthenticated, principal } = useAuth();
 
   const fetchDAOs = async () => {
     setLoading(true);
     setError(null);
     try {
-      // Load DAOs from localStorage for the current user
+      const registryUrl = import.meta.env.VITE_DAO_REGISTRY_URL || '/api/dao-registry';
+      const response = await fetch(registryUrl);
+      const data = await response.json();
+      const registryDAOs = Array.isArray(data)
+        ? data.map((dao: any) => ({ ...dao, createdAt: new Date(dao.createdAt) }))
+        : [];
+
+      let allDAOs = registryDAOs;
+
       if (principal) {
         const storedDAOs = localStorage.getItem(`user_daos_${principal}`);
         if (storedDAOs) {
           const userDAOs = JSON.parse(storedDAOs).map((dao: any) => ({
             ...dao,
-            createdAt: new Date(dao.createdAt) // Convert string back to Date
+            createdAt: new Date(dao.createdAt),
           }));
-          setDAOs([...mockDAOs, ...userDAOs]);
-        } else {
-          setDAOs(mockDAOs);
+          allDAOs = [...registryDAOs, ...userDAOs];
         }
-      } else {
-        setDAOs(mockDAOs);
+      }
+
+      setDAOs(allDAOs);
+      if (!selectedDAO && allDAOs.length > 0) {
+        setSelectedDAO(allDAOs[0]);
       }
     } catch (err) {
       setError('Failed to fetch DAOs');
@@ -148,7 +83,8 @@ export const DAOManagementProvider: React.FC<DAOManagementProviderProps> = ({ ch
           totalStaked: '$0',
           apr: '0%'
         },
-        ...daoData
+        ...daoData,
+        canisterIds: { daoBackend: '', ...(daoData.canisterIds || {}) },
       };
       
       // Add to state immediately
@@ -204,6 +140,10 @@ export const DAOManagementProvider: React.FC<DAOManagementProviderProps> = ({ ch
     }
   };
 
+  const setActorsForDAO = (daoId: string, actors: Actors) => {
+    setDAOActors(prev => ({ ...prev, [daoId]: actors }));
+  };
+
   useEffect(() => {
     if (isAuthenticated && principal) {
       fetchDAOs();
@@ -216,13 +156,15 @@ export const DAOManagementProvider: React.FC<DAOManagementProviderProps> = ({ ch
   const value: DAOContextType = {
     daos,
     selectedDAO,
+    daoActors,
     loading,
     error,
     fetchDAOs,
     selectDAO,
     createDAO,
     refreshDAOs,
-    deleteDAO
+    deleteDAO,
+    setActorsForDAO
   };
 
   return (

--- a/src/dao_frontend/src/main.jsx
+++ b/src/dao_frontend/src/main.jsx
@@ -4,17 +4,20 @@ import App from './App'
 import { ActorProvider } from './context/ActorContext'
 import { AuthProvider } from './context/AuthContext'
 import { DAOProvider } from './context/DAOContext'
+import { DAOManagementProvider } from './context/DAOManagementContext'
 import './index.css'
 import './app.css'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <AuthProvider>
-      <ActorProvider>
-        <DAOProvider>
-          <App />
-        </DAOProvider>
-      </ActorProvider>
+      <DAOManagementProvider>
+        <ActorProvider>
+          <DAOProvider>
+            <App />
+          </DAOProvider>
+        </ActorProvider>
+      </DAOManagementProvider>
     </AuthProvider>
   </React.StrictMode>,
 )

--- a/src/dao_frontend/src/types/dao.ts
+++ b/src/dao_frontend/src/types/dao.ts
@@ -1,3 +1,5 @@
+import type { CanisterIds, Actors } from '../config/agent';
+
 export interface DAO {
   id: string;
   name: string;
@@ -21,11 +23,13 @@ export interface DAO {
     totalStaked: string;
     apr: string;
   };
+  canisterIds: CanisterIds;
 }
 
 export interface DAOContextType {
   daos: DAO[];
   selectedDAO: DAO | null;
+  daoActors: Record<string, Actors>;
   loading: boolean;
   error: string | null;
   fetchDAOs: () => Promise<void>;
@@ -33,6 +37,7 @@ export interface DAOContextType {
   createDAO: (daoData: Partial<DAO>) => Promise<void>;
   refreshDAOs: () => Promise<void>;
   deleteDAO: (daoId: string) => Promise<void>;
+  setActorsForDAO: (daoId: string, actors: Actors) => void;
 }
 
 export interface DAOFormData {


### PR DESCRIPTION
## Summary
- fetch DAO definitions from a registry and cache actors per DAO
- build canister actors based on selected DAO canister IDs
- track active DAO actors in DAO context and adjust provider hierarchy

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1bc868e4c832093395ade41daa311