### PR TITLE
Update vote call to use DAO principal

### DIFF
--- a/src/dao_backend/main.mo
+++ b/src/dao_backend/main.mo
@@ -695,16 +695,16 @@ persistent actor DAOMain {
         switch (state.proposalsCanister) {
             case null return #err("Proposals canister not configured");
             case (?proposalsId) {
+                let daoPrincipal = Principal.fromText(daoId);
                 let proposals = actor(Principal.toText(proposalsId)) : actor {
                     vote: shared (
-                        DAOId,
                         Principal,
                         ProposalId,
                         VoteChoice,
                         ?Text
                     ) -> async Result<(), Text>;
                 };
-                await proposals.vote(daoId, msg.caller, proposalId, choice, reason)
+                await proposals.vote(daoPrincipal, proposalId, choice, reason)
             };
         }
     };


### PR DESCRIPTION
## Summary
- align vote actor interface with proposals canister
- forward DAO principal instead of caller when voting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1ee1130048320b559694c2d82eb8c