### PR TITLE
feat: guard canisters behind initialization flag

### DIFF
--- a/src/dao_backend/governance/main.mo
+++ b/src/dao_backend/governance/main.mo
@@ -66,25 +66,22 @@ persistent actor GovernanceCanister {
     // Inter-canister communication setup
     // Actor reference for staking canister
 
-    var staking : actor {
+    var staking : ?actor {
         getUserStakingSummary: shared query (Principal, Principal) -> async {
-
             totalStaked: Nat;
             totalRewards: Nat;
             activeStakes: Nat;
             totalVotingPower: Nat;
         };
-
-    } = actor("aaaaa-aa");
+    } = null;
 
     // Inter-canister communication setup
 
     // These actor references enable cross-canister calls for governance functionality
-    var dao : actor {
+    var dao : ?actor {
         getUserProfile: shared query (Types.DAOId, Principal) -> async ?Types.UserProfile;
         checkIsAdmin: shared query (Types.DAOId, Principal) -> async Bool;
-
-    } = actor("aaaaa-aa");
+    } = null;
 
     // Stable storage for upgrade persistence
     // These arrays store serialized data that survives canister upgrades
@@ -92,8 +89,8 @@ persistent actor GovernanceCanister {
     private var proposalsEntries : [(ProposalKey, Proposal)] = [];
     private var votesEntries : [(VoteKey, Vote)] = [];
     private var configEntries : [(Principal, GovernanceConfig)] = [];
-    private var stakingId : Principal = Principal.fromText("aaaaa-aa");
-    private var daoInstance : Types.DAOId = "";
+    private var stakingId : ?Principal = null;
+    private var daoInstance : ?Types.DAOId = null;
     private var initialized : Bool = false;
 
     // Runtime storage - rebuilt from stable storage after upgrades
@@ -121,11 +118,10 @@ persistent actor GovernanceCanister {
             throw Error.reject("Caller is not authorized to initialize");
         };
 
-        stakingId := newStakingId;
-
-        daoInstance := daoInstanceId;
-        dao := daoTemp;
-        staking := actor(Principal.toText(newStakingId));
+        stakingId := ?newStakingId;
+        daoInstance := ?daoInstanceId;
+        dao := ?daoTemp;
+        staking := ?actor(Principal.toText(newStakingId));
         initialized := true;
         Debug.print("Initialization complete");
     };
@@ -179,7 +175,10 @@ persistent actor GovernanceCanister {
             Principal.hash
         );
 
-        staking := actor(Principal.toText(stakingId));
+        switch (stakingId) {
+            case (?id) staking := ?actor(Principal.toText(id));
+            case null {};
+        };
     };
 
     // Public functions
