### PR TITLE
Filter DAO proposals by category

### DIFF
--- a/src/dao_backend/proposals/main.mo
+++ b/src/dao_backend/proposals/main.mo
@@ -475,9 +475,8 @@ persistent actor ProposalsCanister {
             throw Error.reject("Canister not initialized");
         };
         let filteredProposals = Buffer.Buffer<Proposal>(0);
-        // Category filtering not implemented yet; return all proposals for DAO
         for (proposal in proposals.vals()) {
-            if (proposal.daoId == daoId) {
+            if (proposal.daoId == daoId and proposal.category == ?category) {
                 filteredProposals.add(proposal);
             };
         };


### PR DESCRIPTION
## Summary
- refine proposal retrieval to filter by DAO ID and category

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1ee19b33c83209262ecbd2ccac493