### PR TITLE
Use DAO actor for voter profile lookup

### DIFF
--- a/src/dao_backend/governance/main.mo
+++ b/src/dao_backend/governance/main.mo
@@ -267,9 +267,8 @@ persistent actor GovernanceCanister {
             return #err("Voting period has ended");
         };
 
-        // Verify voter registration
-        let daoActor : actor { getUserProfile: shared query (Principal) -> async ?Types.UserProfile } = actor(Principal.toText(daoId));
-        let profileOpt = await daoActor.getUserProfile(caller);
+        // Verify voter registration using the DAO backend actor
+        let profileOpt = await dao.getUserProfile(daoInstance, caller);
         switch (profileOpt) {
             case null return #err("User not registered");
             case (?_) {};


### PR DESCRIPTION
## Summary
- Verify voter registration via DAO backend actor
- Pass DAO identifier and voter principal to `getUserProfile`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1e13a78048320a604438401978f3c