### PR TITLE
refactor: pass dao IDs as strings

### DIFF
--- a/src/dao_frontend/src/hooks/useAssets.js
+++ b/src/dao_frontend/src/hooks/useAssets.js
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Principal } from '@dfinity/principal';
 import { useActors } from '../context/ActorContext';
 
 export const useAssets = () => {
@@ -184,7 +185,9 @@ export const useAssets = () => {
     setLoading(true);
     setError(null);
     try {
-      const res = await actors.assets.addAuthorizedUploader(principal);
+      const res = await actors.assets.addAuthorizedUploader(
+        Principal.fromText(principal)
+      );
       if (res.err) {
         throw new Error(res.err);
       }
@@ -201,7 +204,9 @@ export const useAssets = () => {
     setLoading(true);
     setError(null);
     try {
-      const res = await actors.assets.removeAuthorizedUploader(principal);
+      const res = await actors.assets.removeAuthorizedUploader(
+        Principal.fromText(principal)
+      );
       if (res.err) {
         throw new Error(res.err);
       }

--- a/src/dao_frontend/src/hooks/useGovernance.js
+++ b/src/dao_frontend/src/hooks/useGovernance.js
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Principal } from '@dfinity/principal';
 import { useActors } from '../context/ActorContext';
 import { useDAO } from '../context/DAOContext';
 
@@ -191,7 +192,7 @@ export const useGovernance = () => {
       const res = await actors.governance.getUserVote(
         getDaoId(),
         BigInt(proposalId),
-        user
+        Principal.fromText(user)
       );
       return res && res.length ? res[0] : null;
     } catch (err) {

--- a/src/dao_frontend/src/hooks/useStaking.js
+++ b/src/dao_frontend/src/hooks/useStaking.js
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Principal } from '@dfinity/principal';
 import { useActors } from '../context/ActorContext';
 
 export const useStaking = () => {
@@ -128,7 +129,10 @@ export const useStaking = () => {
     setLoading(true);
     setError(null);
     try {
-      return await actors.staking.getUserStakes(daoId, user);
+      return await actors.staking.getUserStakes(
+        daoId,
+        Principal.fromText(user)
+      );
     } catch (err) {
       setError(err.message);
       throw err;
@@ -141,7 +145,10 @@ export const useStaking = () => {
     setLoading(true);
     setError(null);
     try {
-      return await actors.staking.getUserActiveStakes(daoId, user);
+      return await actors.staking.getUserActiveStakes(
+        daoId,
+        Principal.fromText(user)
+      );
     } catch (err) {
       setError(err.message);
       throw err;
@@ -156,7 +163,7 @@ export const useStaking = () => {
     try {
       return await actors.staking.getUserStakingSummary(
         daoId,
-        user
+        Principal.fromText(user)
       );
     } catch (err) {
       setError(err.message);

--- a/src/dao_frontend/src/hooks/useTreasury.js
+++ b/src/dao_frontend/src/hooks/useTreasury.js
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Principal } from '@dfinity/principal';
 import { useActors } from '../context/ActorContext';
 
 export const useTreasury = () => {
@@ -31,7 +32,7 @@ export const useTreasury = () => {
     try {
       const res = await actors.treasury.withdraw(
         daoId,
-        recipient,
+        Principal.fromText(recipient),
         BigInt(amount),
         description,
         []
@@ -200,7 +201,7 @@ export const useTreasury = () => {
     try {
       const res = await actors.treasury.addAuthorizedPrincipal(
         daoId,
-        principalId
+        Principal.fromText(principalId)
       );
       if ('err' in res) throw new Error(res.err);
       return res.ok;
@@ -218,7 +219,7 @@ export const useTreasury = () => {
     try {
       const res = await actors.treasury.removeAuthorizedPrincipal(
         daoId,
-        principalId
+        Principal.fromText(principalId)
       );
       if ('err' in res) throw new Error(res.err);
       return res.ok;


### PR DESCRIPTION
## Summary
- stop converting DAO IDs to Principals in frontend hooks
- ensure user-provided principals are converted with `Principal.fromText`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2050f49808320b982cab6c5cdb99b