### PR TITLE
fix: remove stray merge marker from treasury canister

### DIFF
--- a/src/dao_backend/treasury/main.mo
+++ b/src/dao_backend/treasury/main.mo
@@ -724,11 +724,10 @@ persistent actor TreasuryCanister {
             case null { #err("Transaction not found") };
         }
     };
-=======
+
     private func isAdmin(daoId: Principal, principal: Principal) : Bool {
         // For now, reuse the authorized principal list for admin checks
         isAuthorized(daoId, principal)
     };
 
-  
 }


### PR DESCRIPTION
## Summary
- remove leftover merge marker in treasury canister

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1fb8248188320bf9e907e95aafdd2