### PR TITLE
Track authorized principals per DAO

### DIFF
--- a/src/dao_backend/treasury/main.mo
+++ b/src/dao_backend/treasury/main.mo
@@ -50,22 +50,21 @@ persistent actor TreasuryCanister {
     private var nextTransactionId : Nat = 1;
     private var transactionsEntries : [(Nat, TreasuryTransaction)] = [];
     private var allowancesEntries : [(Principal, TokenAmount)] = [];
+    private var authorizedPrincipalsEntries : [(Principal, [Principal])] = [];
 
     // Runtime storage - rebuilt from stable storage after upgrades
     // HashMaps provide efficient transaction and allowance management
     private transient var balances = HashMap.HashMap<Principal, TreasuryBalance>(10, Principal.equal, Principal.hash);
     private transient var transactions = HashMap.HashMap<Nat, TreasuryTransaction>(100, Nat.equal, func(n: Nat) : Nat32 { Nat32.fromNat(n) });
     private transient var allowances = HashMap.HashMap<Principal, TokenAmount>(10, Principal.equal, Principal.hash);
-
-    // Authorization system for treasury operations
-    // In production, this would be managed by governance proposals
-    private var authorizedPrincipals : [Principal] = [];
+    private transient var authorizedPrincipals = HashMap.HashMap<Principal, [Principal]>(10, Principal.equal, Principal.hash);
 
     // System functions for upgrades
     system func preupgrade() {
         balancesEntries := Iter.toArray(balances.entries());
         transactionsEntries := Iter.toArray(transactions.entries());
         allowancesEntries := Iter.toArray(allowances.entries());
+        authorizedPrincipalsEntries := Iter.toArray(authorizedPrincipals.entries());
     };
 
     system func postupgrade() {
@@ -84,6 +83,12 @@ persistent actor TreasuryCanister {
         allowances := HashMap.fromIter<Principal, TokenAmount>(
             allowancesEntries.vals(),
             allowancesEntries.size(),
+            Principal.equal,
+            Principal.hash
+        );
+        authorizedPrincipals := HashMap.fromIter<Principal, [Principal]>(
+            authorizedPrincipalsEntries.vals(),
+            authorizedPrincipalsEntries.size(),
             Principal.equal,
             Principal.hash
         );
@@ -137,7 +142,7 @@ persistent actor TreasuryCanister {
         let caller = msg.caller;
 
         // Check authorization
-        if (not isAuthorized(caller)) {
+        if (not isAuthorized(daoId, caller)) {
             return #err("Not authorized to withdraw from treasury");
         };
 
@@ -212,7 +217,7 @@ persistent actor TreasuryCanister {
     // Lock tokens for specific purposes (e.g., staking rewards)
     public shared(msg) func lockTokens(daoId: Principal, amount: TokenAmount, reason: Text) : async Result<(), Text> {
 
-        if (not isAuthorized(msg.caller)) {
+        if (not isAuthorized(daoId, msg.caller)) {
             return #err("Not authorized");
         };
 
@@ -247,7 +252,7 @@ persistent actor TreasuryCanister {
 
     // Unlock tokens
     public shared(msg) func unlockTokens(daoId: Principal, amount: TokenAmount, reason: Text) : async Result<(), Text> {
-        if (not isAuthorized(msg.caller)) {
+        if (not isAuthorized(daoId, msg.caller)) {
             return #err("Not authorized");
         };
 
@@ -282,7 +287,7 @@ persistent actor TreasuryCanister {
 
     // Reserve tokens for future use
     public shared(msg) func reserveTokens(daoId: Principal, amount: TokenAmount, reason: Text) : async Result<(), Text> {
-        if (not isAuthorized(msg.caller)) {
+        if (not isAuthorized(daoId, msg.caller)) {
             return #err("Not authorized");
         };
 
@@ -317,7 +322,7 @@ persistent actor TreasuryCanister {
 
     // Release reserved tokens
     public shared(msg) func releaseReservedTokens(daoId: Principal, amount: TokenAmount, reason: Text) : async Result<(), Text> {
-        if (not isAuthorized(msg.caller)) {
+        if (not isAuthorized(daoId, msg.caller)) {
             return #err("Not authorized");
         };
 
@@ -474,24 +479,40 @@ persistent actor TreasuryCanister {
     // Administrative functions
 
     // Add authorized principal
-    public shared(_msg) func addAuthorizedPrincipal(principal: Principal) : async Result<(), Text> {
+    public shared(_msg) func addAuthorizedPrincipal(daoId: Principal, principal: Principal) : async Result<(), Text> {
         // In real implementation, only governance or admin should be able to do this
-        let principals = Buffer.fromArray<Principal>(authorizedPrincipals);
+        let principals = Buffer.fromArray<Principal>(
+            switch (authorizedPrincipals.get(daoId)) {
+                case (?arr) arr;
+                case null [];
+            }
+        );
         principals.add(principal);
-        authorizedPrincipals := Buffer.toArray(principals);
+        authorizedPrincipals.put(daoId, Buffer.toArray(principals));
         #ok()
     };
 
     // Remove authorized principal
-    public shared(_msg) func removeAuthorizedPrincipal(principal: Principal) : async Result<(), Text> {
+    public shared(_msg) func removeAuthorizedPrincipal(daoId: Principal, principal: Principal) : async Result<(), Text> {
         // In real implementation, only governance or admin should be able to do this
-        authorizedPrincipals := Array.filter<Principal>(authorizedPrincipals, func(p) = p != principal);
+        let updated = switch (authorizedPrincipals.get(daoId)) {
+            case (?arr) Array.filter<Principal>(arr, func(p) = p != principal);
+            case null [];
+        };
+        if (updated.size() == 0) {
+            authorizedPrincipals.remove(daoId);
+        } else {
+            authorizedPrincipals.put(daoId, updated);
+        };
         #ok()
     };
 
     // Get authorized principals
-    public query func getAuthorizedPrincipals() : async [Principal] {
-        authorizedPrincipals
+    public query func getAuthorizedPrincipals(daoId: Principal) : async [Principal] {
+        switch (authorizedPrincipals.get(daoId)) {
+            case (?arr) arr;
+            case null [];
+        }
     };
 
     // Helper functions
@@ -511,8 +532,11 @@ persistent actor TreasuryCanister {
         }
     };
 
-    private func isAuthorized(principal: Principal) : Bool {
-        Array.find<Principal>(authorizedPrincipals, func(p) = p == principal) != null
+    private func isAuthorized(daoId: Principal, principal: Principal) : Bool {
+        switch (authorizedPrincipals.get(daoId)) {
+            case (?arr) { Array.find<Principal>(arr, func(p) = p == principal) != null };
+            case null { false };
+        }
     };
 
     private func executeWithdrawal(_transactionId: Nat) : async Result<(), Text> {

--- a/src/dao_frontend/src/components/management/ManagementTreasury.tsx
+++ b/src/dao_frontend/src/components/management/ManagementTreasury.tsx
@@ -36,20 +36,20 @@ const ManagementTreasury: React.FC = () => {
   useEffect(() => {
     const fetchPrincipals = async () => {
       try {
-        const list = await getAuthorizedPrincipals();
+        const list = await getAuthorizedPrincipals(dao.id);
         setPrincipals(list);
       } catch (err) {
         console.error(err);
       }
     };
     fetchPrincipals();
-  }, [getAuthorizedPrincipals]);
+  }, [dao.id, getAuthorizedPrincipals]);
 
   const handleAdd = async () => {
     if (!newPrincipal.trim()) return;
     try {
-      await addAuthorizedPrincipal(newPrincipal.trim());
-      const list = await getAuthorizedPrincipals();
+      await addAuthorizedPrincipal(dao.id, newPrincipal.trim());
+      const list = await getAuthorizedPrincipals(dao.id);
       setPrincipals(list);
       setNewPrincipal('');
     } catch (err) {
@@ -59,8 +59,8 @@ const ManagementTreasury: React.FC = () => {
 
   const handleRemove = async (principal: string) => {
     try {
-      await removeAuthorizedPrincipal(principal);
-      const list = await getAuthorizedPrincipals();
+      await removeAuthorizedPrincipal(dao.id, principal);
+      const list = await getAuthorizedPrincipals(dao.id);
       setPrincipals(list);
     } catch (err) {
       console.error(err);

--- a/src/dao_frontend/src/declarations/treasury/treasury.did
+++ b/src/dao_frontend/src/declarations/treasury/treasury.did
@@ -45,10 +45,10 @@ type Result =
 type ProposalId = nat;
 type Principal = principal;
 service : {
-  addAuthorizedPrincipal: ("principal": principal) -> (Result_1);
+  addAuthorizedPrincipal: (daoId: Principal, "principal": principal) -> (Result_1);
   deposit: (daoId: Principal, amount: TokenAmount, description: text) -> (Result);
   getAllTransactions: (daoId: Principal) -> (vec TreasuryTransaction) query;
-  getAuthorizedPrincipals: () -> (vec principal) query;
+  getAuthorizedPrincipals: (daoId: Principal) -> (vec principal) query;
   getBalance: (daoId: Principal) -> (TreasuryBalance) query;
   getRecentTransactions: (daoId: Principal, limit: nat) -> (vec TreasuryTransaction) query;
   getTransaction: (transactionId: nat, daoId: Principal) -> (opt TreasuryTransaction) query;
@@ -64,7 +64,7 @@ service : {
     }) query;
   lockTokens: (daoId: Principal, amount: TokenAmount, reason: text) -> (Result_1);
   releaseReservedTokens: (daoId: Principal, amount: TokenAmount, reason: text) -> (Result_1);
-  removeAuthorizedPrincipal: ("principal": principal) -> (Result_1);
+  removeAuthorizedPrincipal: (daoId: Principal, "principal": principal) -> (Result_1);
   reserveTokens: (daoId: Principal, amount: TokenAmount, reason: text) -> (Result_1);
   unlockTokens: (daoId: Principal, amount: TokenAmount, reason: text) -> (Result_1);
   withdraw: (daoId: Principal, recipient: principal, amount: TokenAmount, description:

--- a/src/dao_frontend/src/declarations/treasury/treasury.did.d.ts
+++ b/src/dao_frontend/src/declarations/treasury/treasury.did.d.ts
@@ -36,10 +36,10 @@ export type TreasuryTransactionType = { 'fee' : null } |
   { 'withdrawal' : null } |
   { 'proposalExecution' : null };
 export interface _SERVICE {
-  'addAuthorizedPrincipal' : ActorMethod<[Principal], Result_1>,
+  'addAuthorizedPrincipal' : ActorMethod<[Principal, Principal], Result_1>,
   'deposit' : ActorMethod<[Principal, TokenAmount, string], Result>,
   'getAllTransactions' : ActorMethod<[Principal], Array<TreasuryTransaction>>,
-  'getAuthorizedPrincipals' : ActorMethod<[], Array<Principal>>,
+  'getAuthorizedPrincipals' : ActorMethod<[Principal], Array<Principal>>,
   'getBalance' : ActorMethod<[Principal], TreasuryBalance>,
   'getRecentTransactions' : ActorMethod<[Principal, bigint], Array<TreasuryTransaction>>,
   'getTransaction' : ActorMethod<[bigint, Principal], [] | [TreasuryTransaction]>,
@@ -59,7 +59,7 @@ export interface _SERVICE {
   >,
   'lockTokens' : ActorMethod<[Principal, TokenAmount, string], Result_1>,
   'releaseReservedTokens' : ActorMethod<[Principal, TokenAmount, string], Result_1>,
-  'removeAuthorizedPrincipal' : ActorMethod<[Principal], Result_1>,
+  'removeAuthorizedPrincipal' : ActorMethod<[Principal, Principal], Result_1>,
   'reserveTokens' : ActorMethod<[Principal, TokenAmount, string], Result_1>,
   'unlockTokens' : ActorMethod<[Principal, TokenAmount, string], Result_1>,
   'withdraw' : ActorMethod<

--- a/src/dao_frontend/src/declarations/treasury/treasury.did.js
+++ b/src/dao_frontend/src/declarations/treasury/treasury.did.js
@@ -35,7 +35,7 @@ export const idlFactory = ({ IDL }) => {
     'available' : TokenAmount,
   });
   return IDL.Service({
-    'addAuthorizedPrincipal' : IDL.Func([IDL.Principal], [Result_1], []),
+    'addAuthorizedPrincipal' : IDL.Func([Principal, IDL.Principal], [Result_1], []),
     'deposit' : IDL.Func([Principal, TokenAmount, IDL.Text], [Result], []),
     'getAllTransactions' : IDL.Func(
         [Principal],
@@ -43,7 +43,7 @@ export const idlFactory = ({ IDL }) => {
         ['query'],
       ),
     'getAuthorizedPrincipals' : IDL.Func(
-        [],
+        [Principal],
         [IDL.Vec(IDL.Principal)],
         ['query'],
       ),
@@ -78,7 +78,7 @@ export const idlFactory = ({ IDL }) => {
       ),
     'lockTokens' : IDL.Func([Principal, TokenAmount, IDL.Text], [Result_1], []),
     'releaseReservedTokens' : IDL.Func([Principal, TokenAmount, IDL.Text], [Result_1], []),
-    'removeAuthorizedPrincipal' : IDL.Func([IDL.Principal], [Result_1], []),
+    'removeAuthorizedPrincipal' : IDL.Func([Principal, IDL.Principal], [Result_1], []),
     'reserveTokens' : IDL.Func([Principal, TokenAmount, IDL.Text], [Result_1], []),
     'unlockTokens' : IDL.Func([Principal, TokenAmount, IDL.Text], [Result_1], []),
     'withdraw' : IDL.Func(

--- a/src/dao_frontend/src/hooks/useTreasury.js
+++ b/src/dao_frontend/src/hooks/useTreasury.js
@@ -207,12 +207,16 @@ export const useTreasury = () => {
     }
   };
 
-  const addAuthorizedPrincipal = async (principalId) => {
+  const addAuthorizedPrincipal = async (daoId, principalId) => {
     setLoading(true);
     setError(null);
     try {
+      const daoPrincipal = Principal.fromText(daoId);
       const principal = Principal.fromText(principalId);
-      const res = await actors.treasury.addAuthorizedPrincipal(principal);
+      const res = await actors.treasury.addAuthorizedPrincipal(
+        daoPrincipal,
+        principal
+      );
       if ('err' in res) throw new Error(res.err);
       return res.ok;
     } catch (err) {
@@ -223,12 +227,16 @@ export const useTreasury = () => {
     }
   };
 
-  const removeAuthorizedPrincipal = async (principalId) => {
+  const removeAuthorizedPrincipal = async (daoId, principalId) => {
     setLoading(true);
     setError(null);
     try {
+      const daoPrincipal = Principal.fromText(daoId);
       const principal = Principal.fromText(principalId);
-      const res = await actors.treasury.removeAuthorizedPrincipal(principal);
+      const res = await actors.treasury.removeAuthorizedPrincipal(
+        daoPrincipal,
+        principal
+      );
       if ('err' in res) throw new Error(res.err);
       return res.ok;
     } catch (err) {
@@ -239,11 +247,12 @@ export const useTreasury = () => {
     }
   };
 
-  const getAuthorizedPrincipals = async () => {
+  const getAuthorizedPrincipals = async (daoId) => {
     setLoading(true);
     setError(null);
     try {
-      const res = await actors.treasury.getAuthorizedPrincipals();
+      const daoPrincipal = Principal.fromText(daoId);
+      const res = await actors.treasury.getAuthorizedPrincipals(daoPrincipal);
       return res.map((p) => (typeof p.toText === 'function' ? p.toText() : p));
     } catch (err) {
       setError(err.message);


### PR DESCRIPTION
## Summary
- use HashMap keyed by DAO for treasury authorized principals
- require daoId when adding, removing, or listing authorized principals
- pass active DAO id from hooks and components and update Candid declarations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1d78e1df48320bda53a6a877475e5