### PR TITLE
Persist DAO principal across upgrades

### DIFF
--- a/src/dao_backend/governance/main.mo
+++ b/src/dao_backend/governance/main.mo
@@ -90,6 +90,7 @@ persistent actor GovernanceCanister {
     private var votesEntries : [(VoteKey, Vote)] = [];
     private var configEntries : [(Principal, GovernanceConfig)] = [];
     private var stakingId : ?Principal = null;
+    private var daoPrincipal : ?Principal = null;
     private var daoInstance : ?Types.DAOId = null;
     private var initialized : Bool = false;
 
@@ -119,6 +120,7 @@ persistent actor GovernanceCanister {
         };
 
         stakingId := ?newStakingId;
+        daoPrincipal := ?newDaoId;
         daoInstance := ?daoInstanceId;
         dao := ?daoTemp;
         staking := ?actor(Principal.toText(newStakingId));
@@ -177,6 +179,10 @@ persistent actor GovernanceCanister {
 
         switch (stakingId) {
             case (?id) staking := ?actor(Principal.toText(id));
+            case null {};
+        };
+        switch (daoPrincipal) {
+            case (?id) dao := ?actor(Principal.toText(id));
             case null {};
         };
     };


### PR DESCRIPTION
## Summary
- persist DAO principal in governance canister to survive upgrades
- restore dao actor reference from stored principal during postupgrade

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1fb8e9a5c8320913cddc89ef3e787