### PR TITLE
Add actor initialization checks to frontend hooks

### DIFF
--- a/src/dao_frontend/src/hooks/useAssets.js
+++ b/src/dao_frontend/src/hooks/useAssets.js
@@ -8,6 +8,11 @@ export const useAssets = () => {
   const [error, setError] = useState(null);
 
   const uploadAsset = async (daoId, file, isPublic = true, tags = []) => {
+    if (!actors?.assets) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -34,6 +39,11 @@ export const useAssets = () => {
   };
 
   const getAsset = async (daoId, assetId) => {
+    if (!actors?.assets) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -54,6 +64,11 @@ export const useAssets = () => {
   };
 
   const getAssetMetadata = async (daoId, assetId) => {
+    if (!actors?.assets) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -70,6 +85,11 @@ export const useAssets = () => {
   };
 
   const getPublicAssets = async (daoId) => {
+    if (!actors?.assets) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -83,6 +103,11 @@ export const useAssets = () => {
   };
 
   const getUserAssets = async (daoId) => {
+    if (!actors?.assets) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -96,6 +121,11 @@ export const useAssets = () => {
   };
 
   const searchAssetsByTag = async (daoId, tag) => {
+    if (!actors?.assets) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -112,6 +142,11 @@ export const useAssets = () => {
   };
 
   const deleteAsset = async (daoId, assetId) => {
+    if (!actors?.assets) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -132,6 +167,11 @@ export const useAssets = () => {
   };
 
   const updateAssetMetadata = async (daoId, assetId, { name = null, isPublic = null, tags = null }) => {
+    if (!actors?.assets) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -155,6 +195,11 @@ export const useAssets = () => {
   };
 
   const getStorageStats = async (daoId) => {
+    if (!actors?.assets) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -168,6 +213,11 @@ export const useAssets = () => {
   };
 
   const getAuthorizedUploaders = async () => {
+    if (!actors?.assets) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -182,6 +232,11 @@ export const useAssets = () => {
   };
 
   const addAuthorizedUploader = async (principal) => {
+    if (!actors?.assets) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -201,6 +256,11 @@ export const useAssets = () => {
   };
 
   const removeAuthorizedUploader = async (principal) => {
+    if (!actors?.assets) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -223,6 +283,11 @@ export const useAssets = () => {
     maxFileSizeNew = null,
     maxTotalStorageNew = null
   ) => {
+    if (!actors?.assets) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -243,6 +308,11 @@ export const useAssets = () => {
   };
 
   const getSupportedContentTypes = async () => {
+    if (!actors?.assets) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -256,6 +326,11 @@ export const useAssets = () => {
   };
 
   const getAssetByName = async (daoId, name) => {
+    if (!actors?.assets) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -272,6 +347,11 @@ export const useAssets = () => {
   };
 
   const batchUploadAssets = async (daoId, files) => {
+    if (!actors?.assets) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -295,6 +375,11 @@ export const useAssets = () => {
   };
 
   const getHealth = async () => {
+    if (!actors?.assets) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {

--- a/src/dao_frontend/src/hooks/useGovernance.js
+++ b/src/dao_frontend/src/hooks/useGovernance.js
@@ -22,6 +22,11 @@ export const useGovernance = () => {
     proposalType,
     votingPeriod
   ) => {
+    if (!actors?.governance) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -43,6 +48,11 @@ export const useGovernance = () => {
   };
 
   const vote = async (proposalId, choice, reason) => {
+    if (!actors?.governance) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -64,6 +74,11 @@ export const useGovernance = () => {
   };
 
   const getConfig = async () => {
+    if (!actors?.governance) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -78,6 +93,11 @@ export const useGovernance = () => {
   };
 
   const getGovernanceStats = async () => {
+    if (!actors?.governance) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -92,6 +112,11 @@ export const useGovernance = () => {
   };
 
   const executeProposal = async (proposalId) => {
+    if (!actors?.governance) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -110,6 +135,11 @@ export const useGovernance = () => {
   };
 
   const getActiveProposals = async () => {
+    if (!actors?.governance) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -123,6 +153,11 @@ export const useGovernance = () => {
   };
 
   const getAllProposals = async () => {
+    if (!actors?.governance) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -136,6 +171,11 @@ export const useGovernance = () => {
   };
 
   const getProposal = async (proposalId) => {
+    if (!actors?.governance) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -153,6 +193,11 @@ export const useGovernance = () => {
   };
 
   const getProposalVotes = async (proposalId) => {
+    if (!actors?.governance) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -169,6 +214,11 @@ export const useGovernance = () => {
   };
 
   const getProposalsByStatus = async (status) => {
+    if (!actors?.governance) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -186,6 +236,11 @@ export const useGovernance = () => {
   };
 
   const getUserVote = async (proposalId, user) => {
+    if (!actors?.governance) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -204,6 +259,11 @@ export const useGovernance = () => {
   };
 
   const updateConfig = async (newConfig) => {
+    if (!actors?.governance) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {

--- a/src/dao_frontend/src/hooks/useProposals.js
+++ b/src/dao_frontend/src/hooks/useProposals.js
@@ -15,6 +15,11 @@ export const useProposals = () => {
     category,
     votingPeriod
   ) => {
+    if (!actors?.proposals) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -37,6 +42,11 @@ export const useProposals = () => {
   };
 
   const getAllProposals = async (daoId) => {
+    if (!actors?.proposals) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -50,6 +60,11 @@ export const useProposals = () => {
   };
 
   const getProposalsByCategory = async (daoId, category) => {
+    if (!actors?.proposals) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -63,6 +78,11 @@ export const useProposals = () => {
   };
 
   const getProposalTemplates = async (daoId) => {
+    if (!actors?.proposals) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -76,6 +96,11 @@ export const useProposals = () => {
   };
 
   const vote = async (daoId, proposalId, choice, reason) => {
+    if (!actors?.proposals) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {

--- a/src/dao_frontend/src/hooks/useStaking.js
+++ b/src/dao_frontend/src/hooks/useStaking.js
@@ -8,6 +8,11 @@ export const useStaking = () => {
   const [error, setError] = useState(null);
 
   const stake = async (daoId, amount, period) => {
+    if (!actors?.staking) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -28,6 +33,11 @@ export const useStaking = () => {
   };
 
   const unstake = async (daoId, stakeId) => {
+    if (!actors?.staking) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -46,6 +56,11 @@ export const useStaking = () => {
   };
 
   const claimRewards = async (daoId, stakeId) => {
+    if (!actors?.staking) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -64,6 +79,11 @@ export const useStaking = () => {
   };
 
   const extendStakingPeriod = async (daoId, stakeId, newPeriod) => {
+    if (!actors?.staking) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -84,6 +104,11 @@ export const useStaking = () => {
   };
 
   const getStake = async (daoId, stakeId) => {
+    if (!actors?.staking) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -97,6 +122,11 @@ export const useStaking = () => {
   };
 
   const getStakingRewards = async (daoId, stakeId) => {
+    if (!actors?.staking) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -113,6 +143,11 @@ export const useStaking = () => {
   };
 
   const getStakingStats = async (daoId) => {
+    if (!actors?.staking) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -126,6 +161,11 @@ export const useStaking = () => {
   };
 
   const getUserStakes = async (daoId, user) => {
+    if (!actors?.staking) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -142,6 +182,11 @@ export const useStaking = () => {
   };
 
   const getUserActiveStakes = async (daoId, user) => {
+    if (!actors?.staking) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -158,6 +203,11 @@ export const useStaking = () => {
   };
 
   const getUserStakingSummary = async (daoId, user) => {
+    if (!actors?.staking) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -174,6 +224,11 @@ export const useStaking = () => {
   };
 
   const setMinimumStakeAmount = async (amount) => {
+    if (!actors?.staking) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -189,6 +244,11 @@ export const useStaking = () => {
   };
 
   const setMaximumStakeAmount = async (amount) => {
+    if (!actors?.staking) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -204,6 +264,11 @@ export const useStaking = () => {
   };
 
   const setStakingEnabled = async (enabled) => {
+    if (!actors?.staking) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {

--- a/src/dao_frontend/src/hooks/useTreasury.js
+++ b/src/dao_frontend/src/hooks/useTreasury.js
@@ -8,6 +8,11 @@ export const useTreasury = () => {
   const [error, setError] = useState(null);
 
   const deposit = async (daoId, amount, description) => {
+    if (!actors?.treasury) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -27,6 +32,11 @@ export const useTreasury = () => {
   };
 
   const withdraw = async (daoId, recipient, amount, description) => {
+    if (!actors?.treasury) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -48,6 +58,11 @@ export const useTreasury = () => {
   };
 
   const lockTokens = async (daoId, amount, reason) => {
+    if (!actors?.treasury) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -66,6 +81,11 @@ export const useTreasury = () => {
   };
 
   const unlockTokens = async (daoId, amount, reason) => {
+    if (!actors?.treasury) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -84,6 +104,11 @@ export const useTreasury = () => {
   };
 
   const reserveTokens = async (daoId, amount, reason) => {
+    if (!actors?.treasury) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -102,6 +127,11 @@ export const useTreasury = () => {
   };
 
   const releaseReservedTokens = async (daoId, amount, reason) => {
+    if (!actors?.treasury) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -120,6 +150,11 @@ export const useTreasury = () => {
   };
 
   const getBalance = async (daoId) => {
+    if (!actors?.treasury) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -135,6 +170,11 @@ export const useTreasury = () => {
   };
 
   const getAllTransactions = async (daoId) => {
+    if (!actors?.treasury) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -149,6 +189,11 @@ export const useTreasury = () => {
   };
 
   const getTransactionsByType = async (daoId, type) => {
+    if (!actors?.treasury) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -165,6 +210,11 @@ export const useTreasury = () => {
   };
 
   const getRecentTransactions = async (daoId, limit) => {
+    if (!actors?.treasury) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -182,6 +232,11 @@ export const useTreasury = () => {
   };
 
   const getTreasuryStats = async (daoId) => {
+    if (!actors?.treasury) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -196,6 +251,11 @@ export const useTreasury = () => {
   };
 
   const addAuthorizedPrincipal = async (daoId, principalId) => {
+    if (!actors?.treasury) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -214,6 +274,11 @@ export const useTreasury = () => {
   };
 
   const removeAuthorizedPrincipal = async (daoId, principalId) => {
+    if (!actors?.treasury) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -232,6 +297,11 @@ export const useTreasury = () => {
   };
 
   const getAuthorizedPrincipals = async (daoId) => {
+    if (!actors?.treasury) {
+      const err = new Error("Actors not initialized");
+      setError(err.message);
+      throw err;
+    }
     setLoading(true);
     setError(null);
     try {


### PR DESCRIPTION
## Summary
- ensure asset, governance, proposal, staking, and treasury hooks verify actors before operations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a20f5899088320898b53269659975b