### PR TITLE
Pass proposal settings to proposals canister

### DIFF
--- a/src/dao_backend/main.mo
+++ b/src/dao_backend/main.mo
@@ -666,9 +666,9 @@ persistent actor DAOMain {
                             Principal.fromText(daoId),
                             title,
                             description,
-                            #textProposal(description),
-                            null,
-                            null
+                            proposalType,
+                            category,
+                            votingPeriod
                         );
                         res
                     };


### PR DESCRIPTION
## Summary
- allow `createProposal` to forward the specified `proposalType`, `category`, and `votingPeriod` to the proposals canister

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1ed8de6788320af80fe6f5d3944da