### PR TITLE
Convert proposal period to Int for deadline calculations

### DIFF
--- a/src/dao_backend/governance/main.mo
+++ b/src/dao_backend/governance/main.mo
@@ -218,6 +218,7 @@ persistent actor GovernanceCanister {
             case (?p) p;
             case null currentConfig.votingPeriod;
         };
+        let periodInt = Int.fromNat(period);
 
         let proposal : Proposal = {
             daoId = daoId;
@@ -231,9 +232,9 @@ persistent actor GovernanceCanister {
             votesAgainst = 0;
             totalVotingPower = 0;
             createdAt = Time.now();
-            votingDeadline = Time.now() + period;
+            votingDeadline = Time.now() + periodInt;
 
-            executionDeadline = ?(Time.now() + period + (24 * 60 * 60 * 1_000_000_000));
+            executionDeadline = ?(Time.now() + periodInt + Int.fromNat(24 * 60 * 60 * 1_000_000_000));
             quorumThreshold = currentConfig.quorumThreshold;
             approvalThreshold = currentConfig.approvalThreshold;
         };

--- a/src/dao_backend/proposals/main.mo
+++ b/src/dao_backend/proposals/main.mo
@@ -234,6 +234,7 @@ persistent actor ProposalsCanister {
             case (?p) p;
             case null currentConfig.votingPeriod;
         };
+        let periodInt = Int.fromNat(period);
 
         let proposal : Proposal = {
             daoId = Principal.fromText(daoId);
@@ -248,8 +249,8 @@ persistent actor ProposalsCanister {
             votesAgainst = 0;
             totalVotingPower = 0;
             createdAt = Time.now();
-            votingDeadline = Time.now() + period;
-            executionDeadline = ?(Time.now() + period + (24 * 60 * 60 * 1_000_000_000)); // 1 day after voting
+            votingDeadline = Time.now() + periodInt;
+            executionDeadline = ?(Time.now() + periodInt + Int.fromNat(24 * 60 * 60 * 1_000_000_000)); // 1 day after voting
             quorumThreshold = currentConfig.quorumThreshold;
             approvalThreshold = currentConfig.approvalThreshold;
         };


### PR DESCRIPTION
## Summary
- Convert proposal `votingPeriod` to `Int` in governance and proposals canisters
- Calculate `votingDeadline` and `executionDeadline` using `Time.now() + periodInt`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a20465f62483209891c35dbdfc7d47