### PR TITLE
Delegate proposal creation via proposals canister

### DIFF
--- a/src/dao_backend/main.mo
+++ b/src/dao_backend/main.mo
@@ -445,21 +445,51 @@ persistent actor DAOMain {
         }
     };
 
-    // Temporary proposal creation (will delegate to proposals canister later)
+    // Proposal creation delegates to the proposals canister
     public shared(msg) func createProposal(
         daoId: DAOId,
         title: Text,
-        _description: Text,
-        _proposalType: Text
+        description: Text,
+        proposalType: Types.ProposalType,
+        category: ?Text,
+        votingPeriod: ?Nat
     ) : async Result<Nat, Text> {
         if (not isRegisteredUser(daoId, msg.caller)) {
             return #err("Only registered users can create proposals");
         };
-        
-        // For now, return success with a dummy proposal ID
-        // Later this will delegate to the proposals canister
-        Debug.print("Proposal created: " # title);
-        #ok(1) // Return dummy proposal ID
+
+        let state = ensureDAO(daoId);
+        let canisterId = switch (state.proposalsCanister) {
+            case (?pid) pid;
+            case null return #err("Proposals canister not set");
+        };
+
+        let proposals = actor(Principal.toText(canisterId)) : actor {
+            createProposal : shared (
+                Principal,
+                Text,
+                Text,
+                Types.ProposalType,
+                ?Text,
+                ?Nat
+            ) -> async Result<Nat, Text>;
+        };
+
+        let daoPrincipal = Principal.fromText(daoId);
+        let result = try {
+            await proposals.createProposal(
+                daoPrincipal,
+                title,
+                description,
+                proposalType,
+                category,
+                votingPeriod
+            )
+        } catch (err) {
+            return #err("Failed to call proposals canister");
+        };
+
+        result
     };
 
     // Temporary voting function (will delegate to proposals canister later)


### PR DESCRIPTION
## Summary
- forward proposal creation to proposals canister with proper interface and error handling

## Testing
- `npm test` *(fails: dfx: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e5f71d908320bf69ceaf2a4d787e