### PR TITLE
Prevent removal of last DAO admin

### DIFF
--- a/src/dao_backend/main.mo
+++ b/src/dao_backend/main.mo
@@ -770,6 +770,9 @@ persistent actor DAOMain {
         if (not state.initialized) {
             return #err("DAO not initialized");
         };
+        if (state.adminPrincipals.size() <= 1) {
+            return #err("Cannot remove the last admin");
+        };
         state.adminPrincipals.delete(adminToRemove);
         Debug.print("Admin removed: " # Principal.toText(adminToRemove));
         #ok()


### PR DESCRIPTION
## Summary
- guard against removing final administrator in `removeAdmin`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a20b4834688320bfa6b82356b92f75