### PR TITLE
Validate proposer registration before proposal creation

### DIFF
--- a/src/dao_backend/governance/main.mo
+++ b/src/dao_backend/governance/main.mo
@@ -203,6 +203,21 @@ persistent actor GovernanceCanister {
 
         let caller = msg.caller;
 
+        // Verify proposer registration using the DAO backend actor
+        let daoActor = switch (dao) {
+            case (?d) d;
+            case null return #err("Canister not initialized");
+        };
+        let instanceId = switch (daoInstance) {
+            case (?id) id;
+            case null return #err("Canister not initialized");
+        };
+        let profileOpt = await daoActor.getUserProfile(instanceId, caller);
+        switch (profileOpt) {
+            case null return #err("User not registered");
+            case (?_) {};
+        };
+
         // Check if user has too many active proposals in this DAO
         let activeProposals = getActiveProposalsByUser(daoId, caller);
         let currentConfig = getConfigForDao(daoId);


### PR DESCRIPTION
## Summary
- ensure `createProposal` checks user registration via DAO backend
- return `#err("User not registered")` when profile lookup fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a20470176c8320a6537873d1f4ea05