### PR TITLE
Use Principal IDs for asset DAO references

### DIFF
--- a/src/dao_backend/assets/main.mo
+++ b/src/dao_backend/assets/main.mo
@@ -17,7 +17,7 @@ persistent actor AssetCanister {
 
     // Asset types
     public type AssetId = Nat;
-    public type DaoId = Nat;
+    public type DaoId = Principal;
     public type AssetData = Blob;
 
     public type AssetKey = {
@@ -74,7 +74,7 @@ persistent actor AssetCanister {
     };
 
     private func assetKeyHash(k: AssetKey) : Nat32 {
-        Nat32.fromNat(k.daoId * 1_000_003 + k.assetId)
+        Nat32.xor(Principal.hash(k.daoId), Nat32.fromNat(k.assetId))
     };
 
     private type UploaderKey = {
@@ -87,7 +87,7 @@ persistent actor AssetCanister {
     };
 
     private func uploaderKeyHash(k: UploaderKey) : Nat32 {
-        Nat32.xor(Nat32.fromNat(k.daoId), Principal.hash(k.uploader))
+        Nat32.xor(Principal.hash(k.daoId), Principal.hash(k.uploader))
     };
 
     private transient var assets = HashMap.HashMap<AssetKey, Asset>(100, assetKeyEqual, assetKeyHash);

--- a/src/dao_backend/assets/main.test.mo
+++ b/src/dao_backend/assets/main.test.mo
@@ -13,7 +13,7 @@ actor {
 
         // Upload should fail while no authorized uploaders exist.
         let data = Blob.fromArray([1,2,3]);
-        let uploadBefore = await Asset.uploadAsset(1, "test", "image/png", data, true, []);
+        let uploadBefore = await Asset.uploadAsset(selfPrincipal, "test", "image/png", data, true, []);
         assert uploadBefore == #err("Uploads are disabled until an uploader is authorized or open uploads are enabled");
 
         // Anyone can authorize the first uploader.
@@ -24,7 +24,7 @@ actor {
         assert Array.find<Principal>(uploaders, func(p) = p == selfPrincipal) != null;
 
         // After authorization, upload succeeds.
-        let uploadAfter = await Asset.uploadAsset(1, "test2", "image/png", data, true, []);
+        let uploadAfter = await Asset.uploadAsset(selfPrincipal, "test2", "image/png", data, true, []);
         switch uploadAfter { case (#ok(_)) {}; case (_) { assert false } };
 
         let duplicateRes = await Asset.addAuthorizedUploader(selfPrincipal);

--- a/src/dao_frontend/src/declarations/assets/assets.did
+++ b/src/dao_frontend/src/declarations/assets/assets.did
@@ -1,22 +1,23 @@
 type Time = int;
-type Result_2 = 
+type Result_2 =
  variant {
    err: text;
    ok: Asset;
  };
-type Result_1 = 
+type Result_1 =
  variant {
    err: text;
    ok;
  };
-type Result = 
+type Result =
  variant {
    err: text;
    ok: AssetId;
  };
-type AssetMetadata = 
+type AssetMetadata =
  record {
    contentType: text;
+   daoId: principal;
    id: AssetId;
    isPublic: bool;
    name: text;
@@ -26,10 +27,12 @@ type AssetMetadata =
    uploadedBy: principal;
  };
 type AssetId = nat;
+type DaoId = principal;
 type AssetData = blob;
-type Asset = 
+type Asset =
  record {
    contentType: text;
+   daoId: DaoId;
    data: AssetData;
    id: AssetId;
    isPublic: bool;
@@ -40,44 +43,44 @@ type Asset =
    uploadedBy: principal;
  };
 service : {
-  addAuthorizedUploader: ("principal": principal) -> (Result_1);
-  batchUploadAssets: (assets_data:
-   vec record {
-         text;
-         text;
-         AssetData;
-         bool;
-         vec text;
-       }) -> (vec Result);
-  deleteAsset: (assetId: AssetId) -> (Result_1);
-  getAsset: (assetId: AssetId) -> (Result_2);
-  getAssetByName: (name: text) -> (opt AssetMetadata) query;
-  getAssetMetadata: (assetId: AssetId) -> (opt AssetMetadata) query;
-  getAuthorizedUploaders: () -> (vec principal) query;
-  getPublicAssets: () -> (vec AssetMetadata) query;
-  getStorageStats: () ->
-   (record {
-      averageFileSize: nat;
-      storageAvailable: nat;
-      storageLimit: nat;
-      storageUsed: nat;
-      totalAssets: nat;
-    }) query;
-  getSupportedContentTypes: () -> (vec text) query;
-  getUserAssets: () -> (vec AssetMetadata);
-  health: () ->
-   (record {
-      status: text;
-      storageUsed: nat;
-      timestamp: Time;
-    }) query;
-  init: (initialUploader: opt principal, openUploads: bool) -> ();
-  removeAuthorizedUploader: ("principal": principal) -> (Result_1);
-  searchAssetsByTag: (tag: text) -> (vec AssetMetadata) query;
-  updateAssetMetadata: (assetId: AssetId, name: opt text, isPublic: opt bool,
-   tags: opt vec text) -> (Result_1);
-  updateStorageLimits: (maxFileSizeNew: opt nat, maxTotalStorageNew:
-   opt nat) -> (Result_1);
-  uploadAsset: (name: text, contentType: text, data: AssetData, isPublic:
-   bool, tags: vec text) -> (Result);
+ addAuthorizedUploader: ("principal": principal) -> (Result_1);
+ batchUploadAssets: (daoId: DaoId, assets_data:
+  vec record {
+        text;
+        text;
+        AssetData;
+        bool;
+        vec text;
+      }) -> (vec Result);
+ deleteAsset: (daoId: DaoId, assetId: AssetId) -> (Result_1);
+ getAsset: (daoId: DaoId, assetId: AssetId) -> (Result_2);
+ getAssetByName: (daoId: DaoId, name: text) -> (opt AssetMetadata) query;
+ getAssetMetadata: (daoId: DaoId, assetId: AssetId) -> (opt AssetMetadata) query;
+ getAuthorizedUploaders: () -> (vec principal) query;
+ getPublicAssets: (daoId: DaoId) -> (vec AssetMetadata) query;
+ getStorageStats: (daoId: DaoId) ->
+  (record {
+     averageFileSize: nat;
+     storageAvailable: nat;
+     storageLimit: nat;
+     storageUsed: nat;
+     totalAssets: nat;
+   }) query;
+ getSupportedContentTypes: () -> (vec text) query;
+ getUserAssets: (daoId: DaoId) -> (vec AssetMetadata);
+ health: () ->
+  (record {
+     status: text;
+     storageUsed: nat;
+     timestamp: Time;
+   }) query;
+ init: (initialUploader: opt principal, openUploads: bool) -> ();
+ removeAuthorizedUploader: ("principal": principal) -> (Result_1);
+ searchAssetsByTag: (daoId: DaoId, tag: text) -> (vec AssetMetadata) query;
+ updateAssetMetadata: (daoId: DaoId, assetId: AssetId, name: opt text, isPublic: opt bool,
+  tags: opt vec text) -> (Result_1);
+ updateStorageLimits: (maxFileSizeNew: opt nat, maxTotalStorageNew:
+  opt nat) -> (Result_1);
+ uploadAsset: (daoId: DaoId, name: text, contentType: text, data: AssetData, isPublic:
+  bool, tags: vec text) -> (Result);
 }

--- a/src/dao_frontend/src/declarations/assets/assets.did.d.ts
+++ b/src/dao_frontend/src/declarations/assets/assets.did.d.ts
@@ -4,6 +4,7 @@ import type { IDL } from '@dfinity/candid';
 
 export interface Asset {
   'id' : AssetId,
+  'daoId' : Principal,
   'contentType' : string,
   'data' : AssetData,
   'name' : string,
@@ -17,13 +18,14 @@ export type AssetData = Uint8Array | number[];
 export type AssetId = bigint;
 export interface AssetMetadata {
   'id' : AssetId,
-  'contentType' : string,
+  'daoId' : Principal,
   'name' : string,
+  'contentType' : string,
   'size' : bigint,
-  'tags' : Array<string>,
-  'isPublic' : boolean,
-  'uploadedAt' : Time,
   'uploadedBy' : Principal,
+  'uploadedAt' : Time,
+  'isPublic' : boolean,
+  'tags' : Array<string>,
 }
 export type Result = { 'ok' : AssetId } |
   { 'err' : string };
@@ -35,17 +37,17 @@ export type Time = bigint;
 export interface _SERVICE {
   'addAuthorizedUploader' : ActorMethod<[Principal], Result_1>,
   'batchUploadAssets' : ActorMethod<
-    [Array<[string, string, AssetData, boolean, Array<string>]>],
+    [Principal, Array<[string, string, AssetData, boolean, Array<string>]>],
     Array<Result>
   >,
-  'deleteAsset' : ActorMethod<[AssetId], Result_1>,
-  'getAsset' : ActorMethod<[AssetId], Result_2>,
-  'getAssetByName' : ActorMethod<[string], [] | [AssetMetadata]>,
-  'getAssetMetadata' : ActorMethod<[AssetId], [] | [AssetMetadata]>,
+  'deleteAsset' : ActorMethod<[Principal, AssetId], Result_1>,
+  'getAsset' : ActorMethod<[Principal, AssetId], Result_2>,
+  'getAssetByName' : ActorMethod<[Principal, string], [] | [AssetMetadata]>,
+  'getAssetMetadata' : ActorMethod<[Principal, AssetId], [] | [AssetMetadata]>,
   'getAuthorizedUploaders' : ActorMethod<[], Array<Principal>>,
-  'getPublicAssets' : ActorMethod<[], Array<AssetMetadata>>,
+  'getPublicAssets' : ActorMethod<[Principal], Array<AssetMetadata>>,
   'getStorageStats' : ActorMethod<
-    [],
+    [Principal],
     {
       'storageLimit' : bigint,
       'totalAssets' : bigint,
@@ -55,21 +57,27 @@ export interface _SERVICE {
     }
   >,
   'getSupportedContentTypes' : ActorMethod<[], Array<string>>,
-  'getUserAssets' : ActorMethod<[], Array<AssetMetadata>>,
+  'getUserAssets' : ActorMethod<[Principal], Array<AssetMetadata>>,
   'health' : ActorMethod<
     [],
     { 'status' : string, 'storageUsed' : bigint, 'timestamp' : Time }
   >,
   'init' : ActorMethod<[[] | [Principal], boolean], undefined>,
   'removeAuthorizedUploader' : ActorMethod<[Principal], Result_1>,
-  'searchAssetsByTag' : ActorMethod<[string], Array<AssetMetadata>>,
+  'searchAssetsByTag' : ActorMethod<[Principal, string], Array<AssetMetadata>>,
   'updateAssetMetadata' : ActorMethod<
-    [AssetId, [] | [string], [] | [boolean], [] | [Array<string>]],
+    [
+      Principal,
+      AssetId,
+      [] | [string],
+      [] | [boolean],
+      [] | [Array<string>]
+    ],
     Result_1
   >,
   'updateStorageLimits' : ActorMethod<[[] | [bigint], [] | [bigint]], Result_1>,
   'uploadAsset' : ActorMethod<
-    [string, string, AssetData, boolean, Array<string>],
+    [Principal, string, string, AssetData, boolean, Array<string>],
     Result
   >,
 }

--- a/src/dao_frontend/src/declarations/assets/assets.did.js
+++ b/src/dao_frontend/src/declarations/assets/assets.did.js
@@ -6,6 +6,7 @@ export const idlFactory = ({ IDL }) => {
   const Time = IDL.Int;
   const Asset = IDL.Record({
     'id' : AssetId,
+    'daoId' : IDL.Principal,
     'contentType' : IDL.Text,
     'data' : AssetData,
     'name' : IDL.Text,
@@ -18,18 +19,20 @@ export const idlFactory = ({ IDL }) => {
   const Result_2 = IDL.Variant({ 'ok' : Asset, 'err' : IDL.Text });
   const AssetMetadata = IDL.Record({
     'id' : AssetId,
-    'contentType' : IDL.Text,
+    'daoId' : IDL.Principal,
     'name' : IDL.Text,
+    'contentType' : IDL.Text,
     'size' : IDL.Nat,
-    'tags' : IDL.Vec(IDL.Text),
-    'isPublic' : IDL.Bool,
-    'uploadedAt' : Time,
     'uploadedBy' : IDL.Principal,
+    'uploadedAt' : Time,
+    'isPublic' : IDL.Bool,
+    'tags' : IDL.Vec(IDL.Text),
   });
   return IDL.Service({
     'addAuthorizedUploader' : IDL.Func([IDL.Principal], [Result_1], []),
     'batchUploadAssets' : IDL.Func(
         [
+          IDL.Principal,
           IDL.Vec(
             IDL.Tuple(
               IDL.Text,
@@ -43,15 +46,15 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Vec(Result)],
         [],
       ),
-    'deleteAsset' : IDL.Func([AssetId], [Result_1], []),
-    'getAsset' : IDL.Func([AssetId], [Result_2], []),
+    'deleteAsset' : IDL.Func([IDL.Principal, AssetId], [Result_1], []),
+    'getAsset' : IDL.Func([IDL.Principal, AssetId], [Result_2], []),
     'getAssetByName' : IDL.Func(
-        [IDL.Text],
+        [IDL.Principal, IDL.Text],
         [IDL.Opt(AssetMetadata)],
         ['query'],
       ),
     'getAssetMetadata' : IDL.Func(
-        [AssetId],
+        [IDL.Principal, AssetId],
         [IDL.Opt(AssetMetadata)],
         ['query'],
       ),
@@ -60,9 +63,9 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Vec(IDL.Principal)],
         ['query'],
       ),
-    'getPublicAssets' : IDL.Func([], [IDL.Vec(AssetMetadata)], ['query']),
+    'getPublicAssets' : IDL.Func([IDL.Principal], [IDL.Vec(AssetMetadata)], ['query']),
     'getStorageStats' : IDL.Func(
-        [],
+        [IDL.Principal],
         [
           IDL.Record({
             'storageLimit' : IDL.Nat,
@@ -75,7 +78,7 @@ export const idlFactory = ({ IDL }) => {
         ['query'],
       ),
     'getSupportedContentTypes' : IDL.Func([], [IDL.Vec(IDL.Text)], ['query']),
-    'getUserAssets' : IDL.Func([], [IDL.Vec(AssetMetadata)], []),
+    'getUserAssets' : IDL.Func([IDL.Principal], [IDL.Vec(AssetMetadata)], []),
     'health' : IDL.Func(
         [],
         [
@@ -90,12 +93,13 @@ export const idlFactory = ({ IDL }) => {
     'init' : IDL.Func([IDL.Opt(IDL.Principal), IDL.Bool], [], []),
     'removeAuthorizedUploader' : IDL.Func([IDL.Principal], [Result_1], []),
     'searchAssetsByTag' : IDL.Func(
-        [IDL.Text],
+        [IDL.Principal, IDL.Text],
         [IDL.Vec(AssetMetadata)],
         ['query'],
       ),
     'updateAssetMetadata' : IDL.Func(
         [
+          IDL.Principal,
           AssetId,
           IDL.Opt(IDL.Text),
           IDL.Opt(IDL.Bool),
@@ -110,7 +114,7 @@ export const idlFactory = ({ IDL }) => {
         [],
       ),
     'uploadAsset' : IDL.Func(
-        [IDL.Text, IDL.Text, AssetData, IDL.Bool, IDL.Vec(IDL.Text)],
+        [IDL.Principal, IDL.Text, IDL.Text, AssetData, IDL.Bool, IDL.Vec(IDL.Text)],
         [Result],
         [],
       ),

--- a/src/dao_frontend/src/hooks/useAssets.js
+++ b/src/dao_frontend/src/hooks/useAssets.js
@@ -14,7 +14,7 @@ export const useAssets = () => {
       const arrayBuffer = await file.arrayBuffer();
       const data = Array.from(new Uint8Array(arrayBuffer));
       const result = await actors.assets.uploadAsset(
-        BigInt(daoId),
+        Principal.fromText(daoId),
         file.name,
         file.type,
         data,
@@ -37,7 +37,10 @@ export const useAssets = () => {
     setLoading(true);
     setError(null);
     try {
-      const res = await actors.assets.getAsset(BigInt(daoId), BigInt(assetId));
+      const res = await actors.assets.getAsset(
+        Principal.fromText(daoId),
+        BigInt(assetId)
+      );
       if (res.err) {
         throw new Error(res.err);
       }
@@ -54,7 +57,10 @@ export const useAssets = () => {
     setLoading(true);
     setError(null);
     try {
-      return await actors.assets.getAssetMetadata(BigInt(daoId), BigInt(assetId));
+      return await actors.assets.getAssetMetadata(
+        Principal.fromText(daoId),
+        BigInt(assetId)
+      );
     } catch (err) {
       setError(err.message);
       throw err;
@@ -67,7 +73,7 @@ export const useAssets = () => {
     setLoading(true);
     setError(null);
     try {
-      return await actors.assets.getPublicAssets(BigInt(daoId));
+      return await actors.assets.getPublicAssets(Principal.fromText(daoId));
     } catch (err) {
       setError(err.message);
       throw err;
@@ -80,7 +86,7 @@ export const useAssets = () => {
     setLoading(true);
     setError(null);
     try {
-      return await actors.assets.getUserAssets(BigInt(daoId));
+      return await actors.assets.getUserAssets(Principal.fromText(daoId));
     } catch (err) {
       setError(err.message);
       throw err;
@@ -93,7 +99,10 @@ export const useAssets = () => {
     setLoading(true);
     setError(null);
     try {
-      return await actors.assets.searchAssetsByTag(BigInt(daoId), tag);
+      return await actors.assets.searchAssetsByTag(
+        Principal.fromText(daoId),
+        tag
+      );
     } catch (err) {
       setError(err.message);
       throw err;
@@ -106,7 +115,10 @@ export const useAssets = () => {
     setLoading(true);
     setError(null);
     try {
-      const res = await actors.assets.deleteAsset(BigInt(daoId), BigInt(assetId));
+      const res = await actors.assets.deleteAsset(
+        Principal.fromText(daoId),
+        BigInt(assetId)
+      );
       if (res.err) {
         throw new Error(res.err);
       }
@@ -124,7 +136,7 @@ export const useAssets = () => {
     setError(null);
     try {
       const res = await actors.assets.updateAssetMetadata(
-        BigInt(daoId),
+        Principal.fromText(daoId),
         BigInt(assetId),
         name === null ? [] : [name],
         isPublic === null ? [] : [isPublic],
@@ -146,7 +158,7 @@ export const useAssets = () => {
     setLoading(true);
     setError(null);
     try {
-      return await actors.assets.getStorageStats(BigInt(daoId));
+      return await actors.assets.getStorageStats(Principal.fromText(daoId));
     } catch (err) {
       setError(err.message);
       throw err;
@@ -247,7 +259,10 @@ export const useAssets = () => {
     setLoading(true);
     setError(null);
     try {
-      return await actors.assets.getAssetByName(BigInt(daoId), name);
+      return await actors.assets.getAssetByName(
+        Principal.fromText(daoId),
+        name
+      );
     } catch (err) {
       setError(err.message);
       throw err;
@@ -267,7 +282,10 @@ export const useAssets = () => {
           return [file.name, file.type, data, isPublic, tags];
         })
       );
-      return await actors.assets.batchUploadAssets(BigInt(daoId), formatted);
+      return await actors.assets.batchUploadAssets(
+        Principal.fromText(daoId),
+        formatted
+      );
     } catch (err) {
       setError(err.message);
       throw err;


### PR DESCRIPTION
## Summary
- switch asset canister to use `Principal`-based DAO identifiers
- update asset hooks to send principals instead of `BigInt`
- refresh asset canister declarations for new identifier

## Testing
- `npm test` *(fails: dfx: not found; vitest tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_68a1dbd42fb88320aa4912cd76a60e5a