### PR TITLE
Look up governance canister ID

### DIFF
--- a/src/dao_frontend/src/config/agent.ts
+++ b/src/dao_frontend/src/config/agent.ts
@@ -185,8 +185,24 @@ export const initializeAgents = async (
       identity
     );
 
+    let governanceCanisterId: string | undefined = canisterIds.governance;
+
+    if (!governanceCanisterId) {
+      try {
+        const references = await daoBackend.getCanisterReferences(daoId);
+        const principal = references.governance[0];
+        if (!principal) {
+          throw new Error("Governance canister principal not found");
+        }
+        governanceCanisterId = principal.toString();
+      } catch (err) {
+        console.error("Failed to retrieve governance canister ID:", err);
+        throw new Error("Unable to retrieve governance canister principal");
+      }
+    }
+
     const governance = await handleOptionalActor<GovernanceService>(
-      canisterIds.governance || daoId,
+      governanceCanisterId,
       governanceIdl,
       "GOVERNANCE",
       identity


### PR DESCRIPTION
## Summary
- fetch governance canister ID via dao backend
- throw explicit error when governance principal cannot be found

## Testing
- ❌ `npm test` (missing dfx)
- ✅ `npm --prefix src/dao_frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68a1fc7941048320956a48192c77f30e