### PR TITLE
Initialize AuthContext with explicit default

### DIFF
--- a/src/dao_frontend/src/context/AuthContext.jsx
+++ b/src/dao_frontend/src/context/AuthContext.jsx
@@ -1,8 +1,8 @@
-import React, { createContext, useContext, useState, useEffect } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
 import { AuthClient } from '@dfinity/auth-client';
 
 // Create the AuthContext
-const AuthContext = createContext();
+const AuthContext = createContext(null);
 
 // AuthProvider component to wrap the app and provide auth state
 


### PR DESCRIPTION
## Summary
- import required React hooks and AuthClient
- initialize AuthContext with `null` default

## Testing
- `cd src/dao_frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a20b3d25748320922d25ac5c95c1e7