### PR TITLE
Remove Principal conversion for DAO IDs

### DIFF
--- a/src/dao_frontend/src/hooks/useAssets.js
+++ b/src/dao_frontend/src/hooks/useAssets.js
@@ -14,7 +14,7 @@ export const useAssets = () => {
       const arrayBuffer = await file.arrayBuffer();
       const data = Array.from(new Uint8Array(arrayBuffer));
       const result = await actors.assets.uploadAsset(
-        Principal.fromText(daoId),
+        daoId,
         file.name,
         file.type,
         data,
@@ -38,7 +38,7 @@ export const useAssets = () => {
     setError(null);
     try {
       const res = await actors.assets.getAsset(
-        Principal.fromText(daoId),
+        daoId,
         BigInt(assetId)
       );
       if (res.err) {
@@ -58,7 +58,7 @@ export const useAssets = () => {
     setError(null);
     try {
       return await actors.assets.getAssetMetadata(
-        Principal.fromText(daoId),
+        daoId,
         BigInt(assetId)
       );
     } catch (err) {
@@ -73,7 +73,7 @@ export const useAssets = () => {
     setLoading(true);
     setError(null);
     try {
-      return await actors.assets.getPublicAssets(Principal.fromText(daoId));
+      return await actors.assets.getPublicAssets(daoId);
     } catch (err) {
       setError(err.message);
       throw err;
@@ -86,7 +86,7 @@ export const useAssets = () => {
     setLoading(true);
     setError(null);
     try {
-      return await actors.assets.getUserAssets(Principal.fromText(daoId));
+      return await actors.assets.getUserAssets(daoId);
     } catch (err) {
       setError(err.message);
       throw err;
@@ -100,7 +100,7 @@ export const useAssets = () => {
     setError(null);
     try {
       return await actors.assets.searchAssetsByTag(
-        Principal.fromText(daoId),
+        daoId,
         tag
       );
     } catch (err) {
@@ -116,7 +116,7 @@ export const useAssets = () => {
     setError(null);
     try {
       const res = await actors.assets.deleteAsset(
-        Principal.fromText(daoId),
+        daoId,
         BigInt(assetId)
       );
       if (res.err) {
@@ -136,7 +136,7 @@ export const useAssets = () => {
     setError(null);
     try {
       const res = await actors.assets.updateAssetMetadata(
-        Principal.fromText(daoId),
+        daoId,
         BigInt(assetId),
         name === null ? [] : [name],
         isPublic === null ? [] : [isPublic],
@@ -158,7 +158,7 @@ export const useAssets = () => {
     setLoading(true);
     setError(null);
     try {
-      return await actors.assets.getStorageStats(Principal.fromText(daoId));
+      return await actors.assets.getStorageStats(daoId);
     } catch (err) {
       setError(err.message);
       throw err;
@@ -260,7 +260,7 @@ export const useAssets = () => {
     setError(null);
     try {
       return await actors.assets.getAssetByName(
-        Principal.fromText(daoId),
+        daoId,
         name
       );
     } catch (err) {
@@ -283,7 +283,7 @@ export const useAssets = () => {
         })
       );
       return await actors.assets.batchUploadAssets(
-        Principal.fromText(daoId),
+        daoId,
         formatted
       );
     } catch (err) {

--- a/src/dao_frontend/src/hooks/useGovernance.js
+++ b/src/dao_frontend/src/hooks/useGovernance.js
@@ -11,9 +11,9 @@ export const useGovernance = () => {
 
   const toNanoseconds = (seconds) => BigInt(seconds) * 1_000_000_000n;
 
-  const getDaoPrincipal = () => {
+  const getDaoId = () => {
     if (!activeDAO?.id) throw new Error('No active DAO selected');
-    return Principal.fromText(activeDAO.id);
+    return activeDAO.id;
   };
 
   const createProposal = async (
@@ -25,9 +25,8 @@ export const useGovernance = () => {
     setLoading(true);
     setError(null);
     try {
-      const daoPrincipal = getDaoPrincipal();
       const res = await actors.governance.createProposal(
-        daoPrincipal,
+        getDaoId(),
         title,
         description,
         proposalType,
@@ -48,9 +47,8 @@ export const useGovernance = () => {
     setError(null);
     try {
       const choiceVariant = { [choice]: null };
-      const daoPrincipal = getDaoPrincipal();
       const res = await actors.governance.vote(
-        daoPrincipal,
+        getDaoId(),
         BigInt(proposalId),
         choiceVariant,
         reason ? [reason] : []
@@ -69,8 +67,7 @@ export const useGovernance = () => {
     setLoading(true);
     setError(null);
     try {
-      const daoPrincipal = getDaoPrincipal();
-      const res = await actors.governance.getConfig(daoPrincipal);
+      const res = await actors.governance.getConfig(getDaoId());
       return res && res.length ? res[0] : null;
     } catch (err) {
       setError(err.message);
@@ -84,8 +81,7 @@ export const useGovernance = () => {
     setLoading(true);
     setError(null);
     try {
-      const daoPrincipal = getDaoPrincipal();
-      const res = await actors.governance.getGovernanceStats(daoPrincipal);
+      const res = await actors.governance.getGovernanceStats(getDaoId());
       return res;
     } catch (err) {
       setError(err.message);
@@ -99,9 +95,8 @@ export const useGovernance = () => {
     setLoading(true);
     setError(null);
     try {
-      const daoPrincipal = getDaoPrincipal();
       const res = await actors.governance.executeProposal(
-        daoPrincipal,
+        getDaoId(),
         BigInt(proposalId)
       );
       if ('err' in res) throw new Error(res.err);
@@ -118,8 +113,7 @@ export const useGovernance = () => {
     setLoading(true);
     setError(null);
     try {
-      const daoPrincipal = getDaoPrincipal();
-      return await actors.governance.getActiveProposals(daoPrincipal);
+      return await actors.governance.getActiveProposals(getDaoId());
     } catch (err) {
       setError(err.message);
       throw err;
@@ -132,8 +126,7 @@ export const useGovernance = () => {
     setLoading(true);
     setError(null);
     try {
-      const daoPrincipal = getDaoPrincipal();
-      return await actors.governance.getAllProposals(daoPrincipal);
+      return await actors.governance.getAllProposals(getDaoId());
     } catch (err) {
       setError(err.message);
       throw err;
@@ -146,9 +139,8 @@ export const useGovernance = () => {
     setLoading(true);
     setError(null);
     try {
-      const daoPrincipal = getDaoPrincipal();
       const res = await actors.governance.getProposal(
-        daoPrincipal,
+        getDaoId(),
         BigInt(proposalId)
       );
       return res && res.length ? res[0] : null;
@@ -164,9 +156,8 @@ export const useGovernance = () => {
     setLoading(true);
     setError(null);
     try {
-      const daoPrincipal = getDaoPrincipal();
       return await actors.governance.getProposalVotes(
-        daoPrincipal,
+        getDaoId(),
         BigInt(proposalId)
       );
     } catch (err) {
@@ -182,9 +173,8 @@ export const useGovernance = () => {
     setError(null);
     try {
       const statusVariant = { [status]: null };
-      const daoPrincipal = getDaoPrincipal();
       return await actors.governance.getProposalsByStatus(
-        daoPrincipal,
+        getDaoId(),
         statusVariant
       );
     } catch (err) {
@@ -199,10 +189,9 @@ export const useGovernance = () => {
     setLoading(true);
     setError(null);
     try {
-      const daoPrincipal = getDaoPrincipal();
       const userPrincipal = Principal.fromText(user);
       const res = await actors.governance.getUserVote(
-        daoPrincipal,
+        getDaoId(),
         BigInt(proposalId),
         userPrincipal
       );
@@ -219,9 +208,8 @@ export const useGovernance = () => {
     setLoading(true);
     setError(null);
     try {
-      const daoPrincipal = getDaoPrincipal();
       const res = await actors.governance.updateConfig(
-        daoPrincipal,
+        getDaoId(),
         newConfig
       );
       if ('err' in res) throw new Error(res.err);

--- a/src/dao_frontend/src/hooks/useStaking.js
+++ b/src/dao_frontend/src/hooks/useStaking.js
@@ -11,10 +11,9 @@ export const useStaking = () => {
     setLoading(true);
     setError(null);
     try {
-      const daoPrincipal = Principal.fromText(daoId);
       const periodVariant = { [period]: null };
       const res = await actors.staking.stake(
-        daoPrincipal,
+        daoId,
         BigInt(amount),
         periodVariant
       );
@@ -32,9 +31,8 @@ export const useStaking = () => {
     setLoading(true);
     setError(null);
     try {
-      const daoPrincipal = Principal.fromText(daoId);
       const res = await actors.staking.unstake(
-        daoPrincipal,
+        daoId,
         BigInt(stakeId)
       );
       if ('err' in res) throw new Error(res.err);
@@ -51,9 +49,8 @@ export const useStaking = () => {
     setLoading(true);
     setError(null);
     try {
-      const daoPrincipal = Principal.fromText(daoId);
       const res = await actors.staking.claimRewards(
-        daoPrincipal,
+        daoId,
         BigInt(stakeId)
       );
       if ('err' in res) throw new Error(res.err);
@@ -71,9 +68,8 @@ export const useStaking = () => {
     setError(null);
     try {
       const periodVariant = { [newPeriod]: null };
-      const daoPrincipal = Principal.fromText(daoId);
       const res = await actors.staking.extendStakingPeriod(
-        daoPrincipal,
+        daoId,
         BigInt(stakeId),
         periodVariant
       );
@@ -91,8 +87,7 @@ export const useStaking = () => {
     setLoading(true);
     setError(null);
     try {
-      const daoPrincipal = Principal.fromText(daoId);
-      return await actors.staking.getStake(daoPrincipal, BigInt(stakeId));
+      return await actors.staking.getStake(daoId, BigInt(stakeId));
     } catch (err) {
       setError(err.message);
       throw err;
@@ -105,9 +100,8 @@ export const useStaking = () => {
     setLoading(true);
     setError(null);
     try {
-      const daoPrincipal = Principal.fromText(daoId);
       return await actors.staking.getStakingRewards(
-        daoPrincipal,
+        daoId,
         BigInt(stakeId)
       );
     } catch (err) {
@@ -122,8 +116,7 @@ export const useStaking = () => {
     setLoading(true);
     setError(null);
     try {
-      const daoPrincipal = Principal.fromText(daoId);
-      return await actors.staking.getStakingStats(daoPrincipal);
+      return await actors.staking.getStakingStats(daoId);
     } catch (err) {
       setError(err.message);
       throw err;
@@ -137,8 +130,7 @@ export const useStaking = () => {
     setError(null);
     try {
       const principal = Principal.fromText(user);
-      const daoPrincipal = Principal.fromText(daoId);
-      return await actors.staking.getUserStakes(daoPrincipal, principal);
+      return await actors.staking.getUserStakes(daoId, principal);
     } catch (err) {
       setError(err.message);
       throw err;
@@ -152,8 +144,7 @@ export const useStaking = () => {
     setError(null);
     try {
       const principal = Principal.fromText(user);
-      const daoPrincipal = Principal.fromText(daoId);
-      return await actors.staking.getUserActiveStakes(daoPrincipal, principal);
+      return await actors.staking.getUserActiveStakes(daoId, principal);
     } catch (err) {
       setError(err.message);
       throw err;
@@ -167,9 +158,8 @@ export const useStaking = () => {
     setError(null);
     try {
       const principal = Principal.fromText(user);
-      const daoPrincipal = Principal.fromText(daoId);
       return await actors.staking.getUserStakingSummary(
-        daoPrincipal,
+        daoId,
         principal
       );
     } catch (err) {

--- a/src/dao_frontend/src/hooks/useTreasury.js
+++ b/src/dao_frontend/src/hooks/useTreasury.js
@@ -11,9 +11,8 @@ export const useTreasury = () => {
     setLoading(true);
     setError(null);
     try {
-      const daoPrincipal = Principal.fromText(daoId);
       const res = await actors.treasury.deposit(
-        daoPrincipal,
+        daoId,
         BigInt(amount),
         description
       );
@@ -32,9 +31,8 @@ export const useTreasury = () => {
     setError(null);
     try {
       const principal = Principal.fromText(recipient);
-      const daoPrincipal = Principal.fromText(daoId);
       const res = await actors.treasury.withdraw(
-        daoPrincipal,
+        daoId,
         principal,
         BigInt(amount),
         description,
@@ -54,9 +52,8 @@ export const useTreasury = () => {
     setLoading(true);
     setError(null);
     try {
-      const daoPrincipal = Principal.fromText(daoId);
       const result = await actors.treasury.lockTokens(
-        daoPrincipal,
+        daoId,
         BigInt(amount),
         reason
       );
@@ -73,9 +70,8 @@ export const useTreasury = () => {
     setLoading(true);
     setError(null);
     try {
-      const daoPrincipal = Principal.fromText(daoId);
       const result = await actors.treasury.unlockTokens(
-        daoPrincipal,
+        daoId,
         BigInt(amount),
         reason
       );
@@ -92,9 +88,8 @@ export const useTreasury = () => {
     setLoading(true);
     setError(null);
     try {
-      const daoPrincipal = Principal.fromText(daoId);
       const result = await actors.treasury.reserveTokens(
-        daoPrincipal,
+        daoId,
         BigInt(amount),
         reason
       );
@@ -111,9 +106,8 @@ export const useTreasury = () => {
     setLoading(true);
     setError(null);
     try {
-      const daoPrincipal = Principal.fromText(daoId);
       const result = await actors.treasury.releaseReservedTokens(
-        daoPrincipal,
+        daoId,
         BigInt(amount),
         reason
       );
@@ -130,8 +124,7 @@ export const useTreasury = () => {
     setLoading(true);
     setError(null);
     try {
-      const daoPrincipal = Principal.fromText(daoId);
-      const res = await actors.treasury.getBalance(daoPrincipal);
+      const res = await actors.treasury.getBalance(daoId);
       if ('err' in res) throw new Error(res.err);
       return 'ok' in res ? res.ok : res;
     } catch (err) {
@@ -146,8 +139,7 @@ export const useTreasury = () => {
     setLoading(true);
     setError(null);
     try {
-      const daoPrincipal = Principal.fromText(daoId);
-      const txs = await actors.treasury.getAllTransactions(daoPrincipal);
+      const txs = await actors.treasury.getAllTransactions(daoId);
       return txs;
     } catch (err) {
       setError(err.message);
@@ -161,8 +153,7 @@ export const useTreasury = () => {
     setLoading(true);
     setError(null);
     try {
-      const daoPrincipal = Principal.fromText(daoId);
-      const txs = await actors.treasury.getTransactionsByType(daoPrincipal, {
+      const txs = await actors.treasury.getTransactionsByType(daoId, {
         [type]: null,
       });
       return txs;
@@ -178,9 +169,8 @@ export const useTreasury = () => {
     setLoading(true);
     setError(null);
     try {
-      const daoPrincipal = Principal.fromText(daoId);
       const txs = await actors.treasury.getRecentTransactions(
-        daoPrincipal,
+        daoId,
         BigInt(limit)
       );
       return txs;
@@ -196,8 +186,7 @@ export const useTreasury = () => {
     setLoading(true);
     setError(null);
     try {
-      const daoPrincipal = Principal.fromText(daoId);
-      const stats = await actors.treasury.getTreasuryStats(daoPrincipal);
+      const stats = await actors.treasury.getTreasuryStats(daoId);
       return stats;
     } catch (err) {
       setError(err.message);
@@ -211,10 +200,9 @@ export const useTreasury = () => {
     setLoading(true);
     setError(null);
     try {
-      const daoPrincipal = Principal.fromText(daoId);
       const principal = Principal.fromText(principalId);
       const res = await actors.treasury.addAuthorizedPrincipal(
-        daoPrincipal,
+        daoId,
         principal
       );
       if ('err' in res) throw new Error(res.err);
@@ -231,10 +219,9 @@ export const useTreasury = () => {
     setLoading(true);
     setError(null);
     try {
-      const daoPrincipal = Principal.fromText(daoId);
       const principal = Principal.fromText(principalId);
       const res = await actors.treasury.removeAuthorizedPrincipal(
-        daoPrincipal,
+        daoId,
         principal
       );
       if ('err' in res) throw new Error(res.err);
@@ -251,8 +238,7 @@ export const useTreasury = () => {
     setLoading(true);
     setError(null);
     try {
-      const daoPrincipal = Principal.fromText(daoId);
-      const res = await actors.treasury.getAuthorizedPrincipals(daoPrincipal);
+      const res = await actors.treasury.getAuthorizedPrincipals(daoId);
       return res.map((p) => (typeof p.toText === 'function' ? p.toText() : p));
     } catch (err) {
       setError(err.message);


### PR DESCRIPTION
## Summary
- pass DAO IDs as strings directly to treasury, staking, assets, and governance actors
- rename governance helper to `getDaoId`
- clean up unused `daoPrincipal` handling across hooks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1f2edd32c8320b500271c4eb1f0ed