### PR TITLE
feat: support proposal category and voting period

### DIFF
--- a/src/dao_frontend/src/utils/daoAPI.js
+++ b/src/dao_frontend/src/utils/daoAPI.js
@@ -183,10 +183,10 @@ export class DAOAPIWrapper {
         );
     }
 
-    async createProposal(daoId, title, description, proposalType) {
+    async createProposal(daoId, title, description, proposalType, category, votingPeriod) {
         const id = this.ensureDaoId(daoId);
         return this.callAPI(
-            () => this.actors.daoBackend.createProposal(id, title, description, proposalType),
+            () => this.actors.daoBackend.createProposal(id, title, description, proposalType, category, votingPeriod),
             'Create Proposal'
         );
     }


### PR DESCRIPTION
## Summary
- extend createProposal API to accept category and voting period

## Testing
- `npm test` *(fails: dfx not found)*
- `cd src/dao_frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a204c17dbc8320a616d5ceed3016bc