### PR TITLE
Add DAO identifier to governance calls

### DIFF
--- a/src/dao_frontend/src/config/agent.ts
+++ b/src/dao_frontend/src/config/agent.ts
@@ -168,6 +168,7 @@ const handleOptionalActor = async <T>(
 
 export const initializeAgents = async (
   canisterIds: CanisterIds,
+  daoId: string,
   identity?: Identity
 ): Promise<Actors> => {
   try {
@@ -185,7 +186,7 @@ export const initializeAgents = async (
     );
 
     const governance = await handleOptionalActor<GovernanceService>(
-      canisterIds.governance,
+      canisterIds.governance || daoId,
       governanceIdl,
       "GOVERNANCE",
       identity

--- a/src/dao_frontend/src/context/ActorContext.tsx
+++ b/src/dao_frontend/src/context/ActorContext.tsx
@@ -40,6 +40,7 @@ export const ActorProvider = ({ children }: ActorProviderProps) => {
           }
           const initializedActors = await initializeAgents(
             selectedDAO.canisterIds,
+            selectedDAO.id,
             identity
           );
           setActors(initializedActors);

--- a/src/dao_frontend/src/context/AuthContext.test.jsx
+++ b/src/dao_frontend/src/context/AuthContext.test.jsx
@@ -80,7 +80,11 @@ describe('AuthContext', () => {
     });
 
     await waitFor(() => {
-      expect(initializeAgents).toHaveBeenCalledWith(mockDAO.canisterIds, mockIdentity);
+      expect(initializeAgents).toHaveBeenCalledWith(
+        mockDAO.canisterIds,
+        mockDAO.id,
+        mockIdentity
+      );
     });
   });
 });

--- a/src/dao_frontend/src/declarations/governance/governance.did
+++ b/src/dao_frontend/src/declarations/governance/governance.did
@@ -110,7 +110,7 @@ service : {
   getProposalVotes: (daoId: principal, proposalId: ProposalId) -> (vec Vote) query;
   getProposalsByStatus: (daoId: principal, status: ProposalStatus) -> (vec Proposal) query;
   getUserVote: (daoId: principal, proposalId: ProposalId, user: principal) -> (opt Vote) query;
-  init: (newDaoId: principal, newStakingId: principal) -> ();
+   init: (newDaoId: principal, newStakingId: principal, daoInstanceId: text) -> ();
   updateConfig: (daoId: principal, newConfig: GovernanceConfig) -> (Result);
   vote: (daoId: principal, proposalId: ProposalId, choice: VoteChoice, reason: opt text) ->
    (Result);

--- a/src/dao_frontend/src/declarations/governance/governance.did.d.ts
+++ b/src/dao_frontend/src/declarations/governance/governance.did.d.ts
@@ -95,7 +95,7 @@ export interface _SERVICE {
   'getProposalVotes' : ActorMethod<[Principal, ProposalId], Array<Vote>>,
   'getProposalsByStatus' : ActorMethod<[Principal, ProposalStatus], Array<Proposal>>,
   'getUserVote' : ActorMethod<[Principal, ProposalId, Principal], [] | [Vote]>,
-  'init' : ActorMethod<[Principal, Principal], undefined>,
+  'init' : ActorMethod<[Principal, Principal, string], undefined>,
   'updateConfig' : ActorMethod<[Principal, GovernanceConfig], Result>,
   'vote' : ActorMethod<[Principal, ProposalId, VoteChoice, [] | [string]], Result>,
 }

--- a/src/dao_frontend/src/declarations/governance/governance.did.js
+++ b/src/dao_frontend/src/declarations/governance/governance.did.js
@@ -107,7 +107,7 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Opt(Vote)],
         ['query'],
       ),
