### PR TITLE
feat: add activity feeds for DAO modules

### DIFF
--- a/src/dao_backend/governance/main.mo
+++ b/src/dao_backend/governance/main.mo
@@ -630,4 +630,58 @@ persistent actor GovernanceCanister {
             totalVotes = voteCount;
         }
     };
+
+    // Recent governance activity
+    public query func getRecentActivity() : async [Types.Activity] {
+        if (not initialized) {
+            throw Error.reject("Canister not initialized");
+        };
+
+        let buffer = Buffer.Buffer<Types.Activity>(0);
+
+        for (proposal in proposals.vals()) {
+            let statusText = switch (proposal.status) {
+                case (#pending) "pending";
+                case (#active) "active";
+                case (#succeeded) "succeeded";
+                case (#executed) "executed";
+                case (#failed) "failed";
+                case (#cancelled) "cancelled";
+            };
+            buffer.add({
+                activityType = "proposal";
+                title = proposal.title;
+                description = proposal.description;
+                timestamp = proposal.createdAt;
+                status = statusText;
+            });
+        };
+
+        for (vote in votes.vals()) {
+            let choiceText = switch (vote.choice) {
+                case (#inFavor) "inFavor";
+                case (#against) "against";
+                case (#abstain) "abstain";
+            };
+            buffer.add({
+                activityType = "vote";
+                title = "Vote on proposal #" # Nat.toText(vote.proposalId);
+                description = choiceText;
+                timestamp = vote.timestamp;
+                status = choiceText;
+            });
+        };
+
+        let all = Buffer.toArray(buffer);
+        let sorted = Array.sort(all, func(a: Types.Activity, b: Types.Activity) : { #less; #equal; #greater } {
+            if (a.timestamp > b.timestamp) { #less } else if (a.timestamp < b.timestamp) { #greater } else { #equal }
+        });
+
+        let limit = 20;
+        if (sorted.size() <= limit) {
+            sorted
+        } else {
+            Array.tabulate<Types.Activity>(limit, func(i) = sorted[i])
+        }
+    };
 }

--- a/src/dao_backend/main.mo
+++ b/src/dao_backend/main.mo
@@ -50,7 +50,7 @@ persistent actor DAOMain {
     };
 
     private type TreasuryActor = actor {
-        listTransactions : shared query () -> async [Activity];
+        getRecentActivity : shared query () -> async [Activity];
     };
 
     private type GovernanceActor = actor {
@@ -565,7 +565,7 @@ persistent actor DAOMain {
                     case (?cid) {
                         let can : TreasuryActor = actor (Principal.toText(cid));
                         try {
-                            await can.listTransactions();
+                            await can.getRecentActivity();
                         } catch (_) { [] };
                     };
                     case null [];

--- a/src/dao_backend/proposals/main.mo
+++ b/src/dao_backend/proposals/main.mo
@@ -656,4 +656,58 @@ persistent actor ProposalsCanister {
             totalCategories = categories.size();
         }
     };
+
+    // Recent activity combining proposals and votes
+    public query func getRecentActivity() : async [Types.Activity] {
+        if (not initialized) {
+            throw Error.reject("Canister not initialized");
+        };
+
+        let buffer = Buffer.Buffer<Types.Activity>(0);
+
+        for (proposal in proposals.vals()) {
+            let statusText = switch (proposal.status) {
+                case (#pending) "pending";
+                case (#active) "active";
+                case (#succeeded) "succeeded";
+                case (#executed) "executed";
+                case (#failed) "failed";
+                case (#cancelled) "cancelled";
+            };
+            buffer.add({
+                activityType = "proposal";
+                title = proposal.title;
+                description = proposal.description;
+                timestamp = proposal.createdAt;
+                status = statusText;
+            });
+        };
+
+        for (vote in votes.vals()) {
+            let choiceText = switch (vote.choice) {
+                case (#inFavor) "inFavor";
+                case (#against) "against";
+                case (#abstain) "abstain";
+            };
+            buffer.add({
+                activityType = "vote";
+                title = "Vote on proposal #" # Nat.toText(vote.proposalId);
+                description = choiceText;
+                timestamp = vote.timestamp;
+                status = choiceText;
+            });
+        };
+
+        let all = Buffer.toArray(buffer);
+        let sorted = Array.sort(all, func(a: Types.Activity, b: Types.Activity) : { #less; #equal; #greater } {
+            if (a.timestamp > b.timestamp) { #less } else if (a.timestamp < b.timestamp) { #greater } else { #equal }
+        });
+
+        let limit = 20;
+        if (sorted.size() <= limit) {
+            sorted
+        } else {
+            Array.tabulate<Types.Activity>(limit, func(i) = sorted[i])
+        }
+    };
 }

--- a/src/dao_backend/staking/main.mo
+++ b/src/dao_backend/staking/main.mo
@@ -397,10 +397,10 @@ persistent actor StakingCanister {
     public query func getStakingStats(daoId: Principal) : async {
         totalStakes: Nat;
         activeStakes: Nat;
-        totalStakedAmount: TokenAmount;
-        totalRewardsDistributed: TokenAmount;
-        averageStakeAmount: Float;
-        stakingPeriodDistribution: [(StakingPeriod, Nat)];
+       totalStakedAmount: TokenAmount;
+       totalRewardsDistributed: TokenAmount;
+       averageStakeAmount: Float;
+       stakingPeriodDistribution: [(StakingPeriod, Nat)];
     } {
         var totalStakesDao : Nat = 0;
         var activeStakesDao : Nat = 0;
@@ -447,6 +447,40 @@ persistent actor StakingCanister {
                 (#locked180, locked180Count),
                 (#locked365, locked365Count)
             ];
+        }
+    };
+
+    // Recent staking activity
+    public query func getRecentActivity() : async [Types.Activity] {
+        let buf = Buffer.Buffer<Types.Activity>(0);
+        for (stake in stakes.vals()) {
+            let periodText = switch (stake.stakingPeriod) {
+                case (#instant) "instant";
+                case (#locked30) "locked30";
+                case (#locked90) "locked90";
+                case (#locked180) "locked180";
+                case (#locked365) "locked365";
+            };
+            let statusText = if (stake.isActive) { "active" } else { "ended" };
+            buf.add({
+                activityType = "stake";
+                title = "Stake " # Nat.toText(stake.amount) # " tokens";
+                description = "period: " # periodText;
+                timestamp = stake.stakedAt;
+                status = statusText;
+            });
+        };
+
+        let all = Buffer.toArray(buf);
+        let sorted = Array.sort(all, func(a: Types.Activity, b: Types.Activity) : { #less; #equal; #greater } {
+            if (a.timestamp > b.timestamp) { #less } else if (a.timestamp < b.timestamp) { #greater } else { #equal }
+        });
+
+        let limit = 20;
+        if (sorted.size() <= limit) {
+            sorted
+        } else {
+            Array.tabulate<Types.Activity>(limit, func(i) = sorted[i])
         }
     };
 

--- a/src/dao_backend/treasury/main.mo
+++ b/src/dao_backend/treasury/main.mo
@@ -424,6 +424,49 @@ persistent actor TreasuryCanister {
         }
     };
 
+    // Convert recent transactions into activity records
+    public query func getRecentActivity() : async [Types.Activity] {
+        let txBuffer = Buffer.Buffer<TreasuryTransaction>(0);
+        for (tx in transactions.vals()) {
+            txBuffer.add(tx);
+        };
+        let allTx = Buffer.toArray(txBuffer);
+        let sortedTx = Array.sort(allTx, func(a: TreasuryTransaction, b: TreasuryTransaction) : {#less; #equal; #greater} {
+            if (a.timestamp > b.timestamp) #less
+            else if (a.timestamp < b.timestamp) #greater
+            else #equal
+        });
+
+        let limit = 20;
+        let selected = if (sortedTx.size() <= limit) {
+            sortedTx
+        } else {
+            Array.tabulate<TreasuryTransaction>(limit, func(i) = sortedTx[i])
+        };
+
+        Array.map<TreasuryTransaction, Types.Activity>(selected, func(tx) : Types.Activity {
+            let typeText = switch (tx.transactionType) {
+                case (#deposit) "deposit";
+                case (#withdrawal) "withdrawal";
+                case (#proposalExecution) "proposalExecution";
+                case (#stakingReward) "stakingReward";
+                case (#fee) "fee";
+            };
+            let statusText = switch (tx.status) {
+                case (#pending) "pending";
+                case (#completed) "completed";
+                case (#failed) "failed";
+            };
+            {
+                activityType = typeText;
+                title = typeText;
+                description = tx.description;
+                timestamp = tx.timestamp;
+                status = statusText;
+            }
+        })
+    };
+
     // Get treasury statistics
     public query func getTreasuryStats(daoId: Principal) : async {
         totalTransactions: Nat;


### PR DESCRIPTION
## Summary
- add `getRecentActivity` for proposals, staking, governance and treasury
- return unified `Types.Activity` records and sort by time
- aggregate new activity feeds in `dao_backend` main

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1efb3f5a88320a984be624a5ddb1d