### PR TITLE
Use DAOId when building user profiles

### DIFF
--- a/src/dao_backend/main.mo
+++ b/src/dao_backend/main.mo
@@ -249,7 +249,7 @@ persistent actor DAOMain {
         };
 
         let userProfile : UserProfile = {
-
+            daoId = daoId;
             id = caller;
             displayName = displayName;
             bio = bio;
@@ -281,7 +281,7 @@ persistent actor DAOMain {
         };
 
         let userProfile : UserProfile = {
-            daoId = Principal.fromActor(DAOMain);
+            daoId = daoId;
             id = newUser;
             displayName = displayName;
             bio = bio;
@@ -307,7 +307,7 @@ persistent actor DAOMain {
             case null return #err("User not found");
             case (?profile) {
                 let updatedProfile = {
-
+                    daoId = daoId;
                     id = profile.id;
                     displayName = displayName;
                     bio = bio;

--- a/src/dao_backend/shared/types.mo
+++ b/src/dao_backend/shared/types.mo
@@ -17,7 +17,7 @@ module {
     public type UserId = Principal;
     
     public type UserProfile = {
-        daoId: Principal;
+        daoId: DAOId;
         id: UserId;
         displayName: Text;
         bio: Text;

--- a/src/dao_frontend/src/declarations/dao_backend/dao_backend.did
+++ b/src/dao_frontend/src/declarations/dao_backend/dao_backend.did
@@ -1,6 +1,6 @@
 type UserProfile =
  record {
-  daoId: principal;
+  daoId: text;
   bio: text;
   displayName: text;
   id: UserId;

--- a/src/dao_frontend/src/declarations/dao_backend/dao_backend.did.d.ts
+++ b/src/dao_frontend/src/declarations/dao_backend/dao_backend.did.d.ts
@@ -47,7 +47,7 @@ export type Time = bigint;
 export type TokenAmount = bigint;
 export type UserId = Principal;
 export interface UserProfile {
-  'daoId' : Principal,
+  'daoId' : string,
   'id' : UserId,
   'bio' : string,
   'displayName' : string,

--- a/src/dao_frontend/src/declarations/dao_backend/dao_backend.did.js
+++ b/src/dao_frontend/src/declarations/dao_backend/dao_backend.did.js
@@ -4,7 +4,7 @@ export const idlFactory = ({ IDL }) => {
   const UserId = IDL.Principal;
   const Time = IDL.Int;
   const UserProfile = IDL.Record({
-    'daoId' : IDL.Principal,
+    'daoId' : IDL.Text,
     'id' : UserId,
     'bio' : IDL.Text,
     'displayName' : IDL.Text,


### PR DESCRIPTION
## Summary
- store DAO identifiers in `UserProfile` using `DAOId` instead of `Principal`
- propagate `daoId` through registration and profile update handlers
- regenerate DAO backend declarations to expose `daoId` as `text`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1e13a80a4832089344dd6acb83efc