### PR TITLE
Use text DAO IDs for assets

### DIFF
--- a/src/dao_backend/assets/main.mo
+++ b/src/dao_backend/assets/main.mo
@@ -11,13 +11,15 @@ import Text "mo:base/Text";
 import Blob "mo:base/Blob";
 import Nat32 "mo:base/Nat32";
 
+import Types "../shared/types";
+
 persistent actor AssetCanister {
     type Result<T, E> = Result.Result<T, E>;
     type Time = Time.Time;
 
     // Asset types
     public type AssetId = Nat;
-    public type DaoId = Principal;
+    public type DaoId = Types.DAOId;
     public type AssetData = Blob;
 
     public type AssetKey = {
@@ -70,11 +72,11 @@ persistent actor AssetCanister {
 
     // Runtime storage
     private func assetKeyEqual(a: AssetKey, b: AssetKey) : Bool {
-        a.daoId == b.daoId and a.assetId == b.assetId
+        Text.equal(a.daoId, b.daoId) and a.assetId == b.assetId
     };
 
     private func assetKeyHash(k: AssetKey) : Nat32 {
-        Nat32.xor(Principal.hash(k.daoId), Nat32.fromNat(k.assetId))
+        Nat32.xor(Text.hash(k.daoId), Nat32.fromNat(k.assetId))
     };
 
     private type UploaderKey = {
@@ -83,11 +85,11 @@ persistent actor AssetCanister {
     };
 
     private func uploaderKeyEqual(a: UploaderKey, b: UploaderKey) : Bool {
-        a.daoId == b.daoId and a.uploader == b.uploader
+        Text.equal(a.daoId, b.daoId) and a.uploader == b.uploader
     };
 
     private func uploaderKeyHash(k: UploaderKey) : Nat32 {
-        Nat32.xor(Principal.hash(k.daoId), Principal.hash(k.uploader))
+        Nat32.xor(Text.hash(k.daoId), Principal.hash(k.uploader))
     };
 
     private transient var assets = HashMap.HashMap<AssetKey, Asset>(100, assetKeyEqual, assetKeyHash);
@@ -264,7 +266,7 @@ persistent actor AssetCanister {
     public query func getPublicAssets(daoId: DaoId) : async [AssetMetadata] {
         let publicAssets = Buffer.Buffer<AssetMetadata>(0);
         for ((key, asset) in assets.entries()) {
-            if (key.daoId == daoId and asset.isPublic) {
+            if (Text.equal(key.daoId, daoId) and asset.isPublic) {
                 publicAssets.add({
                     id = asset.id;
                     daoId = asset.daoId;
@@ -317,7 +319,7 @@ persistent actor AssetCanister {
     public query func searchAssetsByTag(daoId: DaoId, tag: Text) : async [AssetMetadata] {
         let matchingAssets = Buffer.Buffer<AssetMetadata>(0);
         for ((key, asset) in assets.entries()) {
-            if (key.daoId == daoId and asset.isPublic) {
+            if (Text.equal(key.daoId, daoId) and asset.isPublic) {
                 let hasTag = Array.find<Text>(asset.tags, func(t) = t == tag);
                 if (hasTag != null) {
                     matchingAssets.add({
@@ -415,7 +417,7 @@ persistent actor AssetCanister {
         var totalAssets : Nat = 0;
         var daoStorage : Nat = 0;
         for ((key, asset) in assets.entries()) {
-            if (key.daoId == daoId) {
+            if (Text.equal(key.daoId, daoId)) {
                 totalAssets += 1;
                 daoStorage += asset.size;
             };
@@ -520,7 +522,7 @@ persistent actor AssetCanister {
     // Get asset by name (for convenience)
     public query func getAssetByName(daoId: DaoId, name: Text) : async ?AssetMetadata {
         for ((key, asset) in assets.entries()) {
-            if (key.daoId == daoId and asset.name == name and asset.isPublic) {
+            if (Text.equal(key.daoId, daoId) and asset.name == name and asset.isPublic) {
                 return ?{
                     id = asset.id;
                     daoId = asset.daoId;

--- a/src/dao_backend/assets/main.test.mo
+++ b/src/dao_backend/assets/main.test.mo
@@ -10,10 +10,11 @@ import Debug "mo:base/Debug";
 actor {
     public func main() : async () {
         let selfPrincipal = Principal.fromActor(this);
+        let daoId = Principal.toText(selfPrincipal);
 
         // Upload should fail while no authorized uploaders exist.
         let data = Blob.fromArray([1,2,3]);
-        let uploadBefore = await Asset.uploadAsset(selfPrincipal, "test", "image/png", data, true, []);
+        let uploadBefore = await Asset.uploadAsset(daoId, "test", "image/png", data, true, []);
         assert uploadBefore == #err("Uploads are disabled until an uploader is authorized or open uploads are enabled");
 
         // Anyone can authorize the first uploader.
@@ -24,7 +25,7 @@ actor {
         assert Array.find<Principal>(uploaders, func(p) = p == selfPrincipal) != null;
 
         // After authorization, upload succeeds.
-        let uploadAfter = await Asset.uploadAsset(selfPrincipal, "test2", "image/png", data, true, []);
+        let uploadAfter = await Asset.uploadAsset(daoId, "test2", "image/png", data, true, []);
         switch uploadAfter { case (#ok(_)) {}; case (_) { assert false } };
 
         let duplicateRes = await Asset.addAuthorizedUploader(selfPrincipal);

--- a/src/dao_frontend/src/declarations/assets/assets.did
+++ b/src/dao_frontend/src/declarations/assets/assets.did
@@ -16,8 +16,8 @@ type Result =
  };
 type AssetMetadata =
  record {
-   contentType: text;
-   daoId: principal;
+  contentType: text;
+   daoId: DaoId;
    id: AssetId;
    isPublic: bool;
    name: text;
@@ -27,7 +27,7 @@ type AssetMetadata =
    uploadedBy: principal;
  };
 type AssetId = nat;
-type DaoId = principal;
+type DaoId = text;
 type AssetData = blob;
 type Asset =
  record {

--- a/src/dao_frontend/src/declarations/assets/assets.did.d.ts
+++ b/src/dao_frontend/src/declarations/assets/assets.did.d.ts
@@ -4,7 +4,7 @@ import type { IDL } from '@dfinity/candid';
 
 export interface Asset {
   'id' : AssetId,
-  'daoId' : Principal,
+  'daoId' : string,
   'contentType' : string,
   'data' : AssetData,
   'name' : string,
@@ -18,7 +18,7 @@ export type AssetData = Uint8Array | number[];
 export type AssetId = bigint;
 export interface AssetMetadata {
   'id' : AssetId,
-  'daoId' : Principal,
+  'daoId' : string,
   'name' : string,
   'contentType' : string,
   'size' : bigint,
@@ -37,17 +37,17 @@ export type Time = bigint;
 export interface _SERVICE {
   'addAuthorizedUploader' : ActorMethod<[Principal], Result_1>,
   'batchUploadAssets' : ActorMethod<
-    [Principal, Array<[string, string, AssetData, boolean, Array<string>]>],
+    [string, Array<[string, string, AssetData, boolean, Array<string>]>],
     Array<Result>
   >,
-  'deleteAsset' : ActorMethod<[Principal, AssetId], Result_1>,
-  'getAsset' : ActorMethod<[Principal, AssetId], Result_2>,
-  'getAssetByName' : ActorMethod<[Principal, string], [] | [AssetMetadata]>,
-  'getAssetMetadata' : ActorMethod<[Principal, AssetId], [] | [AssetMetadata]>,
+  'deleteAsset' : ActorMethod<[string, AssetId], Result_1>,
+  'getAsset' : ActorMethod<[string, AssetId], Result_2>,
+  'getAssetByName' : ActorMethod<[string, string], [] | [AssetMetadata]>,
+  'getAssetMetadata' : ActorMethod<[string, AssetId], [] | [AssetMetadata]>,
   'getAuthorizedUploaders' : ActorMethod<[], Array<Principal>>,
-  'getPublicAssets' : ActorMethod<[Principal], Array<AssetMetadata>>,
+  'getPublicAssets' : ActorMethod<[string], Array<AssetMetadata>>,
   'getStorageStats' : ActorMethod<
-    [Principal],
+    [string],
     {
       'storageLimit' : bigint,
       'totalAssets' : bigint,
@@ -57,17 +57,17 @@ export interface _SERVICE {
     }
   >,
   'getSupportedContentTypes' : ActorMethod<[], Array<string>>,
-  'getUserAssets' : ActorMethod<[Principal], Array<AssetMetadata>>,
+  'getUserAssets' : ActorMethod<[string], Array<AssetMetadata>>,
   'health' : ActorMethod<
     [],
     { 'status' : string, 'storageUsed' : bigint, 'timestamp' : Time }
   >,
   'init' : ActorMethod<[[] | [Principal], boolean], undefined>,
   'removeAuthorizedUploader' : ActorMethod<[Principal], Result_1>,
-  'searchAssetsByTag' : ActorMethod<[Principal, string], Array<AssetMetadata>>,
+  'searchAssetsByTag' : ActorMethod<[string, string], Array<AssetMetadata>>,
   'updateAssetMetadata' : ActorMethod<
     [
-      Principal,
+      string,
       AssetId,
       [] | [string],
       [] | [boolean],
@@ -77,7 +77,7 @@ export interface _SERVICE {
   >,
   'updateStorageLimits' : ActorMethod<[[] | [bigint], [] | [bigint]], Result_1>,
   'uploadAsset' : ActorMethod<
-    [Principal, string, string, AssetData, boolean, Array<string>],
+    [string, string, string, AssetData, boolean, Array<string>],
     Result
   >,
 }

--- a/src/dao_frontend/src/declarations/assets/assets.did.js
+++ b/src/dao_frontend/src/declarations/assets/assets.did.js
@@ -6,7 +6,7 @@ export const idlFactory = ({ IDL }) => {
   const Time = IDL.Int;
   const Asset = IDL.Record({
     'id' : AssetId,
-    'daoId' : IDL.Principal,
+    'daoId' : IDL.Text,
     'contentType' : IDL.Text,
     'data' : AssetData,
     'name' : IDL.Text,
@@ -19,7 +19,7 @@ export const idlFactory = ({ IDL }) => {
   const Result_2 = IDL.Variant({ 'ok' : Asset, 'err' : IDL.Text });
   const AssetMetadata = IDL.Record({
     'id' : AssetId,
-    'daoId' : IDL.Principal,
+    'daoId' : IDL.Text,
     'name' : IDL.Text,
     'contentType' : IDL.Text,
     'size' : IDL.Nat,
@@ -32,7 +32,7 @@ export const idlFactory = ({ IDL }) => {
     'addAuthorizedUploader' : IDL.Func([IDL.Principal], [Result_1], []),
     'batchUploadAssets' : IDL.Func(
         [
-          IDL.Principal,
+          IDL.Text,
           IDL.Vec(
             IDL.Tuple(
               IDL.Text,
@@ -46,15 +46,15 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Vec(Result)],
         [],
       ),
-    'deleteAsset' : IDL.Func([IDL.Principal, AssetId], [Result_1], []),
-    'getAsset' : IDL.Func([IDL.Principal, AssetId], [Result_2], []),
+    'deleteAsset' : IDL.Func([IDL.Text, AssetId], [Result_1], []),
+    'getAsset' : IDL.Func([IDL.Text, AssetId], [Result_2], []),
     'getAssetByName' : IDL.Func(
-        [IDL.Principal, IDL.Text],
+        [IDL.Text, IDL.Text],
         [IDL.Opt(AssetMetadata)],
         ['query'],
       ),
     'getAssetMetadata' : IDL.Func(
-        [IDL.Principal, AssetId],
+        [IDL.Text, AssetId],
         [IDL.Opt(AssetMetadata)],
         ['query'],
       ),
@@ -63,9 +63,9 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Vec(IDL.Principal)],
         ['query'],
       ),
-    'getPublicAssets' : IDL.Func([IDL.Principal], [IDL.Vec(AssetMetadata)], ['query']),
+    'getPublicAssets' : IDL.Func([IDL.Text], [IDL.Vec(AssetMetadata)], ['query']),
     'getStorageStats' : IDL.Func(
-        [IDL.Principal],
+        [IDL.Text],
         [
           IDL.Record({
             'storageLimit' : IDL.Nat,
@@ -78,7 +78,7 @@ export const idlFactory = ({ IDL }) => {
         ['query'],
       ),
     'getSupportedContentTypes' : IDL.Func([], [IDL.Vec(IDL.Text)], ['query']),
-    'getUserAssets' : IDL.Func([IDL.Principal], [IDL.Vec(AssetMetadata)], []),
+    'getUserAssets' : IDL.Func([IDL.Text], [IDL.Vec(AssetMetadata)], []),
     'health' : IDL.Func(
         [],
         [
@@ -93,13 +93,13 @@ export const idlFactory = ({ IDL }) => {
     'init' : IDL.Func([IDL.Opt(IDL.Principal), IDL.Bool], [], []),
     'removeAuthorizedUploader' : IDL.Func([IDL.Principal], [Result_1], []),
     'searchAssetsByTag' : IDL.Func(
-        [IDL.Principal, IDL.Text],
+        [IDL.Text, IDL.Text],
         [IDL.Vec(AssetMetadata)],
         ['query'],
       ),
     'updateAssetMetadata' : IDL.Func(
         [
-          IDL.Principal,
+          IDL.Text,
           AssetId,
           IDL.Opt(IDL.Text),
           IDL.Opt(IDL.Bool),
@@ -114,7 +114,7 @@ export const idlFactory = ({ IDL }) => {
         [],
       ),
     'uploadAsset' : IDL.Func(
-        [IDL.Principal, IDL.Text, IDL.Text, AssetData, IDL.Bool, IDL.Vec(IDL.Text)],
+        [IDL.Text, IDL.Text, IDL.Text, AssetData, IDL.Bool, IDL.Vec(IDL.Text)],
         [Result],
         [],
       ),


### PR DESCRIPTION
## Summary
- use text-based DAOId type in asset canister
- update asset service declarations to accept DAO IDs as text
- adjust asset tests for string IDs

## Testing
- `npm test`
- `moc --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2051b8a1c83208db697cb603a9e5a