@@ -192,6 +191,9 @@ persistent actor GovernanceCanister {
         proposalType: Types.ProposalType,
         votingPeriod: ?Nat
     ) : async Result<ProposalId, Text> {
+        if (not initialized) {
+            return #err("Canister not initialized");
+        };
 
         let caller = msg.caller;
 
@@ -242,6 +244,9 @@ persistent actor GovernanceCanister {
         choice: Types.VoteChoice,
         reason: ?Text
     ) : async Result<(), Text> {
+        if (not initialized) {
+            return #err("Canister not initialized");
+        };
 
         let caller = msg.caller;
         let voteKey : VoteKey = (daoId, proposalId, caller);
@@ -268,14 +273,26 @@ persistent actor GovernanceCanister {
         };
 
         // Verify voter registration using the DAO backend actor
-        let profileOpt = await dao.getUserProfile(daoInstance, caller);
+        let daoActor = switch (dao) {
+            case (?d) d;
+            case null return #err("Canister not initialized");
+        };
+        let instanceId = switch (daoInstance) {
+            case (?id) id;
+            case null return #err("Canister not initialized");
+        };
+        let profileOpt = await daoActor.getUserProfile(instanceId, caller);
         switch (profileOpt) {
             case null return #err("User not registered");
             case (?_) {};
         };
 
         // Determine voting power from staking data
-        let summary = await staking.getUserStakingSummary(daoId, caller);
+        let stakingActor = switch (staking) {
+            case (?s) s;
+            case null return #err("Canister not initialized");
+        };
+        let summary = await stakingActor.getUserStakingSummary(daoId, caller);
         let votingPower = summary.totalVotingPower;
         if (votingPower == 0) {
             return #err("No voting power");
@@ -365,6 +382,10 @@ persistent actor GovernanceCanister {
 
     // Execute a proposal
     public shared(_msg) func executeProposal(daoId: Principal, proposalId: ProposalId) : async Result<(), Text> {
+        if (not initialized) {
+            return #err("Canister not initialized");
+        };
+
         let proposal = switch (proposals.get((daoId, proposalId))) {
             case (?p) p;
             case null return #err("Proposal not found");
@@ -466,11 +487,17 @@ persistent actor GovernanceCanister {
 
     // Get proposal by ID
     public query func getProposal(daoId: Principal, proposalId: ProposalId) : async ?Proposal {
+        if (not initialized) {
+            throw Error.reject("Canister not initialized");
+        };
         proposals.get((daoId, proposalId))
     };
 
     // Get all proposals for a DAO
     public query func getAllProposals(daoId: Principal) : async [Proposal] {
+        if (not initialized) {
+            throw Error.reject("Canister not initialized");
+        };
         let buffer = Buffer.Buffer<Proposal>(0);
         for (proposal in proposals.vals()) {
             if (proposal.daoId == daoId) {
@@ -482,6 +509,9 @@ persistent actor GovernanceCanister {
 
     // Get active proposals for a DAO
     public query func getActiveProposals(daoId: Principal) : async [Proposal] {
+        if (not initialized) {
+            throw Error.reject("Canister not initialized");
+        };
         let activeProposals = Buffer.Buffer<Proposal>(0);
         for (proposal in proposals.vals()) {
             if (proposal.daoId == daoId and proposal.status == #active and Time.now() <= proposal.votingDeadline) {
@@ -493,6 +523,9 @@ persistent actor GovernanceCanister {
 
     // Get proposals by status for a DAO
     public query func getProposalsByStatus(daoId: Principal, status: Types.ProposalStatus) : async [Proposal] {
+        if (not initialized) {
+            throw Error.reject("Canister not initialized");
+        };
         let filteredProposals = Buffer.Buffer<Proposal>(0);
         for (proposal in proposals.vals()) {
             if (proposal.daoId == daoId and proposal.status == status) {
@@ -504,11 +537,17 @@ persistent actor GovernanceCanister {
 
     // Get user's vote on a proposal
     public query func getUserVote(daoId: Principal, proposalId: ProposalId, user: Principal) : async ?Vote {
+        if (not initialized) {
+            throw Error.reject("Canister not initialized");
+        };
         votes.get((daoId, proposalId, user))
     };
 
     // Get all votes for a proposal
     public query func getProposalVotes(daoId: Principal, proposalId: ProposalId) : async [Vote] {
+        if (not initialized) {
+            throw Error.reject("Canister not initialized");
+        };
         let proposalVotes = Buffer.Buffer<Vote>(0);
         for (vote in votes.vals()) {
             if (vote.daoId == daoId and vote.proposalId == proposalId) {
@@ -520,11 +559,17 @@ persistent actor GovernanceCanister {
 
     // Get governance configuration for a DAO
     public query func getConfig(daoId: Principal) : async ?GovernanceConfig {
+        if (not initialized) {
+            throw Error.reject("Canister not initialized");
+        };
         config.get(daoId)
     };
 
     // Update governance configuration (admin only)
     public shared(_msg) func updateConfig(daoId: Principal, newConfig: GovernanceConfig) : async Result<(), Text> {
+        if (not initialized) {
+            return #err("Canister not initialized");
+        };
         // In a real implementation, you'd check if the caller is an admin
         config.put(daoId, newConfig);
         #ok()
@@ -549,6 +594,9 @@ persistent actor GovernanceCanister {
         failedProposals: Nat;
         totalVotes: Nat;
     } {
+        if (not initialized) {
+            throw Error.reject("Canister not initialized");
+        };
         var activeCount = 0;
         var succeededCount = 0;
         var failedCount = 0;

--- a/src/dao_backend/proposals/main.mo
+++ b/src/dao_backend/proposals/main.mo
@@ -9,6 +9,7 @@ import Buffer "mo:base/Buffer";
 import Nat "mo:base/Nat";
 import Text "mo:base/Text";
 import Nat32 "mo:base/Nat32";
+import Error "mo:base/Error";
 
 import Types "../shared/types";
 
@@ -54,6 +55,8 @@ persistent actor ProposalsCanister {
     private var templatesEntries : [(Nat, ProposalTemplate)] = [];
     private var categoriesEntries : [(Text, ProposalCategory)] = [];
     private var configEntries : [(Text, GovernanceConfig)] = [];
+    private var stakingCanisterId : ?Principal = null;
+    private var initialized : Bool = false;
 
     // Runtime storage
     private transient var proposals = HashMap.HashMap<ProposalKey, Proposal>(10, eqProposalKey, hashProposalKey);
@@ -63,14 +66,14 @@ persistent actor ProposalsCanister {
     private transient var config = HashMap.HashMap<Text, GovernanceConfig>(1, Text.equal, Text.hash);
 
     // Inter-canister reference to staking for voting power
-    var staking : actor {
+    var staking : ?actor {
         getUserStakingSummary: shared query (Principal, Principal) -> async {
             totalStaked: Nat;
             totalRewards: Nat;
             activeStakes: Nat;
             totalVotingPower: Nat;
         };
-    } = actor("aaaaa-aa");
+    } = null;
 
     // Initialize default data
     private func initializeDefaults() {
@@ -167,12 +170,16 @@ persistent actor ProposalsCanister {
             Text.hash
         );
         config := HashMap.fromIter<Text, GovernanceConfig>(
-            configEntries.vals(), 
-            configEntries.size(), 
-            Text.equal, 
+            configEntries.vals(),
+            configEntries.size(),
+            Text.equal,
             Text.hash
         );
-        
+        switch (stakingCanisterId) {
+            case (?id) staking := ?actor(Principal.toText(id));
+            case null {};
+        };
+
         if (config.size() == 0 or categories.size() == 0 or templates.size() == 0) {
             initializeDefaults();
         };
@@ -185,7 +192,12 @@ persistent actor ProposalsCanister {
 
     // Set staking canister reference
     public shared(_msg) func init(stakingId: Principal) {
-        staking := actor(Principal.toText(stakingId));
+        if (initialized) {
+            throw Error.reject("Proposals canister already initialized");
+        };
+        staking := ?actor(Principal.toText(stakingId));
+        stakingCanisterId := ?stakingId;
+        initialized := true;
     };
 
     // Public functions
@@ -199,6 +211,9 @@ persistent actor ProposalsCanister {
         category: ?Text,
         votingPeriod: ?Nat
     ) : async Result<ProposalId, Text> {
+        if (not initialized) {
+            return #err("Canister not initialized");
+        };
         let caller = msg.caller;
         
         // Check if user has too many active proposals
@@ -250,6 +265,9 @@ persistent actor ProposalsCanister {
         parameters: [(Text, Text)],
         votingPeriod: ?Nat
     ) : async Result<ProposalId, Text> {
+        if (not initialized) {
+            return #err("Canister not initialized");
+        };
         let template = switch (templates.get(templateId)) {
             case (?t) t;
             case null return #err("Template not found");
@@ -285,13 +303,18 @@ persistent actor ProposalsCanister {
         daoId: Principal,
         votes: [(ProposalId, Types.VoteChoice, ?Text)]
     ) : async [Result<(), Text>] {
+        if (not initialized) {
+            return Array.tabulate<Result<(), Text>>(votes.size(), func (_ : Nat) : Result<(), Text> {
+                #err("Canister not initialized")
+            });
+        };
         let results = Buffer.Buffer<Result<(), Text>>(votes.size());
 
         for ((proposalId, choice, reason) in votes.vals()) {
             let result = await vote(daoId, proposalId, choice, reason);
             results.add(result);
         };
-        
+
         Buffer.toArray(results)
     };
 
@@ -302,6 +325,9 @@ persistent actor ProposalsCanister {
         choice: Types.VoteChoice,
         reason: ?Text
     ) : async Result<(), Text> {
+        if (not initialized) {
+            return #err("Canister not initialized");
+        };
         let caller = msg.caller;
         let voteKey = Principal.toText(daoId) # "_" # Nat.toText(proposalId) # "_" # Principal.toText(caller);
 
@@ -327,8 +353,12 @@ persistent actor ProposalsCanister {
         };
 
         // Determine voting power from staking
+        let stakingActor = switch (staking) {
+            case (?s) s;
+            case null return #err("Canister not initialized");
+        };
         let summary = try {
-            await staking.getUserStakingSummary(daoId, caller)
+            await stakingActor.getUserStakingSummary(daoId, caller)
         } catch (_) {
             return #err("Failed to get staking summary");
         };
@@ -419,11 +449,17 @@ persistent actor ProposalsCanister {
 
     // Get proposal by ID
     public query func getProposal(daoId: Principal, proposalId: ProposalId) : async ?Proposal {
+        if (not initialized) {
+            throw Error.reject("Canister not initialized");
+        };
         proposals.get((daoId, proposalId))
     };
 
     // Get all proposals
     public query func getAllProposals(daoId: Principal) : async [Proposal] {
+        if (not initialized) {
+            throw Error.reject("Canister not initialized");
+        };
         let filtered = Buffer.Buffer<Proposal>(0);
         for (proposal in proposals.vals()) {
             if (proposal.daoId == daoId) {
@@ -435,6 +471,9 @@ persistent actor ProposalsCanister {
 
     // Get proposals by category
     public query func getProposalsByCategory(daoId: Principal, category: Text) : async [Proposal] {
+        if (not initialized) {
+            throw Error.reject("Canister not initialized");
+        };
         let filteredProposals = Buffer.Buffer<Proposal>(0);
         // Category filtering not implemented yet; return all proposals for DAO
         for (proposal in proposals.vals()) {
@@ -447,6 +486,9 @@ persistent actor ProposalsCanister {
 
     // Get trending proposals (by vote activity)
     public query func getTrendingProposals(daoId: Principal, limit: Nat) : async [Proposal] {
+        if (not initialized) {
+            throw Error.reject("Canister not initialized");
+        };
         let allProposals = Buffer.Buffer<Proposal>(0);
         for (proposal in proposals.vals()) {
             if (proposal.daoId == daoId) {
@@ -468,21 +510,33 @@ persistent actor ProposalsCanister {
 
     // Get proposal templates
     public query func getProposalTemplates(_daoId: Principal) : async [ProposalTemplate] {
+        if (not initialized) {
+            throw Error.reject("Canister not initialized");
+        };
         Iter.toArray(templates.vals())
     };
 
     // Get proposal categories
     public query func getProposalCategories(_daoId: Principal) : async [ProposalCategory] {
+        if (not initialized) {
+            throw Error.reject("Canister not initialized");
+        };
         Iter.toArray(categories.vals())
     };
 
     // Get template by ID
     public query func getTemplate(_daoId: Principal, templateId: Nat) : async ?ProposalTemplate {
+        if (not initialized) {
+            throw Error.reject("Canister not initialized");
+        };
         templates.get(templateId)
     };
 
     // Get templates by category
     public query func getTemplatesByCategory(_daoId: Principal, category: Text) : async [ProposalTemplate] {
+        if (not initialized) {
+            throw Error.reject("Canister not initialized");
+        };
         let filteredTemplates = Buffer.Buffer<ProposalTemplate>(0);
         for (template in templates.vals()) {
             if (template.category == category) {
@@ -503,6 +557,9 @@ persistent actor ProposalsCanister {
         requiredFields: [Text],
         template: Text
     ) : async Result<Nat, Text> {
+        if (not initialized) {
+            return #err("Canister not initialized");
+        };
         let templateId = nextTemplateId;
         nextTemplateId += 1;
 
@@ -527,6 +584,9 @@ persistent actor ProposalsCanister {
         description: Text,
         color: Text
     ) : async Result<(), Text> {
+        if (not initialized) {
+            return #err("Canister not initialized");
+        };
         let newCategory : ProposalCategory = {
             id = id;
             name = name;
@@ -559,6 +619,9 @@ persistent actor ProposalsCanister {
         totalTemplates: Nat;
         totalCategories: Nat;
     } {
+        if (not initialized) {
+            throw Error.reject("Canister not initialized");
+        };
         var activeCount = 0;
         var succeededCount = 0;
         var failedCount = 0;


### PR DESCRIPTION
## Summary
- ensure governance canister actor references are assigned only during init
- gate governance and proposal canister methods on `initialized`
- reject calls when canisters are not initialized

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1e59042988320bcff7d551a193101