### PR TITLE
Namespace staking state by DAO

### DIFF
--- a/src/dao_backend/governance/main.mo
+++ b/src/dao_backend/governance/main.mo
@@ -66,7 +66,7 @@ persistent actor GovernanceCanister {
     // Inter-canister communication setup
     // Actor reference for staking canister
     var staking : actor {
-        getUserStakingSummary: shared query (Principal) -> async {
+        getUserStakingSummary: shared query (Principal, Principal) -> async {
             totalStaked: Nat;
             totalRewards: Nat;
             activeStakes: Nat;
@@ -271,7 +271,7 @@ persistent actor GovernanceCanister {
         };
 
         // Determine voting power from staking data
-        let summary = await staking.getUserStakingSummary(caller);
+        let summary = await staking.getUserStakingSummary(daoId, caller);
         let votingPower = summary.totalVotingPower;
         if (votingPower == 0) {
             return #err("No voting power");

--- a/src/dao_backend/governance/main.test.mo
+++ b/src/dao_backend/governance/main.test.mo
@@ -12,7 +12,7 @@ actor {
             public query func checkIsAdmin(_: Types.DAOId, p: Principal) : async Bool { p == admin };
         };
         let stakingStub = actor {
-            public shared query func getUserStakingSummary(_: Principal) -> async {
+            public shared query func getUserStakingSummary(_: Principal, _: Principal) -> async {
                 totalStaked: Nat;
                 totalRewards: Nat;
                 activeStakes: Nat;

--- a/src/dao_backend/proposals/main.mo
+++ b/src/dao_backend/proposals/main.mo
@@ -54,7 +54,7 @@ persistent actor ProposalsCanister {
 
     // Inter-canister reference to staking for voting power
     var staking : actor {
-        getUserStakingSummary: shared query (Principal) -> async {
+        getUserStakingSummary: shared query (Principal, Principal) -> async {
             totalStaked: Nat;
             totalRewards: Nat;
             activeStakes: Nat;
@@ -318,7 +318,7 @@ persistent actor ProposalsCanister {
 
         // Determine voting power from staking
         let summary = try {
-            await staking.getUserStakingSummary(caller)
+            await staking.getUserStakingSummary(daoId, caller)
         } catch (_) {
             return #err("Failed to get staking summary");
         };

--- a/src/dao_backend/staking/main.mo
+++ b/src/dao_backend/staking/main.mo
@@ -49,15 +49,21 @@ persistent actor StakingCanister {
     // Stable storage for upgrade persistence
     // Core staking data that must survive canister upgrades
     private var nextStakeId : Nat = 1;
-    private var stakesEntries : [(StakeId, Stake)] = [];
-    private var userStakesEntries : [(Principal, [StakeId])] = [];
+    private var stakesEntries : [((Principal, StakeId), Stake)] = [];
+    private var userStakesEntries : [(Principal, [(Principal, [StakeId])])] = [];
     private var totalStakedAmount : TokenAmount = 0;
     private var totalRewardsDistributed : TokenAmount = 0;
 
     // Runtime storage - rebuilt from stable storage after upgrades
     // HashMaps provide efficient lookup and management of stake data
-    private transient var stakes = HashMap.HashMap<StakeId, Stake>(100, Nat.equal, func(n: Nat) : Nat32 { Nat32.fromNat(n) });
-    private transient var userStakes = HashMap.HashMap<Principal, [StakeId]>(50, Principal.equal, Principal.hash);
+    private func stakeKeyEqual(a: (Principal, StakeId), b: (Principal, StakeId)) : Bool {
+        Principal.equal(a.0, b.0) and Nat.equal(a.1, b.1)
+    };
+    private func stakeKeyHash(k: (Principal, StakeId)) : Nat32 {
+        Nat32.xor(Principal.hash(k.0), Nat32.fromNat(k.1))
+    };
+    private transient var stakes = HashMap.HashMap<(Principal, StakeId), Stake>(100, stakeKeyEqual, stakeKeyHash);
+    private transient var userStakes = HashMap.HashMap<Principal, HashMap.HashMap<Principal, [StakeId]>>(50, Principal.equal, Principal.hash);
 
     // Staking configuration parameters
     // These control the economic parameters of the staking system
@@ -68,22 +74,30 @@ persistent actor StakingCanister {
     // System functions for upgrades
     system func preupgrade() {
         stakesEntries := Iter.toArray(stakes.entries());
-        userStakesEntries := Iter.toArray(userStakes.entries());
+        userStakesEntries := Iter.toArray(
+            Iter.map(userStakes.entries(), func ((user, daoMap)) {
+                (user, Iter.toArray(daoMap.entries()))
+            })
+        );
     };
 
     system func postupgrade() {
-        stakes := HashMap.fromIter<StakeId, Stake>(
-            stakesEntries.vals(), 
-            stakesEntries.size(), 
-            Nat.equal, 
-            func(n: Nat) : Nat32 { Nat32.fromNat(n) }
+        stakes := HashMap.fromIter<(Principal, StakeId), Stake>(
+            stakesEntries.vals(),
+            stakesEntries.size(),
+            stakeKeyEqual,
+            stakeKeyHash
         );
-        userStakes := HashMap.fromIter<Principal, [StakeId]>(
-            userStakesEntries.vals(), 
-            userStakesEntries.size(), 
-            Principal.equal, 
-            Principal.hash
-        );
+        userStakes := HashMap.HashMap<Principal, HashMap.HashMap<Principal, [StakeId]>>(50, Principal.equal, Principal.hash);
+        for ((user, daoEntries) in userStakesEntries.vals()) {
+            let daoMap = HashMap.fromIter<Principal, [StakeId]>(
+                daoEntries.vals(),
+                daoEntries.size(),
+                Principal.equal,
+                Principal.hash
+            );
+            userStakes.put(user, daoMap);
+        };
     };
 
     // Public functions
@@ -122,15 +136,20 @@ persistent actor StakingCanister {
             isActive = true;
         };
 
-        stakes.put(stakeId, newStake);
-        
+        stakes.put((daoId, stakeId), newStake);
+
         // Update user stakes
-        let currentUserStakes = switch (userStakes.get(caller)) {
+        let daoMap = switch (userStakes.get(caller)) {
+            case (?map) map;
+            case null HashMap.HashMap<Principal, [StakeId]>(1, Principal.equal, Principal.hash);
+        };
+        let currentUserStakes = switch (daoMap.get(daoId)) {
             case (?stakes) stakes;
             case null [];
         };
         let updatedUserStakes = Array.append<StakeId>(currentUserStakes, [stakeId]);
-        userStakes.put(caller, updatedUserStakes);
+        daoMap.put(daoId, updatedUserStakes);
+        userStakes.put(caller, daoMap);
 
         // Update total staked amount
         totalStakedAmount += amount;
@@ -142,7 +161,7 @@ persistent actor StakingCanister {
     public shared(msg) func unstake(daoId: Principal, stakeId: StakeId) : async Result<TokenAmount, Text> {
         let caller = msg.caller;
 
-        let stake = switch (stakes.get(stakeId)) {
+        let stake = switch (stakes.get((daoId, stakeId))) {
             case (?s) s;
             case null return #err("Stake not found");
         };
@@ -181,7 +200,7 @@ persistent actor StakingCanister {
             rewards = finalRewards;
             isActive = false;
         };
-        stakes.put(stakeId, updatedStake);
+        stakes.put((daoId, stakeId), updatedStake);
 
         // Update total staked amount
         totalStakedAmount -= stake.amount;
@@ -194,7 +213,7 @@ persistent actor StakingCanister {
     public shared(msg) func claimRewards(daoId: Principal, stakeId: StakeId) : async Result<TokenAmount, Text> {
         let caller = msg.caller;
 
-        let stake = switch (stakes.get(stakeId)) {
+        let stake = switch (stakes.get((daoId, stakeId))) {
             case (?s) s;
             case null return #err("Stake not found");
         };
@@ -234,7 +253,7 @@ persistent actor StakingCanister {
             rewards = currentRewards;
             isActive = stake.isActive;
         };
-        stakes.put(stakeId, updatedStake);
+        stakes.put((daoId, stakeId), updatedStake);
 
         totalRewardsDistributed += claimableRewards;
 
@@ -245,7 +264,7 @@ persistent actor StakingCanister {
     public shared(msg) func extendStakingPeriod(daoId: Principal, stakeId: StakeId, newPeriod: StakingPeriod) : async Result<(), Text> {
         let caller = msg.caller;
 
-        let stake = switch (stakes.get(stakeId)) {
+        let stake = switch (stakes.get((daoId, stakeId))) {
             case (?s) s;
             case null return #err("Stake not found");
         };
@@ -275,7 +294,7 @@ persistent actor StakingCanister {
             rewards = stake.rewards;
             isActive = stake.isActive;
         };
-        stakes.put(stakeId, updatedStake);
+        stakes.put((daoId, stakeId), updatedStake);
 
         #ok()
     };
@@ -283,21 +302,25 @@ persistent actor StakingCanister {
     // Query functions
 
     // Get stake by ID
-    public query func getStake(stakeId: StakeId) : async ?Stake {
-        stakes.get(stakeId)
+    public query func getStake(daoId: Principal, stakeId: StakeId) : async ?Stake {
+        stakes.get((daoId, stakeId))
     };
 
     // Get user's stakes
     // Private version for internal use
-    private func getUserStakesInternal(user: Principal) : [Stake] {
-        let stakeIds = switch (userStakes.get(user)) {
+    private func getUserStakesInternal(daoId: Principal, user: Principal) : [Stake] {
+        let daoMap = switch (userStakes.get(user)) {
+            case (?map) map;
+            case null return [];
+        };
+        let stakeIds = switch (daoMap.get(daoId)) {
             case (?ids) ids;
             case null return [];
         };
 
         let userStakesList = Buffer.Buffer<Stake>(0);
         for (stakeId in stakeIds.vals()) {
-            switch (stakes.get(stakeId)) {
+            switch (stakes.get((daoId, stakeId))) {
                 case (?stake) userStakesList.add(stake);
                 case null {};
             };
@@ -305,20 +328,19 @@ persistent actor StakingCanister {
         Buffer.toArray(userStakesList)
     };
 
-
-    public query func getUserStakes(user: Principal) : async [Stake] {
-        getUserStakesInternal(user)
+    public query func getUserStakes(daoId: Principal, user: Principal) : async [Stake] {
+        getUserStakesInternal(daoId, user)
     };
 
     // Get user's active stakes
-    public query func getUserActiveStakes(user: Principal) : async [Stake] {
-    let allUserStakes = getUserStakesInternal(user);
+    public query func getUserActiveStakes(daoId: Principal, user: Principal) : async [Stake] {
+        let allUserStakes = getUserStakesInternal(daoId, user);
         Array.filter<Stake>(allUserStakes, func(stake) = stake.isActive)
     };
 
     // Get staking rewards for a stake
-    public query func getStakingRewards(stakeId: StakeId) : async ?StakingRewards {
-        switch (stakes.get(stakeId)) {
+    public query func getStakingRewards(daoId: Principal, stakeId: StakeId) : async ?StakingRewards {
+        switch (stakes.get((daoId, stakeId))) {
             case (?stake) {
                 let totalRewards = calculateRewards(stake);
                 let claimableRewards: Nat =
@@ -342,13 +364,13 @@ persistent actor StakingCanister {
     };
 
     // Get user's total staking summary
-    public query func getUserStakingSummary(user: Principal) : async {
+    public query func getUserStakingSummary(daoId: Principal, user: Principal) : async {
         totalStaked: TokenAmount;
         totalRewards: TokenAmount;
         activeStakes: Nat;
         totalVotingPower: Nat;
     } {
-        let userStakesList = getUserStakesInternal(user);
+        let userStakesList = getUserStakesInternal(daoId, user);
         var totalStaked : TokenAmount = 0;
         var totalRewards : TokenAmount = 0;
         var activeStakes : Nat = 0;
@@ -372,7 +394,7 @@ persistent actor StakingCanister {
     };
 
     // Get staking statistics
-    public query func getStakingStats() : async {
+    public query func getStakingStats(daoId: Principal) : async {
         totalStakes: Nat;
         activeStakes: Nat;
         totalStakedAmount: TokenAmount;
@@ -380,7 +402,10 @@ persistent actor StakingCanister {
         averageStakeAmount: Float;
         stakingPeriodDistribution: [(StakingPeriod, Nat)];
     } {
-        var activeStakes : Nat = 0;
+        var totalStakesDao : Nat = 0;
+        var activeStakesDao : Nat = 0;
+        var totalStakedAmountDao : TokenAmount = 0;
+        var totalRewardsDistributedDao : TokenAmount = 0;
         var instantCount : Nat = 0;
         var locked30Count : Nat = 0;
         var locked90Count : Nat = 0;
@@ -388,27 +413,32 @@ persistent actor StakingCanister {
         var locked365Count : Nat = 0;
 
         for (stake in stakes.vals()) {
-            if (stake.isActive) {
-                activeStakes += 1;
-                switch (stake.stakingPeriod) {
-                    case (#instant) instantCount += 1;
-                    case (#locked30) locked30Count += 1;
-                    case (#locked90) locked90Count += 1;
-                    case (#locked180) locked180Count += 1;
-                    case (#locked365) locked365Count += 1;
+            if (Principal.equal(stake.daoId, daoId)) {
+                totalStakesDao += 1;
+                totalRewardsDistributedDao += stake.rewards;
+                if (stake.isActive) {
+                    activeStakesDao += 1;
+                    totalStakedAmountDao += stake.amount;
+                    switch (stake.stakingPeriod) {
+                        case (#instant) instantCount += 1;
+                        case (#locked30) locked30Count += 1;
+                        case (#locked90) locked90Count += 1;
+                        case (#locked180) locked180Count += 1;
+                        case (#locked365) locked365Count += 1;
+                    };
                 };
             };
         };
 
-        let averageAmount = if (activeStakes > 0) {
-            Float.fromInt(totalStakedAmount) / Float.fromInt(activeStakes)
+        let averageAmount = if (activeStakesDao > 0) {
+            Float.fromInt(totalStakedAmountDao) / Float.fromInt(activeStakesDao)
         } else { 0.0 };
 
         {
-            totalStakes = stakes.size();
-            activeStakes = activeStakes;
-            totalStakedAmount = totalStakedAmount;
-            totalRewardsDistributed = totalRewardsDistributed;
+            totalStakes = totalStakesDao;
+            activeStakes = activeStakesDao;
+            totalStakedAmount = totalStakedAmountDao;
+            totalRewardsDistributed = totalRewardsDistributedDao;
             averageStakeAmount = averageAmount;
             stakingPeriodDistribution = [
                 (#instant, instantCount),

--- a/src/dao_frontend/src/components/Staking.jsx
+++ b/src/dao_frontend/src/components/Staking.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useStaking } from '../hooks/useStaking';
 import { useAuth } from '../context/AuthContext';
+import { useDAO } from '../context/DAOContext';
 
 const Staking = () => {
   const {
@@ -18,6 +19,8 @@ const Staking = () => {
     error,
   } = useStaking();
   const { principal } = useAuth();
+  const { activeDAO } = useDAO();
+  const daoId = activeDAO?.id;
   const [amount, setAmount] = useState('');
   const [period, setPeriod] = useState('instant');
   const [unstakeId, setUnstakeId] = useState('');
@@ -35,7 +38,7 @@ const Staking = () => {
   const handleStake = async (e) => {
     e.preventDefault();
     try {
-      const id = await stake(amount, period);
+      const id = await stake(daoId, amount, period);
       console.log('Stake created:', id);
       setAmount('');
     } catch (err) {
@@ -46,7 +49,7 @@ const Staking = () => {
   const handleUnstake = async (e) => {
     e.preventDefault();
     try {
-      const amount = await unstake(unstakeId);
+      const amount = await unstake(daoId, unstakeId);
       console.log('Unstaked amount:', amount);
       setUnstakeId('');
     } catch (err) {
@@ -58,7 +61,7 @@ const Staking = () => {
     e.preventDefault();
     try {
       setFetchError(null);
-      const stakeRes = await getStake(fetchId);
+      const stakeRes = await getStake(daoId, fetchId);
       if (!stakeRes || stakeRes.length === 0) {
         setFetchedStake(null);
         setPendingRewards(null);
@@ -66,7 +69,7 @@ const Staking = () => {
         return;
       }
       setFetchedStake(stakeRes[0]);
-      const rewardsRes = await getStakingRewards(fetchId);
+      const rewardsRes = await getStakingRewards(daoId, fetchId);
       setPendingRewards(rewardsRes[0] || null);
     } catch (err) {
       console.error(err);
@@ -76,7 +79,7 @@ const Staking = () => {
 
   const handleClaimFetched = async () => {
     try {
-      const rewards = await claimRewards(fetchId);
+      const rewards = await claimRewards(daoId, fetchId);
       console.log('Rewards claimed:', rewards);
       setFetchId('');
       setFetchedStake(null);
@@ -88,7 +91,7 @@ const Staking = () => {
 
   const handleSummary = async () => {
     try {
-      const res = await getUserStakingSummary(principal);
+      const res = await getUserStakingSummary(daoId, principal);
       setSummary(res);
     } catch (err) {
       console.error(err);
@@ -98,7 +101,7 @@ const Staking = () => {
   const handleExtend = async (e) => {
     e.preventDefault();
     try {
-      await extendStakingPeriod(extendId, extendPeriod);
+      await extendStakingPeriod(daoId, extendId, extendPeriod);
       setExtendId('');
     } catch (err) {
       console.error(err);

--- a/src/dao_frontend/src/components/management/ManagementStaking.tsx
+++ b/src/dao_frontend/src/components/management/ManagementStaking.tsx
@@ -63,9 +63,12 @@ const ManagementStaking: React.FC = () => {
     if (!actors?.staking) return;
     try {
       const principalId = principal ? Principal.fromText(principal) : undefined;
+      const daoPrincipal = Principal.fromText(dao.id);
       const [stats, stakes] = await Promise.all([
-        actors.staking.getStakingStats(),
-        principalId ? actors.staking.getUserStakes(principalId) : Promise.resolve([])
+        actors.staking.getStakingStats(daoPrincipal),
+        principalId
+          ? actors.staking.getUserStakes(daoPrincipal, principalId)
+          : Promise.resolve([])
       ]);
 
       setUserStakes(stakes);
@@ -141,7 +144,7 @@ const ManagementStaking: React.FC = () => {
             const period = prompt('Staking period (instant, locked30, locked90, locked180, locked365)?');
             if (!amount || !period) return;
             try {
-              await stake(amount, period);
+              await stake(dao.id, amount, period);
               await fetchData();
             } catch (e) {
               console.error(e);
@@ -252,7 +255,7 @@ const ManagementStaking: React.FC = () => {
                   const amount = prompt('Amount to stake?');
                   if (!amount) return;
                   try {
-                    await stake(amount, pool.periodKey);
+                    await stake(dao.id, amount, pool.periodKey);
                     await fetchData();
                   } catch (e) {
                     console.error(e);
@@ -311,7 +314,7 @@ const ManagementStaking: React.FC = () => {
                   className="flex-1 py-2 bg-green-500/20 border border-green-500/30 text-green-400 rounded-lg hover:bg-green-500/30 transition-colors font-mono"
                   onClick={async () => {
                     try {
-                      await claimRewards(stake.id);
+                      await claimRewards(dao.id, stake.id);
                       await fetchData();
                     } catch (e) {
                       console.error(e);
@@ -324,7 +327,7 @@ const ManagementStaking: React.FC = () => {
                   className="flex-1 py-2 bg-red-500/20 border border-red-500/30 text-red-400 rounded-lg hover:bg-red-500/30 transition-colors font-mono"
                   onClick={async () => {
                     try {
-                      await unstake(stake.id);
+                      await unstake(dao.id, stake.id);
                       await fetchData();
                     } catch (e) {
                       console.error(e);

--- a/src/dao_frontend/src/components/management/Overview.tsx
+++ b/src/dao_frontend/src/components/management/Overview.tsx
@@ -3,7 +3,6 @@ import { motion } from 'framer-motion';
 import { useOutletContext } from 'react-router-dom';
 
 import { useProposals } from '../../hooks/useProposals';
-import { useStaking } from '../../hooks/useStaking';
 import { useTreasury } from '../../hooks/useTreasury';
 import { useNavigate } from 'react-router-dom';
 import { 
@@ -29,7 +28,6 @@ const Overview: React.FC = () => {
   const { dao } = useOutletContext<{ dao: DAO }>();
   const { daoBackend } = useActors();
   const { createProposal } = useProposals();
-  const { stake } = useStaking();
   const { getBalance } = useTreasury();
   const navigate = useNavigate();
 

--- a/src/dao_frontend/src/declarations/staking/staking.did
+++ b/src/dao_frontend/src/declarations/staking/staking.did
@@ -16,8 +16,9 @@ type StakingPeriod =
    locked90;
  };
 type StakeId = nat;
-type Stake = 
+type Stake =
  record {
+   daoId: Principal;
    amount: TokenAmount;
    id: StakeId;
    isActive: bool;
@@ -44,12 +45,12 @@ type Result =
  };
 type Principal = principal;
 service : {
-  claimRewards: (stakeId: StakeId) -> (Result);
-  extendStakingPeriod: (stakeId: StakeId, newPeriod: StakingPeriod) ->
+  claimRewards: (daoId: Principal, stakeId: StakeId) -> (Result);
+  extendStakingPeriod: (daoId: Principal, stakeId: StakeId, newPeriod: StakingPeriod) ->
    (Result_2);
-  getStake: (stakeId: StakeId) -> (opt Stake) query;
-  getStakingRewards: (stakeId: StakeId) -> (opt StakingRewards) query;
-  getStakingStats: () ->
+  getStake: (daoId: Principal, stakeId: StakeId) -> (opt Stake) query;
+  getStakingRewards: (daoId: Principal, stakeId: StakeId) -> (opt StakingRewards) query;
+  getStakingStats: (daoId: Principal) ->
    (record {
       activeStakes: nat;
       averageStakeAmount: float64;
@@ -61,9 +62,9 @@ service : {
       totalStakedAmount: TokenAmount;
       totalStakes: nat;
     }) query;
-  getUserActiveStakes: (user: principal) -> (vec Stake) query;
-  getUserStakes: (user: principal) -> (vec Stake) query;
-  getUserStakingSummary: (user: principal) ->
+  getUserActiveStakes: (daoId: Principal, user: principal) -> (vec Stake) query;
+  getUserStakes: (daoId: Principal, user: principal) -> (vec Stake) query;
+  getUserStakingSummary: (daoId: Principal, user: principal) ->
    (record {
       activeStakes: nat;
       totalRewards: TokenAmount;
@@ -73,6 +74,6 @@ service : {
   setMaximumStakeAmount: (amount: TokenAmount) -> (Result_2);
   setMinimumStakeAmount: (amount: TokenAmount) -> (Result_2);
   setStakingEnabled: (enabled: bool) -> (Result_2);
-  stake: (amount: TokenAmount, period: StakingPeriod) -> (Result_1);
-  unstake: (stakeId: StakeId) -> (Result);
+  stake: (daoId: Principal, amount: TokenAmount, period: StakingPeriod) -> (Result_1);
+  unstake: (daoId: Principal, stakeId: StakeId) -> (Result);
 }

--- a/src/dao_frontend/src/declarations/staking/staking.did.d.ts
+++ b/src/dao_frontend/src/declarations/staking/staking.did.d.ts
@@ -10,6 +10,7 @@ export type Result_1 = { 'ok' : StakeId } |
 export type Result_2 = { 'ok' : null } |
   { 'err' : string };
 export interface Stake {
+  'daoId' : Principal,
   'id' : StakeId,
   'staker' : Principal,
   'unlocksAt' : [] | [Time],
@@ -34,12 +35,15 @@ export interface StakingRewards {
 export type Time = bigint;
 export type TokenAmount = bigint;
 export interface _SERVICE {
-  'claimRewards' : ActorMethod<[StakeId], Result>,
-  'extendStakingPeriod' : ActorMethod<[StakeId, StakingPeriod], Result_2>,
-  'getStake' : ActorMethod<[StakeId], [] | [Stake]>,
-  'getStakingRewards' : ActorMethod<[StakeId], [] | [StakingRewards]>,
+  'claimRewards' : ActorMethod<[Principal, StakeId], Result>,
+  'extendStakingPeriod' : ActorMethod<
+    [Principal, StakeId, StakingPeriod],
+    Result_2
+  >,
+  'getStake' : ActorMethod<[Principal, StakeId], [] | [Stake]>,
+  'getStakingRewards' : ActorMethod<[Principal, StakeId], [] | [StakingRewards]>,
   'getStakingStats' : ActorMethod<
-    [],
+    [Principal],
     {
       'stakingPeriodDistribution' : Array<[StakingPeriod, bigint]>,
       'averageStakeAmount' : number,
@@ -49,10 +53,10 @@ export interface _SERVICE {
       'totalStakedAmount' : TokenAmount,
     }
   >,
-  'getUserActiveStakes' : ActorMethod<[Principal], Array<Stake>>,
-  'getUserStakes' : ActorMethod<[Principal], Array<Stake>>,
+  'getUserActiveStakes' : ActorMethod<[Principal, Principal], Array<Stake>>,
+  'getUserStakes' : ActorMethod<[Principal, Principal], Array<Stake>>,
   'getUserStakingSummary' : ActorMethod<
-    [Principal],
+    [Principal, Principal],
     {
       'totalRewards' : TokenAmount,
       'totalVotingPower' : bigint,
@@ -63,8 +67,8 @@ export interface _SERVICE {
   'setMaximumStakeAmount' : ActorMethod<[TokenAmount], Result_2>,
   'setMinimumStakeAmount' : ActorMethod<[TokenAmount], Result_2>,
   'setStakingEnabled' : ActorMethod<[boolean], Result_2>,
-  'stake' : ActorMethod<[TokenAmount, StakingPeriod], Result_1>,
-  'unstake' : ActorMethod<[StakeId], Result>,
+  'stake' : ActorMethod<[Principal, TokenAmount, StakingPeriod], Result_1>,
+  'unstake' : ActorMethod<[Principal, StakeId], Result>,
 }
 export declare const idlFactory: IDL.InterfaceFactory;
 export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/src/dao_frontend/src/declarations/staking/staking.did.js
+++ b/src/dao_frontend/src/declarations/staking/staking.did.js
@@ -13,14 +13,15 @@ export const idlFactory = ({ IDL }) => {
   const Principal = IDL.Principal;
   const Time = IDL.Int;
   const Stake = IDL.Record({
-    'id' : StakeId,
-    'staker' : Principal,
-    'unlocksAt' : IDL.Opt(Time),
-    'stakedAt' : Time,
-    'isActive' : IDL.Bool,
-    'stakingPeriod' : StakingPeriod,
-    'rewards' : TokenAmount,
+    'daoId' : Principal,
     'amount' : TokenAmount,
+    'id' : StakeId,
+    'isActive' : IDL.Bool,
+    'rewards' : TokenAmount,
+    'stakedAt' : Time,
+    'staker' : Principal,
+    'stakingPeriod' : StakingPeriod,
+    'unlocksAt' : IDL.Opt(Time),
   });
   const StakingRewards = IDL.Record({
     'apr' : IDL.Float64,
@@ -30,16 +31,20 @@ export const idlFactory = ({ IDL }) => {
   });
   const Result_1 = IDL.Variant({ 'ok' : StakeId, 'err' : IDL.Text });
   return IDL.Service({
-    'claimRewards' : IDL.Func([StakeId], [Result], []),
-    'extendStakingPeriod' : IDL.Func([StakeId, StakingPeriod], [Result_2], []),
-    'getStake' : IDL.Func([StakeId], [IDL.Opt(Stake)], ['query']),
+    'claimRewards' : IDL.Func([Principal, StakeId], [Result], []),
+    'extendStakingPeriod' : IDL.Func(
+        [Principal, StakeId, StakingPeriod],
+        [Result_2],
+        [],
+      ),
+    'getStake' : IDL.Func([Principal, StakeId], [IDL.Opt(Stake)], ['query']),
     'getStakingRewards' : IDL.Func(
-        [StakeId],
+        [Principal, StakeId],
         [IDL.Opt(StakingRewards)],
         ['query'],
       ),
     'getStakingStats' : IDL.Func(
-        [],
+        [Principal],
         [
           IDL.Record({
             'stakingPeriodDistribution' : IDL.Vec(
@@ -55,13 +60,17 @@ export const idlFactory = ({ IDL }) => {
         ['query'],
       ),
     'getUserActiveStakes' : IDL.Func(
-        [IDL.Principal],
+        [Principal, IDL.Principal],
         [IDL.Vec(Stake)],
         ['query'],
       ),
-    'getUserStakes' : IDL.Func([IDL.Principal], [IDL.Vec(Stake)], ['query']),
+    'getUserStakes' : IDL.Func(
+        [Principal, IDL.Principal],
+        [IDL.Vec(Stake)],
+        ['query'],
+      ),
     'getUserStakingSummary' : IDL.Func(
-        [IDL.Principal],
+        [Principal, IDL.Principal],
         [
           IDL.Record({
             'totalRewards' : TokenAmount,
@@ -75,8 +84,8 @@ export const idlFactory = ({ IDL }) => {
     'setMaximumStakeAmount' : IDL.Func([TokenAmount], [Result_2], []),
     'setMinimumStakeAmount' : IDL.Func([TokenAmount], [Result_2], []),
     'setStakingEnabled' : IDL.Func([IDL.Bool], [Result_2], []),
-    'stake' : IDL.Func([TokenAmount, StakingPeriod], [Result_1], []),
-    'unstake' : IDL.Func([StakeId], [Result], []),
+    'stake' : IDL.Func([Principal, TokenAmount, StakingPeriod], [Result_1], []),
+    'unstake' : IDL.Func([Principal, StakeId], [Result], []),
   });
 };
 export const init = ({ IDL }) => { return []; };

--- a/src/dao_frontend/src/hooks/useStaking.js
+++ b/src/dao_frontend/src/hooks/useStaking.js
@@ -7,12 +7,17 @@ export const useStaking = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
-  const stake = async (amount, period) => {
+  const stake = async (daoId, amount, period) => {
     setLoading(true);
     setError(null);
     try {
+      const daoPrincipal = Principal.fromText(daoId);
       const periodVariant = { [period]: null };
-      const res = await actors.staking.stake(BigInt(amount), periodVariant);
+      const res = await actors.staking.stake(
+        daoPrincipal,
+        BigInt(amount),
+        periodVariant
+      );
       if ('err' in res) throw new Error(res.err);
       return res.ok;
     } catch (err) {
@@ -23,11 +28,15 @@ export const useStaking = () => {
     }
   };
 
-  const unstake = async (stakeId) => {
+  const unstake = async (daoId, stakeId) => {
     setLoading(true);
     setError(null);
     try {
-      const res = await actors.staking.unstake(BigInt(stakeId));
+      const daoPrincipal = Principal.fromText(daoId);
+      const res = await actors.staking.unstake(
+        daoPrincipal,
+        BigInt(stakeId)
+      );
       if ('err' in res) throw new Error(res.err);
       return res.ok;
     } catch (err) {
@@ -38,11 +47,15 @@ export const useStaking = () => {
     }
   };
 
-  const claimRewards = async (stakeId) => {
+  const claimRewards = async (daoId, stakeId) => {
     setLoading(true);
     setError(null);
     try {
-      const res = await actors.staking.claimRewards(BigInt(stakeId));
+      const daoPrincipal = Principal.fromText(daoId);
+      const res = await actors.staking.claimRewards(
+        daoPrincipal,
+        BigInt(stakeId)
+      );
       if ('err' in res) throw new Error(res.err);
       return res.ok;
     } catch (err) {
@@ -53,12 +66,14 @@ export const useStaking = () => {
     }
   };
 
-  const extendStakingPeriod = async (stakeId, newPeriod) => {
+  const extendStakingPeriod = async (daoId, stakeId, newPeriod) => {
     setLoading(true);
     setError(null);
     try {
       const periodVariant = { [newPeriod]: null };
+      const daoPrincipal = Principal.fromText(daoId);
       const res = await actors.staking.extendStakingPeriod(
+        daoPrincipal,
         BigInt(stakeId),
         periodVariant
       );
@@ -72,11 +87,12 @@ export const useStaking = () => {
     }
   };
 
-  const getStake = async (stakeId) => {
+  const getStake = async (daoId, stakeId) => {
     setLoading(true);
     setError(null);
     try {
-      return await actors.staking.getStake(BigInt(stakeId));
+      const daoPrincipal = Principal.fromText(daoId);
+      return await actors.staking.getStake(daoPrincipal, BigInt(stakeId));
     } catch (err) {
       setError(err.message);
       throw err;
@@ -85,11 +101,15 @@ export const useStaking = () => {
     }
   };
 
-  const getStakingRewards = async (stakeId) => {
+  const getStakingRewards = async (daoId, stakeId) => {
     setLoading(true);
     setError(null);
     try {
-      return await actors.staking.getStakingRewards(BigInt(stakeId));
+      const daoPrincipal = Principal.fromText(daoId);
+      return await actors.staking.getStakingRewards(
+        daoPrincipal,
+        BigInt(stakeId)
+      );
     } catch (err) {
       setError(err.message);
       throw err;
@@ -98,11 +118,12 @@ export const useStaking = () => {
     }
   };
 
-  const getStakingStats = async () => {
+  const getStakingStats = async (daoId) => {
     setLoading(true);
     setError(null);
     try {
-      return await actors.staking.getStakingStats();
+      const daoPrincipal = Principal.fromText(daoId);
+      return await actors.staking.getStakingStats(daoPrincipal);
     } catch (err) {
       setError(err.message);
       throw err;
@@ -111,12 +132,13 @@ export const useStaking = () => {
     }
   };
 
-  const getUserStakes = async (user) => {
+  const getUserStakes = async (daoId, user) => {
     setLoading(true);
     setError(null);
     try {
       const principal = Principal.fromText(user);
-      return await actors.staking.getUserStakes(principal);
+      const daoPrincipal = Principal.fromText(daoId);
+      return await actors.staking.getUserStakes(daoPrincipal, principal);
     } catch (err) {
       setError(err.message);
       throw err;
@@ -125,12 +147,13 @@ export const useStaking = () => {
     }
   };
 
-  const getUserActiveStakes = async (user) => {
+  const getUserActiveStakes = async (daoId, user) => {
     setLoading(true);
     setError(null);
     try {
       const principal = Principal.fromText(user);
-      return await actors.staking.getUserActiveStakes(principal);
+      const daoPrincipal = Principal.fromText(daoId);
+      return await actors.staking.getUserActiveStakes(daoPrincipal, principal);
     } catch (err) {
       setError(err.message);
       throw err;
@@ -139,12 +162,16 @@ export const useStaking = () => {
     }
   };
 
-  const getUserStakingSummary = async (user) => {
+  const getUserStakingSummary = async (daoId, user) => {
     setLoading(true);
     setError(null);
     try {
       const principal = Principal.fromText(user);
-      return await actors.staking.getUserStakingSummary(principal);
+      const daoPrincipal = Principal.fromText(daoId);
+      return await actors.staking.getUserStakingSummary(
+        daoPrincipal,
+        principal
+      );
     } catch (err) {
       setError(err.message);
       throw err;


### PR DESCRIPTION
## Summary
- key stakes by `(daoId, stakeId)` and maintain user stakes per DAO
- require `daoId` for all staking queries and operations and pass it through governance, proposals, and frontend hooks
- regenerate `staking.did` and update React components to send the active DAO id

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1d78a4b048320a069b364f2343f57