-    'init' : IDL.Func([IDL.Principal, IDL.Principal], [], []),
+    'init' : IDL.Func([IDL.Principal, IDL.Principal, IDL.Text], [], []),
     'updateConfig' : IDL.Func([Principal, GovernanceConfig], [Result], []),
     'vote' : IDL.Func(
         [Principal, ProposalId, VoteChoice, IDL.Opt(IDL.Text)],

--- a/src/dao_frontend/src/hooks/useGovernance.js
+++ b/src/dao_frontend/src/hooks/useGovernance.js
@@ -1,12 +1,20 @@
 import { useState } from 'react';
+import { Principal } from '@dfinity/principal';
 import { useActors } from '../context/ActorContext';
+import { useDAO } from '../context/DAOContext';
 
 export const useGovernance = () => {
   const actors = useActors();
+  const { activeDAO } = useDAO();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
   const toNanoseconds = (seconds) => BigInt(seconds) * 1_000_000_000n;
+
+  const getDaoPrincipal = () => {
+    if (!activeDAO?.id) throw new Error('No active DAO selected');
+    return Principal.fromText(activeDAO.id);
+  };
 
   const createProposal = async (
     title,
@@ -17,7 +25,9 @@ export const useGovernance = () => {
     setLoading(true);
     setError(null);
     try {
+      const daoPrincipal = getDaoPrincipal();
       const res = await actors.governance.createProposal(
+        daoPrincipal,
         title,
         description,
         proposalType,
@@ -38,7 +48,9 @@ export const useGovernance = () => {
     setError(null);
     try {
       const choiceVariant = { [choice]: null };
+      const daoPrincipal = getDaoPrincipal();
       const res = await actors.governance.vote(
+        daoPrincipal,
         BigInt(proposalId),
         choiceVariant,
         reason ? [reason] : []
@@ -57,9 +69,9 @@ export const useGovernance = () => {
     setLoading(true);
     setError(null);
     try {
-      const res = await actors.governance.getConfig();
-      if ('err' in res) throw new Error(res.err);
-      return 'ok' in res ? res.ok : res;
+      const daoPrincipal = getDaoPrincipal();
+      const res = await actors.governance.getConfig(daoPrincipal);
+      return res && res.length ? res[0] : null;
     } catch (err) {
       setError(err.message);
       throw err;
@@ -72,7 +84,8 @@ export const useGovernance = () => {
     setLoading(true);
     setError(null);
     try {
-      const res = await actors.governance.getGovernanceStats();
+      const daoPrincipal = getDaoPrincipal();
+      const res = await actors.governance.getGovernanceStats(daoPrincipal);
       return res;
     } catch (err) {
       setError(err.message);
@@ -86,7 +99,11 @@ export const useGovernance = () => {
     setLoading(true);
     setError(null);
     try {
-      const res = await actors.governance.executeProposal(BigInt(proposalId));
+      const daoPrincipal = getDaoPrincipal();
+      const res = await actors.governance.executeProposal(
+        daoPrincipal,
+        BigInt(proposalId)
+      );
       if ('err' in res) throw new Error(res.err);
       return res.ok;
     } catch (err) {
@@ -101,7 +118,8 @@ export const useGovernance = () => {
     setLoading(true);
     setError(null);
     try {
-      return await actors.governance.getActiveProposals();
+      const daoPrincipal = getDaoPrincipal();
+      return await actors.governance.getActiveProposals(daoPrincipal);
     } catch (err) {
       setError(err.message);
       throw err;
@@ -114,7 +132,8 @@ export const useGovernance = () => {
     setLoading(true);
     setError(null);
     try {
-      return await actors.governance.getAllProposals();
+      const daoPrincipal = getDaoPrincipal();
+      return await actors.governance.getAllProposals(daoPrincipal);
     } catch (err) {
       setError(err.message);
       throw err;
@@ -127,7 +146,11 @@ export const useGovernance = () => {
     setLoading(true);
     setError(null);
     try {
-      const res = await actors.governance.getProposal(BigInt(proposalId));
+      const daoPrincipal = getDaoPrincipal();
+      const res = await actors.governance.getProposal(
+        daoPrincipal,
+        BigInt(proposalId)
+      );
       return res && res.length ? res[0] : null;
     } catch (err) {
       setError(err.message);
@@ -141,7 +164,11 @@ export const useGovernance = () => {
     setLoading(true);
     setError(null);
     try {
-      return await actors.governance.getProposalVotes(BigInt(proposalId));
+      const daoPrincipal = getDaoPrincipal();
+      return await actors.governance.getProposalVotes(
+        daoPrincipal,
+        BigInt(proposalId)
+      );
     } catch (err) {
       setError(err.message);
       throw err;
@@ -155,7 +182,11 @@ export const useGovernance = () => {
     setError(null);
     try {
       const statusVariant = { [status]: null };
-      return await actors.governance.getProposalsByStatus(statusVariant);
+      const daoPrincipal = getDaoPrincipal();
+      return await actors.governance.getProposalsByStatus(
+        daoPrincipal,
+        statusVariant
+      );
     } catch (err) {
       setError(err.message);
       throw err;
@@ -168,9 +199,12 @@ export const useGovernance = () => {
     setLoading(true);
     setError(null);
     try {
+      const daoPrincipal = getDaoPrincipal();
+      const userPrincipal = Principal.fromText(user);
       const res = await actors.governance.getUserVote(
+        daoPrincipal,
         BigInt(proposalId),
-        user
+        userPrincipal
       );
       return res && res.length ? res[0] : null;
     } catch (err) {
@@ -185,7 +219,11 @@ export const useGovernance = () => {
     setLoading(true);
     setError(null);
     try {
-      const res = await actors.governance.updateConfig(newConfig);
+      const daoPrincipal = getDaoPrincipal();
+      const res = await actors.governance.updateConfig(
+        daoPrincipal,
+        newConfig
+      );
       if ('err' in res) throw new Error(res.err);
       return res.ok;
     } catch (err) {


### PR DESCRIPTION
## Summary
- regenerate governance.did to expose daoInstanceId in init
- pass active DAO id to governance hooks and actor initialization
- plumb DAO id through initializeAgents and related tests

## Testing
- `npm test` *(fails: Auth client not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_68a1d79cd63c8320a3fa47976cd0ab6a