### PR TITLE
refactor: use DAOId for dao identification

### DIFF
--- a/src/dao_backend/governance/main.mo
+++ b/src/dao_backend/governance/main.mo
@@ -41,33 +41,34 @@ persistent actor GovernanceCanister {
     type GovernanceConfig = Types.GovernanceConfig;
     type GovernanceError = Types.GovernanceError;
     type CommonError = Types.CommonError;
+    type DAOId = Types.DAOId;
 
 
     // Key types for multi-DAO support
-    type ProposalKey = (Principal, ProposalId);
-    type VoteKey = (Principal, ProposalId, Principal);
+    type ProposalKey = (DAOId, ProposalId);
+    type VoteKey = (DAOId, ProposalId, Principal);
 
     private func proposalKeyEqual(a: ProposalKey, b: ProposalKey) : Bool {
-        Principal.equal(a.0, b.0) and a.1 == b.1
+        Text.equal(a.0, b.0) and a.1 == b.1
     };
 
     private func proposalKeyHash(k: ProposalKey) : Nat32 {
-        Principal.hash(k.0) + Nat32.fromNat(k.1)
+        Text.hash(k.0) + Nat32.fromNat(k.1)
     };
 
     private func voteKeyEqual(a: VoteKey, b: VoteKey) : Bool {
-        Principal.equal(a.0, b.0) and a.1 == b.1 and Principal.equal(a.2, b.2)
+        Text.equal(a.0, b.0) and a.1 == b.1 and Principal.equal(a.2, b.2)
     };
 
     private func voteKeyHash(k: VoteKey) : Nat32 {
-        Principal.hash(k.0) + Nat32.fromNat(k.1) + Principal.hash(k.2)
+        Text.hash(k.0) + Nat32.fromNat(k.1) + Principal.hash(k.2)
     };
 
     // Inter-canister communication setup
     // Actor reference for staking canister
 
     var staking : actor {
-        getUserStakingSummary: shared query (Principal, Principal) -> async {
+        getUserStakingSummary: shared query (Types.DAOId, Principal) -> async {
 
             totalStaked: Nat;
             totalRewards: Nat;
@@ -91,7 +92,7 @@ persistent actor GovernanceCanister {
     private var nextProposalId : Nat = 1;
     private var proposalsEntries : [(ProposalKey, Proposal)] = [];
     private var votesEntries : [(VoteKey, Vote)] = [];
-    private var configEntries : [(Principal, GovernanceConfig)] = [];
+    private var configEntries : [(DAOId, GovernanceConfig)] = [];
     private var stakingId : Principal = Principal.fromText("aaaaa-aa");
     private var daoInstance : Types.DAOId = "";
     private var initialized : Bool = false;
@@ -100,7 +101,7 @@ persistent actor GovernanceCanister {
     // HashMaps provide O(1) lookup performance for governance operations
     private transient var proposals = HashMap.HashMap<ProposalKey, Proposal>(10, proposalKeyEqual, proposalKeyHash);
     private transient var votes = HashMap.HashMap<VoteKey, Vote>(100, voteKeyEqual, voteKeyHash);
-    private transient var config = HashMap.HashMap<Principal, GovernanceConfig>(1, Principal.equal, Principal.hash);
+    private transient var config = HashMap.HashMap<DAOId, GovernanceConfig>(1, Text.equal, Text.hash);
 
     public shared(msg) func init(newDaoId: Principal, newStakingId: Principal, daoInstanceId: Types.DAOId) : async () {
         if (initialized) {
@@ -141,7 +142,7 @@ persistent actor GovernanceCanister {
         }
     };
 
-    private func getConfigForDao(daoId: Principal) : GovernanceConfig {
+    private func getConfigForDao(daoId: DAOId) : GovernanceConfig {
         switch (config.get(daoId)) {
             case (?c) c;
             case null {
@@ -172,11 +173,11 @@ persistent actor GovernanceCanister {
             voteKeyEqual,
             voteKeyHash
         );
-        config := HashMap.fromIter<Principal, GovernanceConfig>(
+        config := HashMap.fromIter<DAOId, GovernanceConfig>(
             configEntries.vals(),
             configEntries.size(),
-            Principal.equal,
-            Principal.hash
+            Text.equal,
+            Text.hash
         );
 
         staking := actor(Principal.toText(stakingId));
@@ -186,7 +187,7 @@ persistent actor GovernanceCanister {
 
     // Create a new proposal
     public shared(msg) func createProposal(
-        daoId: Principal,
+        daoId: DAOId,
         title: Text,
         description: Text,
         proposalType: Types.ProposalType,
@@ -237,7 +238,7 @@ persistent actor GovernanceCanister {
 
     // Cast a vote on a proposal
     public shared(msg) func vote(
-        daoId: Principal,
+        daoId: DAOId,
         proposalId: ProposalId,
         choice: Types.VoteChoice,
         reason: ?Text
@@ -364,7 +365,7 @@ persistent actor GovernanceCanister {
     };
 
     // Execute a proposal
-    public shared(_msg) func executeProposal(daoId: Principal, proposalId: ProposalId) : async Result<(), Text> {
+    public shared(_msg) func executeProposal(daoId: DAOId, proposalId: ProposalId) : async Result<(), Text> {
         let proposal = switch (proposals.get((daoId, proposalId))) {
             case (?p) p;
             case null return #err("Proposal not found");
@@ -465,12 +466,12 @@ persistent actor GovernanceCanister {
     // Query functions
 
     // Get proposal by ID
-    public query func getProposal(daoId: Principal, proposalId: ProposalId) : async ?Proposal {
+    public query func getProposal(daoId: DAOId, proposalId: ProposalId) : async ?Proposal {
         proposals.get((daoId, proposalId))
     };
 
     // Get all proposals for a DAO
-    public query func getAllProposals(daoId: Principal) : async [Proposal] {
+    public query func getAllProposals(daoId: DAOId) : async [Proposal] {
         let buffer = Buffer.Buffer<Proposal>(0);
         for (proposal in proposals.vals()) {
             if (proposal.daoId == daoId) {
@@ -481,7 +482,7 @@ persistent actor GovernanceCanister {
     };
 
     // Get active proposals for a DAO
-    public query func getActiveProposals(daoId: Principal) : async [Proposal] {
+    public query func getActiveProposals(daoId: DAOId) : async [Proposal] {
         let activeProposals = Buffer.Buffer<Proposal>(0);
         for (proposal in proposals.vals()) {
             if (proposal.daoId == daoId and proposal.status == #active and Time.now() <= proposal.votingDeadline) {
@@ -492,7 +493,7 @@ persistent actor GovernanceCanister {
     };
 
     // Get proposals by status for a DAO
-    public query func getProposalsByStatus(daoId: Principal, status: Types.ProposalStatus) : async [Proposal] {
+    public query func getProposalsByStatus(daoId: DAOId, status: Types.ProposalStatus) : async [Proposal] {
         let filteredProposals = Buffer.Buffer<Proposal>(0);
         for (proposal in proposals.vals()) {
             if (proposal.daoId == daoId and proposal.status == status) {
@@ -503,12 +504,12 @@ persistent actor GovernanceCanister {
     };
 
     // Get user's vote on a proposal
-    public query func getUserVote(daoId: Principal, proposalId: ProposalId, user: Principal) : async ?Vote {
+    public query func getUserVote(daoId: DAOId, proposalId: ProposalId, user: Principal) : async ?Vote {
         votes.get((daoId, proposalId, user))
     };
 
     // Get all votes for a proposal
-    public query func getProposalVotes(daoId: Principal, proposalId: ProposalId) : async [Vote] {
+    public query func getProposalVotes(daoId: DAOId, proposalId: ProposalId) : async [Vote] {
         let proposalVotes = Buffer.Buffer<Vote>(0);
         for (vote in votes.vals()) {
             if (vote.daoId == daoId and vote.proposalId == proposalId) {
@@ -519,19 +520,19 @@ persistent actor GovernanceCanister {
     };
 
     // Get governance configuration for a DAO
-    public query func getConfig(daoId: Principal) : async ?GovernanceConfig {
+    public query func getConfig(daoId: DAOId) : async ?GovernanceConfig {
         config.get(daoId)
     };
 
     // Update governance configuration (admin only)
-    public shared(_msg) func updateConfig(daoId: Principal, newConfig: GovernanceConfig) : async Result<(), Text> {
+    public shared(_msg) func updateConfig(daoId: DAOId, newConfig: GovernanceConfig) : async Result<(), Text> {
         // In a real implementation, you'd check if the caller is an admin
         config.put(daoId, newConfig);
         #ok()
     };
 
     // Helper functions
-    private func getActiveProposalsByUser(daoId: Principal, user: Principal) : [Proposal] {
+    private func getActiveProposalsByUser(daoId: DAOId, user: Principal) : [Proposal] {
         let userProposals = Buffer.Buffer<Proposal>(0);
         for (proposal in proposals.vals()) {
             if (proposal.daoId == daoId and proposal.proposer == user and proposal.status == #active) {
@@ -542,7 +543,7 @@ persistent actor GovernanceCanister {
     };
 
     // Get governance statistics for a DAO
-    public query func getGovernanceStats(daoId: Principal) : async {
+    public query func getGovernanceStats(daoId: DAOId) : async {
         totalProposals: Nat;
         activeProposals: Nat;
         succeededProposals: Nat;

--- a/src/dao_backend/proposals/main.mo
+++ b/src/dao_backend/proposals/main.mo
@@ -18,15 +18,15 @@ persistent actor ProposalsCanister {
     type Vote = Types.Vote;
     type ProposalId = Types.ProposalId;
     type GovernanceConfig = Types.GovernanceConfig;
-    type DAOId = Types.Principal;
+    type DAOId = Types.DAOId;
     type ProposalKey = (DAOId, ProposalId);
 
     private func eqProposalKey(x : ProposalKey, y : ProposalKey) : Bool {
-        Principal.equal(x.0, y.0) and x.1 == y.1
+        Text.equal(x.0, y.0) and x.1 == y.1
     };
 
     private func hashProposalKey(k : ProposalKey) : Nat32 {
-        Text.hash(Principal.toText(k.0) # "_" # Nat.toText(k.1))
+        Text.hash(k.0 # "_" # Nat.toText(k.1))
     };
 
     // Proposal template types
@@ -64,7 +64,7 @@ persistent actor ProposalsCanister {
 
     // Inter-canister reference to staking for voting power
     var staking : actor {
-        getUserStakingSummary: shared query (Principal, Principal) -> async {
+        getUserStakingSummary: shared query (Types.DAOId, Principal) -> async {
             totalStaked: Nat;
             totalRewards: Nat;
             activeStakes: Nat;
@@ -192,7 +192,7 @@ persistent actor ProposalsCanister {
 
     // Create a new proposal
     public shared(msg) func createProposal(
-        daoId: Principal,
+        daoId: DAOId,
         title: Text,
         description: Text,
         proposalType: Types.ProposalType,
@@ -221,7 +221,7 @@ persistent actor ProposalsCanister {
         };
 
         let proposal : Proposal = {
-            daoId = daoId;
+        daoId = daoId;
             id = proposalId;
             proposer = caller;
             title = title;
@@ -244,7 +244,7 @@ persistent actor ProposalsCanister {
 
     // Create proposal from template
     public shared(_msg) func createProposalFromTemplate(
-        daoId: Principal,
+        daoId: DAOId,
         templateId: Nat,
         title: Text,
         parameters: [(Text, Text)],
@@ -282,7 +282,7 @@ persistent actor ProposalsCanister {
 
     // Batch vote on multiple proposals
     public shared(_msg) func batchVote(
-        daoId: Principal,
+        daoId: DAOId,
         votes: [(ProposalId, Types.VoteChoice, ?Text)]
     ) : async [Result<(), Text>] {
         let results = Buffer.Buffer<Result<(), Text>>(votes.size());
@@ -297,13 +297,13 @@ persistent actor ProposalsCanister {
 
     // Cast a vote on a proposal
     public shared(msg) func vote(
-        daoId: Principal,
+        daoId: DAOId,
         proposalId: ProposalId,
         choice: Types.VoteChoice,
         reason: ?Text
     ) : async Result<(), Text> {
         let caller = msg.caller;
-        let voteKey = Principal.toText(daoId) # "_" # Nat.toText(proposalId) # "_" # Principal.toText(caller);
+        let voteKey = daoId # "_" # Nat.toText(proposalId) # "_" # Principal.toText(caller);
 
         // Check if already voted
         switch (votes.get(voteKey)) {
@@ -418,12 +418,12 @@ persistent actor ProposalsCanister {
     // Query functions
 
     // Get proposal by ID
-    public query func getProposal(daoId: Principal, proposalId: ProposalId) : async ?Proposal {
+    public query func getProposal(daoId: DAOId, proposalId: ProposalId) : async ?Proposal {
         proposals.get((daoId, proposalId))
     };
 
     // Get all proposals
-    public query func getAllProposals(daoId: Principal) : async [Proposal] {
+    public query func getAllProposals(daoId: DAOId) : async [Proposal] {
         let filtered = Buffer.Buffer<Proposal>(0);
         for (proposal in proposals.vals()) {
             if (proposal.daoId == daoId) {
@@ -434,7 +434,7 @@ persistent actor ProposalsCanister {
     };
 
     // Get proposals by category
-    public query func getProposalsByCategory(daoId: Principal, category: Text) : async [Proposal] {
+    public query func getProposalsByCategory(daoId: DAOId, category: Text) : async [Proposal] {
         let filteredProposals = Buffer.Buffer<Proposal>(0);
         // Category filtering not implemented yet; return all proposals for DAO
         for (proposal in proposals.vals()) {
@@ -446,7 +446,7 @@ persistent actor ProposalsCanister {
     };
 
     // Get trending proposals (by vote activity)
-    public query func getTrendingProposals(daoId: Principal, limit: Nat) : async [Proposal] {
+    public query func getTrendingProposals(daoId: DAOId, limit: Nat) : async [Proposal] {
         let allProposals = Buffer.Buffer<Proposal>(0);
         for (proposal in proposals.vals()) {
             if (proposal.daoId == daoId) {
@@ -467,22 +467,22 @@ persistent actor ProposalsCanister {
     };
 
     // Get proposal templates
-    public query func getProposalTemplates(_daoId: Principal) : async [ProposalTemplate] {
+    public query func getProposalTemplates(_daoId: DAOId) : async [ProposalTemplate] {
         Iter.toArray(templates.vals())
     };
 
     // Get proposal categories
-    public query func getProposalCategories(_daoId: Principal) : async [ProposalCategory] {
+    public query func getProposalCategories(_daoId: DAOId) : async [ProposalCategory] {
         Iter.toArray(categories.vals())
     };
 
     // Get template by ID
-    public query func getTemplate(_daoId: Principal, templateId: Nat) : async ?ProposalTemplate {
+    public query func getTemplate(_daoId: DAOId, templateId: Nat) : async ?ProposalTemplate {
         templates.get(templateId)
     };
 
     // Get templates by category
-    public query func getTemplatesByCategory(_daoId: Principal, category: Text) : async [ProposalTemplate] {
+    public query func getTemplatesByCategory(_daoId: DAOId, category: Text) : async [ProposalTemplate] {
         let filteredTemplates = Buffer.Buffer<ProposalTemplate>(0);
         for (template in templates.vals()) {
             if (template.category == category) {
@@ -496,7 +496,7 @@ persistent actor ProposalsCanister {
 
     // Add new template
     public shared(_msg) func addTemplate(
-        _daoId: Principal,
+        _daoId: DAOId,
         name: Text,
         description: Text,
         category: Text,
@@ -521,7 +521,7 @@ persistent actor ProposalsCanister {
 
     // Add new category
     public shared(_msg) func addCategory(
-        _daoId: Principal,
+        _daoId: DAOId,
         id: Text,
         name: Text,
         description: Text,
@@ -539,7 +539,7 @@ persistent actor ProposalsCanister {
     };
 
     // Helper functions
-    private func getActiveProposalsByUser(daoId: Principal, user: Principal) : [Proposal] {
+    private func getActiveProposalsByUser(daoId: DAOId, user: Principal) : [Proposal] {
         let userProposals = Buffer.Buffer<Proposal>(0);
         for (proposal in proposals.vals()) {
             if (proposal.daoId == daoId and proposal.proposer == user and proposal.status == #active) {
@@ -550,7 +550,7 @@ persistent actor ProposalsCanister {
     };
 
     // Get proposal statistics
-    public query func getProposalStats(daoId: Principal) : async {
+    public query func getProposalStats(daoId: DAOId) : async {
         totalProposals: Nat;
         activeProposals: Nat;
         succeededProposals: Nat;

--- a/src/dao_backend/shared/types.mo
+++ b/src/dao_backend/shared/types.mo
@@ -102,7 +102,7 @@ module {
     };
 
     public type Proposal = {
-        daoId: Principal;
+        daoId: DAOId;
         id: ProposalId;
         proposer: Principal;
         title: Text;
@@ -125,7 +125,7 @@ module {
     public type VoteChoice = { #inFavor; #against; #abstain };
 
     public type Vote = {
-        daoId: Principal;
+        daoId: DAOId;
         voter: Principal;
         proposalId: ProposalId;
         choice: VoteChoice;
@@ -147,7 +147,7 @@ module {
     };
 
     public type Stake = {
-        daoId: Principal;
+        daoId: DAOId;
         id: StakeId;
         staker: Principal;
         amount: TokenAmount;
@@ -176,7 +176,7 @@ module {
     public type TreasuryTransaction = {
 
         id: Nat;
-        daoId: Principal;
+        daoId: DAOId;
 
         transactionType: TreasuryTransactionType;
         amount: TokenAmount;

--- a/src/dao_backend/staking/main.mo
+++ b/src/dao_backend/staking/main.mo
@@ -45,25 +45,26 @@ persistent actor StakingCanister {
     type TokenAmount = Types.TokenAmount;
     type StakingError = Types.StakingError;
     type CommonError = Types.CommonError;
+    type DAOId = Types.DAOId;
 
     // Stable storage for upgrade persistence
     // Core staking data that must survive canister upgrades
     private var nextStakeId : Nat = 1;
-    private var stakesEntries : [((Principal, StakeId), Stake)] = [];
-    private var userStakesEntries : [(Principal, [(Principal, [StakeId])])] = [];
+    private var stakesEntries : [((DAOId, StakeId), Stake)] = [];
+    private var userStakesEntries : [(Principal, [(DAOId, [StakeId])])] = [];
     private var totalStakedAmount : TokenAmount = 0;
     private var totalRewardsDistributed : TokenAmount = 0;
 
     // Runtime storage - rebuilt from stable storage after upgrades
     // HashMaps provide efficient lookup and management of stake data
-    private func stakeKeyEqual(a: (Principal, StakeId), b: (Principal, StakeId)) : Bool {
-        Principal.equal(a.0, b.0) and Nat.equal(a.1, b.1)
+    private func stakeKeyEqual(a: (DAOId, StakeId), b: (DAOId, StakeId)) : Bool {
+        Text.equal(a.0, b.0) and Nat.equal(a.1, b.1)
     };
-    private func stakeKeyHash(k: (Principal, StakeId)) : Nat32 {
-        Nat32.xor(Principal.hash(k.0), Nat32.fromNat(k.1))
+    private func stakeKeyHash(k: (DAOId, StakeId)) : Nat32 {
+        Nat32.xor(Text.hash(k.0), Nat32.fromNat(k.1))
     };
-    private transient var stakes = HashMap.HashMap<(Principal, StakeId), Stake>(100, stakeKeyEqual, stakeKeyHash);
-    private transient var userStakes = HashMap.HashMap<Principal, HashMap.HashMap<Principal, [StakeId]>>(50, Principal.equal, Principal.hash);
+    private transient var stakes = HashMap.HashMap<(DAOId, StakeId), Stake>(100, stakeKeyEqual, stakeKeyHash);
+    private transient var userStakes = HashMap.HashMap<Principal, HashMap.HashMap<DAOId, [StakeId]>>(50, Principal.equal, Principal.hash);
 
     // Staking configuration parameters
     // These control the economic parameters of the staking system
@@ -82,19 +83,19 @@ persistent actor StakingCanister {
     };
 
     system func postupgrade() {
-        stakes := HashMap.fromIter<(Principal, StakeId), Stake>(
+        stakes := HashMap.fromIter<(DAOId, StakeId), Stake>(
             stakesEntries.vals(),
             stakesEntries.size(),
             stakeKeyEqual,
             stakeKeyHash
         );
-        userStakes := HashMap.HashMap<Principal, HashMap.HashMap<Principal, [StakeId]>>(50, Principal.equal, Principal.hash);
+        userStakes := HashMap.HashMap<Principal, HashMap.HashMap<DAOId, [StakeId]>>(50, Principal.equal, Principal.hash);
         for ((user, daoEntries) in userStakesEntries.vals()) {
-            let daoMap = HashMap.fromIter<Principal, [StakeId]>(
+            let daoMap = HashMap.fromIter<DAOId, [StakeId]>(
                 daoEntries.vals(),
                 daoEntries.size(),
-                Principal.equal,
-                Principal.hash
+                Text.equal,
+                Text.hash
             );
             userStakes.put(user, daoMap);
         };
@@ -103,7 +104,7 @@ persistent actor StakingCanister {
     // Public functions
 
     // Stake tokens
-    public shared(msg) func stake(daoId: Principal, amount: TokenAmount, period: StakingPeriod) : async Result<StakeId, Text> {
+    public shared(msg) func stake(daoId: DAOId, amount: TokenAmount, period: StakingPeriod) : async Result<StakeId, Text> {
         let caller = msg.caller;
 
         if (not stakingEnabled) {
@@ -141,7 +142,7 @@ persistent actor StakingCanister {
         // Update user stakes
         let daoMap = switch (userStakes.get(caller)) {
             case (?map) map;
-            case null HashMap.HashMap<Principal, [StakeId]>(1, Principal.equal, Principal.hash);
+            case null HashMap.HashMap<DAOId, [StakeId]>(1, Text.equal, Text.hash);
         };
         let currentUserStakes = switch (daoMap.get(daoId)) {
             case (?stakes) stakes;
@@ -158,7 +159,7 @@ persistent actor StakingCanister {
     };
 
     // Unstake tokens
-    public shared(msg) func unstake(daoId: Principal, stakeId: StakeId) : async Result<TokenAmount, Text> {
+    public shared(msg) func unstake(daoId: DAOId, stakeId: StakeId) : async Result<TokenAmount, Text> {
         let caller = msg.caller;
 
         let stake = switch (stakes.get((daoId, stakeId))) {
@@ -210,7 +211,7 @@ persistent actor StakingCanister {
     };
 
     // Claim rewards without unstaking (for instant staking)
-    public shared(msg) func claimRewards(daoId: Principal, stakeId: StakeId) : async Result<TokenAmount, Text> {
+    public shared(msg) func claimRewards(daoId: DAOId, stakeId: StakeId) : async Result<TokenAmount, Text> {
         let caller = msg.caller;
 
         let stake = switch (stakes.get((daoId, stakeId))) {
@@ -261,7 +262,7 @@ persistent actor StakingCanister {
     };
 
     // Extend staking period
-    public shared(msg) func extendStakingPeriod(daoId: Principal, stakeId: StakeId, newPeriod: StakingPeriod) : async Result<(), Text> {
+    public shared(msg) func extendStakingPeriod(daoId: DAOId, stakeId: StakeId, newPeriod: StakingPeriod) : async Result<(), Text> {
         let caller = msg.caller;
 
         let stake = switch (stakes.get((daoId, stakeId))) {
@@ -302,13 +303,13 @@ persistent actor StakingCanister {
     // Query functions
 
     // Get stake by ID
-    public query func getStake(daoId: Principal, stakeId: StakeId) : async ?Stake {
+    public query func getStake(daoId: DAOId, stakeId: StakeId) : async ?Stake {
         stakes.get((daoId, stakeId))
     };
 
     // Get user's stakes
     // Private version for internal use
-    private func getUserStakesInternal(daoId: Principal, user: Principal) : [Stake] {
+    private func getUserStakesInternal(daoId: DAOId, user: Principal) : [Stake] {
         let daoMap = switch (userStakes.get(user)) {
             case (?map) map;
             case null return [];
@@ -328,18 +329,18 @@ persistent actor StakingCanister {
         Buffer.toArray(userStakesList)
     };
 
-    public query func getUserStakes(daoId: Principal, user: Principal) : async [Stake] {
+    public query func getUserStakes(daoId: DAOId, user: Principal) : async [Stake] {
         getUserStakesInternal(daoId, user)
     };
 
     // Get user's active stakes
-    public query func getUserActiveStakes(daoId: Principal, user: Principal) : async [Stake] {
+    public query func getUserActiveStakes(daoId: DAOId, user: Principal) : async [Stake] {
         let allUserStakes = getUserStakesInternal(daoId, user);
         Array.filter<Stake>(allUserStakes, func(stake) = stake.isActive)
     };
 
     // Get staking rewards for a stake
-    public query func getStakingRewards(daoId: Principal, stakeId: StakeId) : async ?StakingRewards {
+    public query func getStakingRewards(daoId: DAOId, stakeId: StakeId) : async ?StakingRewards {
         switch (stakes.get((daoId, stakeId))) {
             case (?stake) {
                 let totalRewards = calculateRewards(stake);
@@ -364,7 +365,7 @@ persistent actor StakingCanister {
     };
 
     // Get user's total staking summary
-    public query func getUserStakingSummary(daoId: Principal, user: Principal) : async {
+    public query func getUserStakingSummary(daoId: DAOId, user: Principal) : async {
         totalStaked: TokenAmount;
         totalRewards: TokenAmount;
         activeStakes: Nat;
@@ -394,7 +395,7 @@ persistent actor StakingCanister {
     };
 
     // Get staking statistics
-    public query func getStakingStats(daoId: Principal) : async {
+    public query func getStakingStats(daoId: DAOId) : async {
         totalStakes: Nat;
         activeStakes: Nat;
         totalStakedAmount: TokenAmount;
@@ -413,7 +414,7 @@ persistent actor StakingCanister {
         var locked365Count : Nat = 0;
 
         for (stake in stakes.vals()) {
-            if (Principal.equal(stake.daoId, daoId)) {
+            if (Text.equal(stake.daoId, daoId)) {
                 totalStakesDao += 1;
                 totalRewardsDistributedDao += stake.rewards;
                 if (stake.isActive) {

--- a/src/dao_backend/treasury/main.mo
+++ b/src/dao_backend/treasury/main.mo
@@ -43,21 +43,22 @@ persistent actor TreasuryCanister {
     type TokenAmount = Types.TokenAmount;
     type TreasuryError = Types.TreasuryError;
     type CommonError = Types.CommonError;
+    type DAOId = Types.DAOId;
 
     // Stable storage for upgrade persistence
     // Core financial data that must survive canister upgrades
-    private var balancesEntries : [(Principal, TreasuryBalance)] = [];
+    private var balancesEntries : [(DAOId, TreasuryBalance)] = [];
     private var nextTransactionId : Nat = 1;
     private var transactionsEntries : [(Nat, TreasuryTransaction)] = [];
     private var allowancesEntries : [(Principal, TokenAmount)] = [];
-    private var authorizedPrincipalsEntries : [(Principal, [Principal])] = [];
+    private var authorizedPrincipalsEntries : [(DAOId, [Principal])] = [];
 
     // Runtime storage - rebuilt from stable storage after upgrades
     // HashMaps provide efficient transaction and allowance management
-    private transient var balances = HashMap.HashMap<Principal, TreasuryBalance>(10, Principal.equal, Principal.hash);
+    private transient var balances = HashMap.HashMap<DAOId, TreasuryBalance>(10, Text.equal, Text.hash);
     private transient var transactions = HashMap.HashMap<Nat, TreasuryTransaction>(100, Nat.equal, func(n: Nat) : Nat32 { Nat32.fromNat(n) });
     private transient var allowances = HashMap.HashMap<Principal, TokenAmount>(10, Principal.equal, Principal.hash);
-    private transient var authorizedPrincipals = HashMap.HashMap<Principal, [Principal]>(10, Principal.equal, Principal.hash);
+    private transient var authorizedPrincipals = HashMap.HashMap<DAOId, [Principal]>(10, Text.equal, Text.hash);
 
     // System functions for upgrades
     system func preupgrade() {
@@ -68,11 +69,11 @@ persistent actor TreasuryCanister {
     };
 
     system func postupgrade() {
-        balances := HashMap.fromIter<Principal, TreasuryBalance>(
+        balances := HashMap.fromIter<DAOId, TreasuryBalance>(
             balancesEntries.vals(),
             balancesEntries.size(),
-            Principal.equal,
-            Principal.hash
+            Text.equal,
+            Text.hash
         );
         transactions := HashMap.fromIter<Nat, TreasuryTransaction>(
             transactionsEntries.vals(),
@@ -86,11 +87,11 @@ persistent actor TreasuryCanister {
             Principal.equal,
             Principal.hash
         );
-        authorizedPrincipals := HashMap.fromIter<Principal, [Principal]>(
+        authorizedPrincipals := HashMap.fromIter<DAOId, [Principal]>(
             authorizedPrincipalsEntries.vals(),
             authorizedPrincipalsEntries.size(),
-            Principal.equal,
-            Principal.hash
+            Text.equal,
+            Text.hash
         );
     };
 
@@ -98,7 +99,7 @@ persistent actor TreasuryCanister {
 
 
     // Deposit tokens to treasury
-    public shared(msg) func deposit(daoId: Principal, amount: TokenAmount, description: Text) : async Result<Nat, Text> {
+    public shared(msg) func deposit(daoId: DAOId, amount: TokenAmount, description: Text) : async Result<Nat, Text> {
         if (amount == 0) {
             return #err("Amount must be greater than 0");
         };
@@ -132,7 +133,7 @@ persistent actor TreasuryCanister {
 
     // Withdraw tokens from treasury (requires authorization)
     public shared(msg) func withdraw(
-        daoId: Principal,
+        daoId: DAOId,
         recipient: Principal,
         amount: TokenAmount,
         description: Text,
@@ -215,7 +216,7 @@ persistent actor TreasuryCanister {
     };
 
     // Lock tokens for specific purposes (e.g., staking rewards)
-    public shared(msg) func lockTokens(daoId: Principal, amount: TokenAmount, reason: Text) : async Result<(), Text> {
+    public shared(msg) func lockTokens(daoId: DAOId, amount: TokenAmount, reason: Text) : async Result<(), Text> {
 
         if (not isAuthorized(daoId, msg.caller)) {
             return #err("Not authorized");
@@ -251,7 +252,7 @@ persistent actor TreasuryCanister {
     };
 
     // Unlock tokens
-    public shared(msg) func unlockTokens(daoId: Principal, amount: TokenAmount, reason: Text) : async Result<(), Text> {
+    public shared(msg) func unlockTokens(daoId: DAOId, amount: TokenAmount, reason: Text) : async Result<(), Text> {
         if (not isAuthorized(daoId, msg.caller)) {
             return #err("Not authorized");
         };
@@ -286,7 +287,7 @@ persistent actor TreasuryCanister {
     };
 
     // Reserve tokens for future use
-    public shared(msg) func reserveTokens(daoId: Principal, amount: TokenAmount, reason: Text) : async Result<(), Text> {
+    public shared(msg) func reserveTokens(daoId: DAOId, amount: TokenAmount, reason: Text) : async Result<(), Text> {
         if (not isAuthorized(daoId, msg.caller)) {
             return #err("Not authorized");
         };
@@ -321,7 +322,7 @@ persistent actor TreasuryCanister {
     };
 
     // Release reserved tokens
-    public shared(msg) func releaseReservedTokens(daoId: Principal, amount: TokenAmount, reason: Text) : async Result<(), Text> {
+    public shared(msg) func releaseReservedTokens(daoId: DAOId, amount: TokenAmount, reason: Text) : async Result<(), Text> {
         if (not isAuthorized(daoId, msg.caller)) {
             return #err("Not authorized");
         };
@@ -358,7 +359,7 @@ persistent actor TreasuryCanister {
     // Query functions
 
     // Get treasury balance
-    public query func getBalance(daoId: Principal) : async TreasuryBalance {
+    public query func getBalance(daoId: DAOId) : async TreasuryBalance {
         switch (balances.get(daoId)) {
             case (?bal) { bal };
             case null {
@@ -373,7 +374,7 @@ persistent actor TreasuryCanister {
     };
 
     // Get transaction by ID
-    public query func getTransaction(transactionId: Nat, daoId: Principal) : async ?TreasuryTransaction {
+    public query func getTransaction(transactionId: Nat, daoId: DAOId) : async ?TreasuryTransaction {
         switch (transactions.get(transactionId)) {
             case (?tx) { if (tx.daoId == daoId) ?tx else null };
             case null { null };
@@ -381,7 +382,7 @@ persistent actor TreasuryCanister {
     };
 
     // Get all transactions
-    public query func getAllTransactions(daoId: Principal) : async [TreasuryTransaction] {
+    public query func getAllTransactions(daoId: DAOId) : async [TreasuryTransaction] {
         let filteredTransactions = Buffer.Buffer<TreasuryTransaction>(0);
         for (transaction in transactions.vals()) {
             if (transaction.daoId == daoId) {
@@ -392,7 +393,7 @@ persistent actor TreasuryCanister {
     };
 
     // Get transactions by type
-    public query func getTransactionsByType(daoId: Principal, transactionType: Types.TreasuryTransactionType) : async [TreasuryTransaction] {
+    public query func getTransactionsByType(daoId: DAOId, transactionType: Types.TreasuryTransactionType) : async [TreasuryTransaction] {
         let filteredTransactions = Buffer.Buffer<TreasuryTransaction>(0);
         for (transaction in transactions.vals()) {
             if (transaction.daoId == daoId and transaction.transactionType == transactionType) {
@@ -403,7 +404,7 @@ persistent actor TreasuryCanister {
     };
 
     // Get recent transactions
-    public query func getRecentTransactions(daoId: Principal, limit: Nat) : async [TreasuryTransaction] {
+    public query func getRecentTransactions(daoId: DAOId, limit: Nat) : async [TreasuryTransaction] {
         let buffer = Buffer.Buffer<TreasuryTransaction>(0);
         for (transaction in transactions.vals()) {
             if (transaction.daoId == daoId) {
@@ -425,7 +426,7 @@ persistent actor TreasuryCanister {
     };
 
     // Get treasury statistics
-    public query func getTreasuryStats(daoId: Principal) : async {
+    public query func getTreasuryStats(daoId: DAOId) : async {
         totalTransactions: Nat;
         totalDeposits: TokenAmount;
         totalWithdrawals: TokenAmount;
@@ -479,7 +480,7 @@ persistent actor TreasuryCanister {
     // Administrative functions
 
     // Add authorized principal
-    public shared(_msg) func addAuthorizedPrincipal(daoId: Principal, principal: Principal) : async Result<(), Text> {
+    public shared(_msg) func addAuthorizedPrincipal(daoId: DAOId, principal: Principal) : async Result<(), Text> {
         // In real implementation, only governance or admin should be able to do this
         let principals = Buffer.fromArray<Principal>(
             switch (authorizedPrincipals.get(daoId)) {
@@ -493,7 +494,7 @@ persistent actor TreasuryCanister {
     };
 
     // Remove authorized principal
-    public shared(_msg) func removeAuthorizedPrincipal(daoId: Principal, principal: Principal) : async Result<(), Text> {
+    public shared(_msg) func removeAuthorizedPrincipal(daoId: DAOId, principal: Principal) : async Result<(), Text> {
         // In real implementation, only governance or admin should be able to do this
         let updated = switch (authorizedPrincipals.get(daoId)) {
             case (?arr) Array.filter<Principal>(arr, func(p) = p != principal);
@@ -508,7 +509,7 @@ persistent actor TreasuryCanister {
     };
 
     // Get authorized principals
-    public query func getAuthorizedPrincipals(daoId: Principal) : async [Principal] {
+    public query func getAuthorizedPrincipals(daoId: DAOId) : async [Principal] {
         switch (authorizedPrincipals.get(daoId)) {
             case (?arr) arr;
             case null [];
@@ -516,7 +517,7 @@ persistent actor TreasuryCanister {
     };
 
     // Helper functions
-    private func getBalanceInternal(daoId: Principal) : TreasuryBalance {
+    private func getBalanceInternal(daoId: DAOId) : TreasuryBalance {
         switch (balances.get(daoId)) {
             case (?bal) { bal };
             case null {
@@ -532,7 +533,7 @@ persistent actor TreasuryCanister {
         }
     };
 
-    private func isAuthorized(daoId: Principal, principal: Principal) : Bool {
+    private func isAuthorized(daoId: DAOId, principal: Principal) : Bool {
         switch (authorizedPrincipals.get(daoId)) {
             case (?arr) { Array.find<Principal>(arr, func(p) = p == principal) != null };
             case null { false };

--- a/src/dao_frontend/src/declarations/governance/governance.did
+++ b/src/dao_frontend/src/declarations/governance/governance.did
@@ -6,7 +6,7 @@ type VoteChoice =
  };
 type Vote =
  record {
-   daoId: Principal;
+   daoId: text;
    choice: VoteChoice;
    proposalId: ProposalId;
    reason: opt text;
@@ -51,7 +51,7 @@ type ProposalStatus =
 type ProposalId = nat;
 type Proposal =
  record {
-   daoId: Principal;
+   daoId: text;
    approvalThreshold: nat;
    createdAt: Time;
    description: text;
@@ -92,13 +92,13 @@ type GovernanceConfig =
    votingPeriod: nat;
  };
 service : {
-  createProposal: (daoId: principal, title: text, description: text, proposalType:
+  createProposal: (daoId: text, title: text, description: text, proposalType:
    ProposalType, votingPeriod: opt nat) -> (Result_1);
-  executeProposal: (daoId: principal, proposalId: ProposalId) -> (Result);
-  getActiveProposals: (daoId: principal) -> (vec Proposal) query;
-  getAllProposals: (daoId: principal) -> (vec Proposal) query;
-  getConfig: (daoId: principal) -> (opt GovernanceConfig) query;
-  getGovernanceStats: (daoId: principal) ->
+  executeProposal: (daoId: text, proposalId: ProposalId) -> (Result);
+  getActiveProposals: (daoId: text) -> (vec Proposal) query;
+  getAllProposals: (daoId: text) -> (vec Proposal) query;
+  getConfig: (daoId: text) -> (opt GovernanceConfig) query;
+  getGovernanceStats: (daoId: text) ->
    (record {
       activeProposals: nat;
       failedProposals: nat;
@@ -106,12 +106,12 @@ service : {
       totalProposals: nat;
       totalVotes: nat;
     }) query;
-  getProposal: (daoId: principal, proposalId: ProposalId) -> (opt Proposal) query;
-  getProposalVotes: (daoId: principal, proposalId: ProposalId) -> (vec Vote) query;
-  getProposalsByStatus: (daoId: principal, status: ProposalStatus) -> (vec Proposal) query;
-  getUserVote: (daoId: principal, proposalId: ProposalId, user: principal) -> (opt Vote) query;
+  getProposal: (daoId: text, proposalId: ProposalId) -> (opt Proposal) query;
+  getProposalVotes: (daoId: text, proposalId: ProposalId) -> (vec Vote) query;
+  getProposalsByStatus: (daoId: text, status: ProposalStatus) -> (vec Proposal) query;
+  getUserVote: (daoId: text, proposalId: ProposalId, user: principal) -> (opt Vote) query;
    init: (newDaoId: principal, newStakingId: principal, daoInstanceId: text) -> ();
-  updateConfig: (daoId: principal, newConfig: GovernanceConfig) -> (Result);
-  vote: (daoId: principal, proposalId: ProposalId, choice: VoteChoice, reason: opt text) ->
+  updateConfig: (daoId: text, newConfig: GovernanceConfig) -> (Result);
+  vote: (daoId: text, proposalId: ProposalId, choice: VoteChoice, reason: opt text) ->
    (Result);
 }

--- a/src/dao_frontend/src/declarations/governance/governance.did.d.ts
+++ b/src/dao_frontend/src/declarations/governance/governance.did.d.ts
@@ -22,7 +22,7 @@ export interface ParameterChangeProposal {
 }
 export type Principal = Principal;
 export interface Proposal {
-  'daoId' : Principal,
+  'daoId' : string,
   'id' : ProposalId,
   'status' : ProposalStatus,
   'title' : string,
@@ -61,7 +61,7 @@ export interface TreasuryTransferProposal {
   'reason' : string,
 }
 export interface Vote {
-  'daoId' : Principal,
+  'daoId' : string,
   'votingPower' : bigint,
   'voter' : Principal,
   'timestamp' : Time,
@@ -74,15 +74,15 @@ export type VoteChoice = { 'against' : null } |
   { 'inFavor' : null };
 export interface _SERVICE {
   'createProposal' : ActorMethod<
-    [Principal, string, string, ProposalType, [] | [bigint]],
+    [string, string, string, ProposalType, [] | [bigint]],
     Result_1
   >,
-  'executeProposal' : ActorMethod<[Principal, ProposalId], Result>,
-  'getActiveProposals' : ActorMethod<[Principal], Array<Proposal>>,
-  'getAllProposals' : ActorMethod<[Principal], Array<Proposal>>,
-  'getConfig' : ActorMethod<[Principal], [] | [GovernanceConfig]>,
+  'executeProposal' : ActorMethod<[string, ProposalId], Result>,
+  'getActiveProposals' : ActorMethod<[string], Array<Proposal>>,
+  'getAllProposals' : ActorMethod<[string], Array<Proposal>>,
+  'getConfig' : ActorMethod<[string], [] | [GovernanceConfig]>,
   'getGovernanceStats' : ActorMethod<
-    [Principal],
+    [string],
     {
       'succeededProposals' : bigint,
       'totalVotes' : bigint,
@@ -91,13 +91,13 @@ export interface _SERVICE {
       'activeProposals' : bigint,
     }
   >,
-  'getProposal' : ActorMethod<[Principal, ProposalId], [] | [Proposal]>,
-  'getProposalVotes' : ActorMethod<[Principal, ProposalId], Array<Vote>>,
-  'getProposalsByStatus' : ActorMethod<[Principal, ProposalStatus], Array<Proposal>>,
-  'getUserVote' : ActorMethod<[Principal, ProposalId, Principal], [] | [Vote]>,
+  'getProposal' : ActorMethod<[string, ProposalId], [] | [Proposal]>,
+  'getProposalVotes' : ActorMethod<[string, ProposalId], Array<Vote>>,
+  'getProposalsByStatus' : ActorMethod<[string, ProposalStatus], Array<Proposal>>,
+  'getUserVote' : ActorMethod<[string, ProposalId, Principal], [] | [Vote]>,
   'init' : ActorMethod<[Principal, Principal, string], undefined>,
-  'updateConfig' : ActorMethod<[Principal, GovernanceConfig], Result>,
-  'vote' : ActorMethod<[Principal, ProposalId, VoteChoice, [] | [string]], Result>,
+  'updateConfig' : ActorMethod<[string, GovernanceConfig], Result>,
+  'vote' : ActorMethod<[string, ProposalId, VoteChoice, [] | [string]], Result>,
 }
 export declare const idlFactory: IDL.InterfaceFactory;
 export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/src/dao_frontend/src/declarations/governance/governance.did.js
+++ b/src/dao_frontend/src/declarations/governance/governance.did.js
@@ -35,7 +35,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const Time = IDL.Int;
   const Proposal = IDL.Record({
-    'daoId' : Principal,
+    'daoId' : IDL.Text,
     'id' : ProposalId,
     'status' : ProposalStatus,
     'title' : IDL.Text,
@@ -64,7 +64,7 @@ export const idlFactory = ({ IDL }) => {
     'inFavor' : IDL.Null,
   });
   const Vote = IDL.Record({
-    'daoId' : Principal,
+    'daoId' : IDL.Text,
     'votingPower' : IDL.Nat,
     'voter' : Principal,
     'timestamp' : Time,
@@ -74,16 +74,16 @@ export const idlFactory = ({ IDL }) => {
   });
   return IDL.Service({
     'createProposal' : IDL.Func(
-        [Principal, IDL.Text, IDL.Text, ProposalType, IDL.Opt(IDL.Nat)],
+        [IDL.Text, IDL.Text, IDL.Text, ProposalType, IDL.Opt(IDL.Nat)],
         [Result_1],
         [],
       ),
-    'executeProposal' : IDL.Func([Principal, ProposalId], [Result], []),
-    'getActiveProposals' : IDL.Func([Principal], [IDL.Vec(Proposal)], ['query']),
-    'getAllProposals' : IDL.Func([Principal], [IDL.Vec(Proposal)], ['query']),
-    'getConfig' : IDL.Func([Principal], [IDL.Opt(GovernanceConfig)], ['query']),
+    'executeProposal' : IDL.Func([IDL.Text, ProposalId], [Result], []),
+    'getActiveProposals' : IDL.Func([IDL.Text], [IDL.Vec(Proposal)], ['query']),
+    'getAllProposals' : IDL.Func([IDL.Text], [IDL.Vec(Proposal)], ['query']),
+    'getConfig' : IDL.Func([IDL.Text], [IDL.Opt(GovernanceConfig)], ['query']),
     'getGovernanceStats' : IDL.Func(
-        [Principal],
+        [IDL.Text],
         [
           IDL.Record({
             'succeededProposals' : IDL.Nat,
@@ -95,22 +95,22 @@ export const idlFactory = ({ IDL }) => {
         ],
         ['query'],
       ),
-    'getProposal' : IDL.Func([Principal, ProposalId], [IDL.Opt(Proposal)], ['query']),
-    'getProposalVotes' : IDL.Func([Principal, ProposalId], [IDL.Vec(Vote)], ['query']),
+    'getProposal' : IDL.Func([IDL.Text, ProposalId], [IDL.Opt(Proposal)], ['query']),
+    'getProposalVotes' : IDL.Func([IDL.Text, ProposalId], [IDL.Vec(Vote)], ['query']),
     'getProposalsByStatus' : IDL.Func(
-        [Principal, ProposalStatus],
+        [IDL.Text, ProposalStatus],
         [IDL.Vec(Proposal)],
         ['query'],
       ),
     'getUserVote' : IDL.Func(
-        [Principal, ProposalId, IDL.Principal],
+        [IDL.Text, ProposalId, IDL.Principal],
         [IDL.Opt(Vote)],
         ['query'],
       ),
     'init' : IDL.Func([IDL.Principal, IDL.Principal, IDL.Text], [], []),
-    'updateConfig' : IDL.Func([Principal, GovernanceConfig], [Result], []),
+    'updateConfig' : IDL.Func([IDL.Text, GovernanceConfig], [Result], []),
     'vote' : IDL.Func(
-        [Principal, ProposalId, VoteChoice, IDL.Opt(IDL.Text)],
+        [IDL.Text, ProposalId, VoteChoice, IDL.Opt(IDL.Text)],
         [Result],
         [],
       ),

--- a/src/dao_frontend/src/declarations/proposals/proposals.did
+++ b/src/dao_frontend/src/declarations/proposals/proposals.did
@@ -60,8 +60,9 @@ type ProposalCategory =
    id: text;
    name: text;
  };
-type Proposal = 
+type Proposal =
  record {
+   daoId: text;
    approvalThreshold: nat;
    createdAt: Time;
    description: text;
@@ -94,26 +95,26 @@ type MembershipChangeProposal =
    role: text;
  };
 service : {
-  addCategory: (id: text, name: text, description: text, color: text) ->
+  addCategory: (daoId: text, id: text, name: text, description: text, color: text) ->
    (Result);
-  addTemplate: (name: text, description: text, category: text,
+  addTemplate: (daoId: text, name: text, description: text, category: text,
    requiredFields: vec text, template: text) -> (Result_2);
-  batchVote: (votes: vec record {
+  batchVote: (daoId: text, votes: vec record {
                            ProposalId;
                            VoteChoice;
                            opt text;
                          }) -> (vec Result);
-  createProposal: (title: text, description: text, proposalType:
+  createProposal: (daoId: text, title: text, description: text, proposalType:
    ProposalType, category: opt text, votingPeriod: opt nat) -> (Result_1);
-  createProposalFromTemplate: (templateId: nat, title: text, parameters:
+  createProposalFromTemplate: (daoId: text, templateId: nat, title: text, parameters:
    vec record {
          text;
          text;
        }, votingPeriod: opt nat) -> (Result_1);
-  getAllProposals: () -> (vec Proposal) query;
-  getProposal: (proposalId: ProposalId) -> (opt Proposal) query;
-  getProposalCategories: () -> (vec ProposalCategory) query;
-  getProposalStats: () ->
+  getAllProposals: (daoId: text) -> (vec Proposal) query;
+  getProposal: (daoId: text, proposalId: ProposalId) -> (opt Proposal) query;
+  getProposalCategories: (daoId: text) -> (vec ProposalCategory) query;
+  getProposalStats: (daoId: text) ->
    (record {
       activeProposals: nat;
       failedProposals: nat;
@@ -123,12 +124,12 @@ service : {
       totalTemplates: nat;
       totalVotes: nat;
     }) query;
-  getProposalTemplates: () -> (vec ProposalTemplate) query;
-  getProposalsByCategory: (category: text) -> (vec Proposal) query;
-  getTemplate: (templateId: nat) -> (opt ProposalTemplate) query;
-  getTemplatesByCategory: (category: text) -> (vec ProposalTemplate) query;
-  getTrendingProposals: (limit: nat) -> (vec Proposal) query;
+  getProposalTemplates: (daoId: text) -> (vec ProposalTemplate) query;
+  getProposalsByCategory: (daoId: text, category: text) -> (vec Proposal) query;
+  getTemplate: (daoId: text, templateId: nat) -> (opt ProposalTemplate) query;
+  getTemplatesByCategory: (daoId: text, category: text) -> (vec ProposalTemplate) query;
+  getTrendingProposals: (daoId: text, limit: nat) -> (vec Proposal) query;
   init: (stakingId: principal) -> () oneway;
-  vote: (proposalId: ProposalId, choice: VoteChoice, reason: opt text) ->
+  vote: (daoId: text, proposalId: ProposalId, choice: VoteChoice, reason: opt text) ->
    (Result);
 }

--- a/src/dao_frontend/src/declarations/proposals/proposals.did.d.ts
+++ b/src/dao_frontend/src/declarations/proposals/proposals.did.d.ts
@@ -15,6 +15,7 @@ export interface ParameterChangeProposal {
 }
 export type Principal = Principal;
 export interface Proposal {
+  'daoId' : string,
   'id' : ProposalId,
   'status' : ProposalStatus,
   'title' : string,
@@ -72,28 +73,28 @@ export type VoteChoice = { 'against' : null } |
   { 'abstain' : null } |
   { 'inFavor' : null };
 export interface _SERVICE {
-  'addCategory' : ActorMethod<[string, string, string, string], Result>,
+  'addCategory' : ActorMethod<[string, string, string, string, string], Result>,
   'addTemplate' : ActorMethod<
-    [string, string, string, Array<string>, string],
+    [string, string, string, string, Array<string>, string],
     Result_2
   >,
   'batchVote' : ActorMethod<
-    [Array<[ProposalId, VoteChoice, [] | [string]]>],
+    [string, Array<[ProposalId, VoteChoice, [] | [string]]>],
     Array<Result>
   >,
   'createProposal' : ActorMethod<
-    [string, string, ProposalType, [] | [string], [] | [bigint]],
+    [string, string, string, ProposalType, [] | [string], [] | [bigint]],
     Result_1
   >,
   'createProposalFromTemplate' : ActorMethod<
-    [bigint, string, Array<[string, string]>, [] | [bigint]],
+    [string, bigint, string, Array<[string, string]>, [] | [bigint]],
     Result_1
   >,
-  'getAllProposals' : ActorMethod<[], Array<Proposal>>,
-  'getProposal' : ActorMethod<[ProposalId], [] | [Proposal]>,
-  'getProposalCategories' : ActorMethod<[], Array<ProposalCategory>>,
+  'getAllProposals' : ActorMethod<[string], Array<Proposal>>,
+  'getProposal' : ActorMethod<[string, ProposalId], [] | [Proposal]>,
+  'getProposalCategories' : ActorMethod<[string], Array<ProposalCategory>>,
   'getProposalStats' : ActorMethod<
-    [],
+    [string],
     {
       'succeededProposals' : bigint,
       'totalVotes' : bigint,
@@ -104,13 +105,13 @@ export interface _SERVICE {
       'activeProposals' : bigint,
     }
   >,
-  'getProposalTemplates' : ActorMethod<[], Array<ProposalTemplate>>,
-  'getProposalsByCategory' : ActorMethod<[string], Array<Proposal>>,
-  'getTemplate' : ActorMethod<[bigint], [] | [ProposalTemplate]>,
-  'getTemplatesByCategory' : ActorMethod<[string], Array<ProposalTemplate>>,
-  'getTrendingProposals' : ActorMethod<[bigint], Array<Proposal>>,
+  'getProposalTemplates' : ActorMethod<[string], Array<ProposalTemplate>>,
+  'getProposalsByCategory' : ActorMethod<[string, string], Array<Proposal>>,
+  'getTemplate' : ActorMethod<[string, bigint], [] | [ProposalTemplate]>,
+  'getTemplatesByCategory' : ActorMethod<[string, string], Array<ProposalTemplate>>,
+  'getTrendingProposals' : ActorMethod<[string, bigint], Array<Proposal>>,
   'init' : ActorMethod<[Principal], undefined>,
-  'vote' : ActorMethod<[ProposalId, VoteChoice, [] | [string]], Result>,
+  'vote' : ActorMethod<[string, ProposalId, VoteChoice, [] | [string]], Result>,
 }
 export declare const idlFactory: IDL.InterfaceFactory;
 export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/src/dao_frontend/src/declarations/proposals/proposals.did.js
+++ b/src/dao_frontend/src/declarations/proposals/proposals.did.js
@@ -41,6 +41,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const Time = IDL.Int;
   const Proposal = IDL.Record({
+    'daoId' : IDL.Text,
     'id' : ProposalId,
     'status' : ProposalStatus,
     'title' : IDL.Text,
@@ -72,27 +73,28 @@ export const idlFactory = ({ IDL }) => {
   });
   return IDL.Service({
     'addCategory' : IDL.Func(
-        [IDL.Text, IDL.Text, IDL.Text, IDL.Text],
+        [IDL.Text, IDL.Text, IDL.Text, IDL.Text, IDL.Text],
         [Result],
         [],
       ),
     'addTemplate' : IDL.Func(
-        [IDL.Text, IDL.Text, IDL.Text, IDL.Vec(IDL.Text), IDL.Text],
+        [IDL.Text, IDL.Text, IDL.Text, IDL.Text, IDL.Vec(IDL.Text), IDL.Text],
         [Result_2],
         [],
       ),
     'batchVote' : IDL.Func(
-        [IDL.Vec(IDL.Tuple(ProposalId, VoteChoice, IDL.Opt(IDL.Text)))],
+        [IDL.Text, IDL.Vec(IDL.Tuple(ProposalId, VoteChoice, IDL.Opt(IDL.Text)))],
         [IDL.Vec(Result)],
         [],
       ),
     'createProposal' : IDL.Func(
-        [IDL.Text, IDL.Text, ProposalType, IDL.Opt(IDL.Text), IDL.Opt(IDL.Nat)],
+        [IDL.Text, IDL.Text, IDL.Text, ProposalType, IDL.Opt(IDL.Text), IDL.Opt(IDL.Nat)],
         [Result_1],
         [],
       ),
     'createProposalFromTemplate' : IDL.Func(
         [
+          IDL.Text,
           IDL.Nat,
           IDL.Text,
           IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
@@ -101,15 +103,15 @@ export const idlFactory = ({ IDL }) => {
         [Result_1],
         [],
       ),
-    'getAllProposals' : IDL.Func([], [IDL.Vec(Proposal)], ['query']),
-    'getProposal' : IDL.Func([ProposalId], [IDL.Opt(Proposal)], ['query']),
+    'getAllProposals' : IDL.Func([IDL.Text], [IDL.Vec(Proposal)], ['query']),
+    'getProposal' : IDL.Func([IDL.Text, ProposalId], [IDL.Opt(Proposal)], ['query']),
     'getProposalCategories' : IDL.Func(
-        [],
+        [IDL.Text],
         [IDL.Vec(ProposalCategory)],
         ['query'],
       ),
     'getProposalStats' : IDL.Func(
-        [],
+        [IDL.Text],
         [
           IDL.Record({
             'succeededProposals' : IDL.Nat,
@@ -124,29 +126,29 @@ export const idlFactory = ({ IDL }) => {
         ['query'],
       ),
     'getProposalTemplates' : IDL.Func(
-        [],
+        [IDL.Text],
         [IDL.Vec(ProposalTemplate)],
         ['query'],
       ),
     'getProposalsByCategory' : IDL.Func(
-        [IDL.Text],
+        [IDL.Text, IDL.Text],
         [IDL.Vec(Proposal)],
         ['query'],
       ),
-    'getTemplate' : IDL.Func([IDL.Nat], [IDL.Opt(ProposalTemplate)], ['query']),
+    'getTemplate' : IDL.Func([IDL.Text, IDL.Nat], [IDL.Opt(ProposalTemplate)], ['query']),
     'getTemplatesByCategory' : IDL.Func(
-        [IDL.Text],
+        [IDL.Text, IDL.Text],
         [IDL.Vec(ProposalTemplate)],
         ['query'],
       ),
     'getTrendingProposals' : IDL.Func(
-        [IDL.Nat],
+        [IDL.Text, IDL.Nat],
         [IDL.Vec(Proposal)],
         ['query'],
       ),
     'init' : IDL.Func([IDL.Principal], [], ['oneway']),
     'vote' : IDL.Func(
-        [ProposalId, VoteChoice, IDL.Opt(IDL.Text)],
+        [IDL.Text, ProposalId, VoteChoice, IDL.Opt(IDL.Text)],
         [Result],
         [],
       ),

--- a/src/dao_frontend/src/declarations/staking/staking.did
+++ b/src/dao_frontend/src/declarations/staking/staking.did
@@ -18,7 +18,7 @@ type StakingPeriod =
 type StakeId = nat;
 type Stake =
  record {
-   daoId: Principal;
+   daoId: text;
    amount: TokenAmount;
    id: StakeId;
    isActive: bool;
@@ -45,12 +45,12 @@ type Result =
  };
 type Principal = principal;
 service : {
-  claimRewards: (daoId: Principal, stakeId: StakeId) -> (Result);
-  extendStakingPeriod: (daoId: Principal, stakeId: StakeId, newPeriod: StakingPeriod) ->
+  claimRewards: (daoId: text, stakeId: StakeId) -> (Result);
+  extendStakingPeriod: (daoId: text, stakeId: StakeId, newPeriod: StakingPeriod) ->
    (Result_2);
-  getStake: (daoId: Principal, stakeId: StakeId) -> (opt Stake) query;
-  getStakingRewards: (daoId: Principal, stakeId: StakeId) -> (opt StakingRewards) query;
-  getStakingStats: (daoId: Principal) ->
+  getStake: (daoId: text, stakeId: StakeId) -> (opt Stake) query;
+  getStakingRewards: (daoId: text, stakeId: StakeId) -> (opt StakingRewards) query;
+  getStakingStats: (daoId: text) ->
    (record {
       activeStakes: nat;
       averageStakeAmount: float64;
@@ -62,9 +62,9 @@ service : {
       totalStakedAmount: TokenAmount;
       totalStakes: nat;
     }) query;
-  getUserActiveStakes: (daoId: Principal, user: principal) -> (vec Stake) query;
-  getUserStakes: (daoId: Principal, user: principal) -> (vec Stake) query;
-  getUserStakingSummary: (daoId: Principal, user: principal) ->
+  getUserActiveStakes: (daoId: text, user: principal) -> (vec Stake) query;
+  getUserStakes: (daoId: text, user: principal) -> (vec Stake) query;
+  getUserStakingSummary: (daoId: text, user: principal) ->
    (record {
       activeStakes: nat;
       totalRewards: TokenAmount;
@@ -74,6 +74,6 @@ service : {
   setMaximumStakeAmount: (amount: TokenAmount) -> (Result_2);
   setMinimumStakeAmount: (amount: TokenAmount) -> (Result_2);
   setStakingEnabled: (enabled: bool) -> (Result_2);
-  stake: (daoId: Principal, amount: TokenAmount, period: StakingPeriod) -> (Result_1);
-  unstake: (daoId: Principal, stakeId: StakeId) -> (Result);
+  stake: (daoId: text, amount: TokenAmount, period: StakingPeriod) -> (Result_1);
+  unstake: (daoId: text, stakeId: StakeId) -> (Result);
 }

--- a/src/dao_frontend/src/declarations/staking/staking.did.d.ts
+++ b/src/dao_frontend/src/declarations/staking/staking.did.d.ts
@@ -10,7 +10,7 @@ export type Result_1 = { 'ok' : StakeId } |
 export type Result_2 = { 'ok' : null } |
   { 'err' : string };
 export interface Stake {
-  'daoId' : Principal,
+  'daoId' : string,
   'id' : StakeId,
   'staker' : Principal,
   'unlocksAt' : [] | [Time],
@@ -35,15 +35,15 @@ export interface StakingRewards {
 export type Time = bigint;
 export type TokenAmount = bigint;
 export interface _SERVICE {
-  'claimRewards' : ActorMethod<[Principal, StakeId], Result>,
+  'claimRewards' : ActorMethod<[string, StakeId], Result>,
   'extendStakingPeriod' : ActorMethod<
-    [Principal, StakeId, StakingPeriod],
+    [string, StakeId, StakingPeriod],
     Result_2
   >,
-  'getStake' : ActorMethod<[Principal, StakeId], [] | [Stake]>,
-  'getStakingRewards' : ActorMethod<[Principal, StakeId], [] | [StakingRewards]>,
+  'getStake' : ActorMethod<[string, StakeId], [] | [Stake]>,
+  'getStakingRewards' : ActorMethod<[string, StakeId], [] | [StakingRewards]>,
   'getStakingStats' : ActorMethod<
-    [Principal],
+    [string],
     {
       'stakingPeriodDistribution' : Array<[StakingPeriod, bigint]>,
       'averageStakeAmount' : number,
@@ -53,10 +53,10 @@ export interface _SERVICE {
       'totalStakedAmount' : TokenAmount,
     }
   >,
-  'getUserActiveStakes' : ActorMethod<[Principal, Principal], Array<Stake>>,
-  'getUserStakes' : ActorMethod<[Principal, Principal], Array<Stake>>,
+  'getUserActiveStakes' : ActorMethod<[string, Principal], Array<Stake>>,
+  'getUserStakes' : ActorMethod<[string, Principal], Array<Stake>>,
   'getUserStakingSummary' : ActorMethod<
-    [Principal, Principal],
+    [string, Principal],
     {
       'totalRewards' : TokenAmount,
       'totalVotingPower' : bigint,
@@ -67,8 +67,8 @@ export interface _SERVICE {
   'setMaximumStakeAmount' : ActorMethod<[TokenAmount], Result_2>,
   'setMinimumStakeAmount' : ActorMethod<[TokenAmount], Result_2>,
   'setStakingEnabled' : ActorMethod<[boolean], Result_2>,
-  'stake' : ActorMethod<[Principal, TokenAmount, StakingPeriod], Result_1>,
-  'unstake' : ActorMethod<[Principal, StakeId], Result>,
+  'stake' : ActorMethod<[string, TokenAmount, StakingPeriod], Result_1>,
+  'unstake' : ActorMethod<[string, StakeId], Result>,
 }
 export declare const idlFactory: IDL.InterfaceFactory;
 export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/src/dao_frontend/src/declarations/staking/staking.did.js
+++ b/src/dao_frontend/src/declarations/staking/staking.did.js
@@ -13,7 +13,7 @@ export const idlFactory = ({ IDL }) => {
   const Principal = IDL.Principal;
   const Time = IDL.Int;
   const Stake = IDL.Record({
-    'daoId' : Principal,
+    'daoId' : IDL.Text,
     'amount' : TokenAmount,
     'id' : StakeId,
     'isActive' : IDL.Bool,
@@ -31,20 +31,20 @@ export const idlFactory = ({ IDL }) => {
   });
   const Result_1 = IDL.Variant({ 'ok' : StakeId, 'err' : IDL.Text });
   return IDL.Service({
-    'claimRewards' : IDL.Func([Principal, StakeId], [Result], []),
+    'claimRewards' : IDL.Func([IDL.Text, StakeId], [Result], []),
     'extendStakingPeriod' : IDL.Func(
-        [Principal, StakeId, StakingPeriod],
+        [IDL.Text, StakeId, StakingPeriod],
         [Result_2],
         [],
       ),
-    'getStake' : IDL.Func([Principal, StakeId], [IDL.Opt(Stake)], ['query']),
+    'getStake' : IDL.Func([IDL.Text, StakeId], [IDL.Opt(Stake)], ['query']),
     'getStakingRewards' : IDL.Func(
-        [Principal, StakeId],
+        [IDL.Text, StakeId],
         [IDL.Opt(StakingRewards)],
         ['query'],
       ),
     'getStakingStats' : IDL.Func(
-        [Principal],
+        [IDL.Text],
         [
           IDL.Record({
             'stakingPeriodDistribution' : IDL.Vec(
@@ -60,17 +60,17 @@ export const idlFactory = ({ IDL }) => {
         ['query'],
       ),
     'getUserActiveStakes' : IDL.Func(
-        [Principal, IDL.Principal],
+        [IDL.Text, IDL.Principal],
         [IDL.Vec(Stake)],
         ['query'],
       ),
     'getUserStakes' : IDL.Func(
-        [Principal, IDL.Principal],
+        [IDL.Text, IDL.Principal],
         [IDL.Vec(Stake)],
         ['query'],
       ),
     'getUserStakingSummary' : IDL.Func(
-        [Principal, IDL.Principal],
+        [IDL.Text, IDL.Principal],
         [
           IDL.Record({
             'totalRewards' : TokenAmount,
@@ -84,8 +84,8 @@ export const idlFactory = ({ IDL }) => {
     'setMaximumStakeAmount' : IDL.Func([TokenAmount], [Result_2], []),
     'setMinimumStakeAmount' : IDL.Func([TokenAmount], [Result_2], []),
     'setStakingEnabled' : IDL.Func([IDL.Bool], [Result_2], []),
-    'stake' : IDL.Func([Principal, TokenAmount, StakingPeriod], [Result_1], []),
-    'unstake' : IDL.Func([Principal, StakeId], [Result], []),
+    'stake' : IDL.Func([IDL.Text, TokenAmount, StakingPeriod], [Result_1], []),
+    'unstake' : IDL.Func([IDL.Text, StakeId], [Result], []),
   });
 };
 export const init = ({ IDL }) => { return []; };

--- a/src/dao_frontend/src/declarations/treasury/treasury.did
+++ b/src/dao_frontend/src/declarations/treasury/treasury.did
@@ -9,7 +9,7 @@ type TreasuryTransactionType =
 type TreasuryTransaction =
  record {
    id: nat;
-   daoId: Principal;
+   daoId: text;
    transactionType: TreasuryTransactionType;
    amount: TokenAmount;
    from: opt Principal;
@@ -45,16 +45,16 @@ type Result =
 type ProposalId = nat;
 type Principal = principal;
 service : {
-  addAuthorizedPrincipal: (daoId: Principal, "principal": principal) -> (Result_1);
-  deposit: (daoId: Principal, amount: TokenAmount, description: text) -> (Result);
-  getAllTransactions: (daoId: Principal) -> (vec TreasuryTransaction) query;
-  getAuthorizedPrincipals: (daoId: Principal) -> (vec principal) query;
-  getBalance: (daoId: Principal) -> (TreasuryBalance) query;
-  getRecentTransactions: (daoId: Principal, limit: nat) -> (vec TreasuryTransaction) query;
-  getTransaction: (transactionId: nat, daoId: Principal) -> (opt TreasuryTransaction) query;
-  getTransactionsByType: (daoId: Principal, transactionType: TreasuryTransactionType) ->
+  addAuthorizedPrincipal: (daoId: text, "principal": principal) -> (Result_1);
+  deposit: (daoId: text, amount: TokenAmount, description: text) -> (Result);
+  getAllTransactions: (daoId: text) -> (vec TreasuryTransaction) query;
+  getAuthorizedPrincipals: (daoId: text) -> (vec principal) query;
+  getBalance: (daoId: text) -> (TreasuryBalance) query;
+  getRecentTransactions: (daoId: text, limit: nat) -> (vec TreasuryTransaction) query;
+  getTransaction: (transactionId: nat, daoId: text) -> (opt TreasuryTransaction) query;
+  getTransactionsByType: (daoId: text, transactionType: TreasuryTransactionType) ->
    (vec TreasuryTransaction) query;
-  getTreasuryStats: (daoId: Principal) ->
+  getTreasuryStats: (daoId: text) ->
    (record {
       averageTransactionAmount: float64;
       balance: TreasuryBalance;
@@ -62,11 +62,11 @@ service : {
       totalTransactions: nat;
       totalWithdrawals: TokenAmount;
     }) query;
-  lockTokens: (daoId: Principal, amount: TokenAmount, reason: text) -> (Result_1);
-  releaseReservedTokens: (daoId: Principal, amount: TokenAmount, reason: text) -> (Result_1);
-  removeAuthorizedPrincipal: (daoId: Principal, "principal": principal) -> (Result_1);
-  reserveTokens: (daoId: Principal, amount: TokenAmount, reason: text) -> (Result_1);
-  unlockTokens: (daoId: Principal, amount: TokenAmount, reason: text) -> (Result_1);
-  withdraw: (daoId: Principal, recipient: principal, amount: TokenAmount, description:
+  lockTokens: (daoId: text, amount: TokenAmount, reason: text) -> (Result_1);
+  releaseReservedTokens: (daoId: text, amount: TokenAmount, reason: text) -> (Result_1);
+  removeAuthorizedPrincipal: (daoId: text, "principal": principal) -> (Result_1);
+  reserveTokens: (daoId: text, amount: TokenAmount, reason: text) -> (Result_1);
+  unlockTokens: (daoId: text, amount: TokenAmount, reason: text) -> (Result_1);
+  withdraw: (daoId: text, recipient: principal, amount: TokenAmount, description:
    text, proposalId: opt ProposalId) -> (Result);
 }

--- a/src/dao_frontend/src/declarations/treasury/treasury.did.d.ts
+++ b/src/dao_frontend/src/declarations/treasury/treasury.did.d.ts
@@ -18,7 +18,7 @@ export interface TreasuryBalance {
 }
 export interface TreasuryTransaction {
   'id' : bigint,
-  'daoId' : Principal,
+  'daoId' : string,
   'transactionType' : TreasuryTransactionType,
   'amount' : TokenAmount,
   'from' : [] | [Principal],
@@ -36,19 +36,19 @@ export type TreasuryTransactionType = { 'fee' : null } |
   { 'withdrawal' : null } |
   { 'proposalExecution' : null };
 export interface _SERVICE {
-  'addAuthorizedPrincipal' : ActorMethod<[Principal, Principal], Result_1>,
-  'deposit' : ActorMethod<[Principal, TokenAmount, string], Result>,
-  'getAllTransactions' : ActorMethod<[Principal], Array<TreasuryTransaction>>,
-  'getAuthorizedPrincipals' : ActorMethod<[Principal], Array<Principal>>,
-  'getBalance' : ActorMethod<[Principal], TreasuryBalance>,
-  'getRecentTransactions' : ActorMethod<[Principal, bigint], Array<TreasuryTransaction>>,
-  'getTransaction' : ActorMethod<[bigint, Principal], [] | [TreasuryTransaction]>,
+  'addAuthorizedPrincipal' : ActorMethod<[string, Principal], Result_1>,
+  'deposit' : ActorMethod<[string, TokenAmount, string], Result>,
+  'getAllTransactions' : ActorMethod<[string], Array<TreasuryTransaction>>,
+  'getAuthorizedPrincipals' : ActorMethod<[string], Array<Principal>>,
+  'getBalance' : ActorMethod<[string], TreasuryBalance>,
+  'getRecentTransactions' : ActorMethod<[string, bigint], Array<TreasuryTransaction>>,
+  'getTransaction' : ActorMethod<[bigint, string], [] | [TreasuryTransaction]>,
   'getTransactionsByType' : ActorMethod<
-    [Principal, TreasuryTransactionType],
+    [string, TreasuryTransactionType],
     Array<TreasuryTransaction>
   >,
   'getTreasuryStats' : ActorMethod<
-    [Principal],
+    [string],
     {
       'balance' : TreasuryBalance,
       'totalWithdrawals' : TokenAmount,
@@ -57,13 +57,13 @@ export interface _SERVICE {
       'totalTransactions' : bigint,
     }
   >,
-  'lockTokens' : ActorMethod<[Principal, TokenAmount, string], Result_1>,
-  'releaseReservedTokens' : ActorMethod<[Principal, TokenAmount, string], Result_1>,
-  'removeAuthorizedPrincipal' : ActorMethod<[Principal, Principal], Result_1>,
-  'reserveTokens' : ActorMethod<[Principal, TokenAmount, string], Result_1>,
-  'unlockTokens' : ActorMethod<[Principal, TokenAmount, string], Result_1>,
+  'lockTokens' : ActorMethod<[string, TokenAmount, string], Result_1>,
+  'releaseReservedTokens' : ActorMethod<[string, TokenAmount, string], Result_1>,
+  'removeAuthorizedPrincipal' : ActorMethod<[string, Principal], Result_1>,
+  'reserveTokens' : ActorMethod<[string, TokenAmount, string], Result_1>,
+  'unlockTokens' : ActorMethod<[string, TokenAmount, string], Result_1>,
   'withdraw' : ActorMethod<
-    [Principal, Principal, TokenAmount, string, [] | [ProposalId]],
+    [string, Principal, TokenAmount, string, [] | [ProposalId]],
     Result
   >,
 }

--- a/src/dao_frontend/src/declarations/treasury/treasury.did.js
+++ b/src/dao_frontend/src/declarations/treasury/treasury.did.js
@@ -14,7 +14,7 @@ export const idlFactory = ({ IDL }) => {
   const ProposalId = IDL.Nat;
   const TreasuryTransaction = IDL.Record({
     'id' : IDL.Nat,
-    'daoId' : Principal,
+    'daoId' : IDL.Text,
     'transactionType' : TreasuryTransactionType,
     'amount' : TokenAmount,
     'from' : IDL.Opt(Principal),
@@ -35,36 +35,36 @@ export const idlFactory = ({ IDL }) => {
     'available' : TokenAmount,
   });
   return IDL.Service({
-    'addAuthorizedPrincipal' : IDL.Func([Principal, IDL.Principal], [Result_1], []),
-    'deposit' : IDL.Func([Principal, TokenAmount, IDL.Text], [Result], []),
+    'addAuthorizedPrincipal' : IDL.Func([IDL.Text, IDL.Principal], [Result_1], []),
+    'deposit' : IDL.Func([IDL.Text, TokenAmount, IDL.Text], [Result], []),
     'getAllTransactions' : IDL.Func(
-        [Principal],
+        [IDL.Text],
         [IDL.Vec(TreasuryTransaction)],
         ['query'],
       ),
     'getAuthorizedPrincipals' : IDL.Func(
-        [Principal],
+        [IDL.Text],
         [IDL.Vec(IDL.Principal)],
         ['query'],
       ),
-    'getBalance' : IDL.Func([Principal], [TreasuryBalance], ['query']),
+    'getBalance' : IDL.Func([IDL.Text], [TreasuryBalance], ['query']),
     'getRecentTransactions' : IDL.Func(
-        [Principal, IDL.Nat],
+        [IDL.Text, IDL.Nat],
         [IDL.Vec(TreasuryTransaction)],
         ['query'],
       ),
     'getTransaction' : IDL.Func(
-        [IDL.Nat, Principal],
+        [IDL.Nat, IDL.Text],
         [IDL.Opt(TreasuryTransaction)],
         ['query'],
       ),
     'getTransactionsByType' : IDL.Func(
-        [Principal, TreasuryTransactionType],
+        [IDL.Text, TreasuryTransactionType],
         [IDL.Vec(TreasuryTransaction)],
         ['query'],
       ),
     'getTreasuryStats' : IDL.Func(
-        [Principal],
+        [IDL.Text],
         [
           IDL.Record({
             'balance' : TreasuryBalance,
@@ -76,13 +76,13 @@ export const idlFactory = ({ IDL }) => {
         ],
         ['query'],
       ),
-    'lockTokens' : IDL.Func([Principal, TokenAmount, IDL.Text], [Result_1], []),
-    'releaseReservedTokens' : IDL.Func([Principal, TokenAmount, IDL.Text], [Result_1], []),
-    'removeAuthorizedPrincipal' : IDL.Func([Principal, IDL.Principal], [Result_1], []),
-    'reserveTokens' : IDL.Func([Principal, TokenAmount, IDL.Text], [Result_1], []),
-    'unlockTokens' : IDL.Func([Principal, TokenAmount, IDL.Text], [Result_1], []),
+    'lockTokens' : IDL.Func([IDL.Text, TokenAmount, IDL.Text], [Result_1], []),
+    'releaseReservedTokens' : IDL.Func([IDL.Text, TokenAmount, IDL.Text], [Result_1], []),
+    'removeAuthorizedPrincipal' : IDL.Func([IDL.Text, IDL.Principal], [Result_1], []),
+    'reserveTokens' : IDL.Func([IDL.Text, TokenAmount, IDL.Text], [Result_1], []),
+    'unlockTokens' : IDL.Func([IDL.Text, TokenAmount, IDL.Text], [Result_1], []),
     'withdraw' : IDL.Func(
-        [Principal, IDL.Principal, TokenAmount, IDL.Text, IDL.Opt(ProposalId)],
+        [IDL.Text, IDL.Principal, TokenAmount, IDL.Text, IDL.Opt(ProposalId)],
         [Result],
         [],
       ),


### PR DESCRIPTION
## Summary
- switch core DAO structures from Principal to DAOId
- update backend canisters and frontend interfaces to use DAOId
- adjust generated declarations to accept DAOId text identifiers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1e57cac8c8320a9b18e47f57ff03a