### PR TITLE
Make getGovernanceStats a query

### DIFF
--- a/src/dao_backend/main.mo
+++ b/src/dao_backend/main.mo
@@ -613,7 +613,7 @@ persistent actor DAOMain {
         getGovernanceStats: shared query (Principal) -> async GovernanceStats;
     };
 
-    public func getGovernanceStats(daoId: DAOId) : async GovernanceStats {
+    public shared query func getGovernanceStats(daoId: DAOId) : async GovernanceStats {
         let defaultStats : GovernanceStats = {
             totalProposals = 0;
             activeProposals = 0;
@@ -627,16 +627,12 @@ persistent actor DAOMain {
                 switch (state.governanceCanister) {
                     case (?govId) {
                         let governance : GovernanceCanister = actor(Principal.toText(govId));
-                        try {
-                            await governance.getGovernanceStats(Principal.fromText(daoId))
-                        } catch (_) {
-                            defaultStats
-                        }
+                        governance.getGovernanceStats(Principal.fromText(daoId))
                     };
-                    case null defaultStats;
+                    case null async { defaultStats };
                 }
             };
-            case null defaultStats;
+            case null async { defaultStats };
         }
     };
 

--- a/src/dao_frontend/src/declarations/dao_backend/dao_backend.did
+++ b/src/dao_frontend/src/declarations/dao_backend/dao_backend.did
@@ -91,10 +91,11 @@ service : {
   getGovernanceStats: (daoId: text) ->
    (record {
       activeProposals: nat;
-      passedProposals: nat;
+      failedProposals: nat;
+      succeededProposals: nat;
       totalProposals: nat;
-      totalVotingPower: nat;
-    });
+      totalVotes: nat;
+    }) query;
   getUserProfile: (daoId: text, userId: principal) -> (opt UserProfile) query;
   greet: (daoId: text, name: text) -> (text) query;
   health: () -> (record {

--- a/src/dao_frontend/src/declarations/dao_backend/dao_backend.did.d.ts
+++ b/src/dao_frontend/src/declarations/dao_backend/dao_backend.did.d.ts
@@ -86,10 +86,11 @@ export interface _SERVICE {
   'getGovernanceStats' : ActorMethod<
     [string],
     {
-      'passedProposals' : bigint,
-      'totalVotingPower' : bigint,
-      'totalProposals' : bigint,
       'activeProposals' : bigint,
+      'failedProposals' : bigint,
+      'succeededProposals' : bigint,
+      'totalProposals' : bigint,
+      'totalVotes' : bigint,
     }
   >,
   'getUserProfile' : ActorMethod<[string, Principal], [] | [UserProfile]>,

--- a/src/dao_frontend/src/declarations/dao_backend/dao_backend.did.js
+++ b/src/dao_frontend/src/declarations/dao_backend/dao_backend.did.js
@@ -92,13 +92,14 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Text],
         [
           IDL.Record({
-            'passedProposals' : IDL.Nat,
-            'totalVotingPower' : IDL.Nat,
-            'totalProposals' : IDL.Nat,
             'activeProposals' : IDL.Nat,
+            'failedProposals' : IDL.Nat,
+            'succeededProposals' : IDL.Nat,
+            'totalProposals' : IDL.Nat,
+            'totalVotes' : IDL.Nat,
           }),
         ],
-        [],
+        ['query'],
       ),
     'getUserProfile' : IDL.Func(
         [IDL.Text, IDL.Principal],


### PR DESCRIPTION
## Summary
- expose `getGovernanceStats` as a shared query method
- update generated dao_backend declarations to mark `getGovernanceStats` as query and match new stats fields

## Testing
- `dfx build dao_backend` *(fails: command not found)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a20461422c8320850cd11bc39a1583