### PR TITLE
feat: add active DAO context to diagnostics

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -625,6 +625,11 @@ localStorage.removeItem('ic-identity');
 const authClient = await AuthClient.create();
 ```
 
+#### 4. Diagnostics Health Checks
+Currently, both the DAO backend and assets canisters expose only global `health` endpoints.
+The `Diagnostics` screen will therefore display service status for the overall canisters and
+cannot provide DAO-specific health information.
+
 ### Debug Tools
 
 #### 1. Backend Debugging

--- a/src/dao_frontend/src/components/Diagnostics.jsx
+++ b/src/dao_frontend/src/components/Diagnostics.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useAuth } from '../context/AuthContext';
 import { useDAOAPI } from '../utils/daoAPI';
 import { useAssets } from '../hooks/useAssets';
+import { useDAO } from '../context/DAOContext';
 import BackgroundParticles from './BackgroundParticles';
 import { Loader2 } from 'lucide-react';
 
@@ -35,6 +36,7 @@ const Diagnostics = () => {
   const { isAuthenticated, loading } = useAuth();
   const daoAPI = useDAOAPI();
   const { getHealth: getAssetsHealth } = useAssets();
+  const { activeDAO } = useDAO();
 
   const [references, setReferences] = useState(null);
   const [fetching, setFetching] = useState(true);
@@ -45,9 +47,16 @@ const Diagnostics = () => {
 
   useEffect(() => {
     const fetchData = async () => {
-      if (!daoAPI) return;
+      if (!daoAPI || !activeDAO) return;
+
+      setFetching(true);
+      setReferences(null);
+      setBackendHealth(null);
+      setAssetsHealth(null);
+      setError(null);
+      setHealthErrors({ backend: null, assets: null });
       try {
-        const refs = await daoAPI.getCanisterReferences();
+        const refs = await daoAPI.getCanisterReferences(activeDAO.id);
         setReferences(refs);
       } catch (err) {
         console.error('Failed to fetch canister references', err);
@@ -55,6 +64,7 @@ const Diagnostics = () => {
       }
 
       try {
+        // DAO backend currently provides only a global health endpoint
         const backend = await daoAPI.healthCheck();
         setBackendHealth(backend);
       } catch (err) {
@@ -63,6 +73,7 @@ const Diagnostics = () => {
       }
 
       try {
+        // Assets canister health is also global
         const assets = await getAssetsHealth();
         setAssetsHealth(assets);
       } catch (err) {
@@ -73,7 +84,7 @@ const Diagnostics = () => {
       }
     };
     fetchData();
-  }, [daoAPI, getAssetsHealth]);
+  }, [daoAPI, getAssetsHealth, activeDAO]);
 
   if (loading || fetching) {
     return (


### PR DESCRIPTION
## Summary
- use active DAO context in Diagnostics and refetch on DAO change
- call `getCanisterReferences` with specific DAO ID and note health check limitations
- document current lack of DAO-specific health endpoints in developer guide

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1dede2ed483209c1b747cd818fb73