### PR TITLE
feat: track uploaders per DAO

### DIFF
--- a/src/dao_backend/assets/main.mo
+++ b/src/dao_backend/assets/main.mo
@@ -64,7 +64,7 @@ persistent actor AssetCanister {
     // Stable storage for upgrades
     private var nextAssetId : Nat = 1;
     private var assetsEntries : [(AssetKey, Asset)] = [];
-    private var authorizedUploaders : [Principal] = [];
+    private var authorizedUploadersEntries : [(DaoId, [Principal])] = [];
     private var maxFileSize : Nat = 10_000_000; // 10MB default
     private var maxTotalStorage : Nat = 1_000_000_000; // 1GB default
     private var currentStorageUsed : Nat = 0;
@@ -94,6 +94,7 @@ persistent actor AssetCanister {
 
     private transient var assets = HashMap.HashMap<AssetKey, Asset>(100, assetKeyEqual, assetKeyHash);
     private transient var uploaderAssets = HashMap.HashMap<UploaderKey, [AssetId]>(50, uploaderKeyEqual, uploaderKeyHash);
+    private transient var authorizedUploaders = HashMap.HashMap<DaoId, [Principal]>(50, Text.equal, Text.hash);
 
     // Supported content types
     private transient let supportedTypes = [
@@ -113,15 +114,14 @@ persistent actor AssetCanister {
     // authorized uploaders starts empty and can be populated later via
     // `addAuthorizedUploader`.
     public shared ({caller = _}) func init(initialUploader : ?Principal, openUploads : Bool) : async () {
-        switch (initialUploader) {
-            case (?p) { authorizedUploaders := [p] };
-            case null {};
-        };
+        // Initial uploader is no longer supported in DAO-specific uploader maps.
+        switch (initialUploader) { case (?_) {}; case null {} }; 
         allowOpenUploads := openUploads;
     };
 
     system func preupgrade() {
         assetsEntries := Iter.toArray(assets.entries());
+        authorizedUploadersEntries := Iter.toArray(authorizedUploaders.entries());
     };
 
     system func postupgrade() {
@@ -130,6 +130,13 @@ persistent actor AssetCanister {
             assetsEntries.size(),
             assetKeyEqual,
             assetKeyHash
+        );
+
+        authorizedUploaders := HashMap.fromIter<DaoId, [Principal]>(
+            authorizedUploadersEntries.vals(),
+            authorizedUploadersEntries.size(),
+            Text.equal,
+            Text.hash
         );
 
         // Rebuild uploader assets mapping
@@ -158,11 +165,15 @@ persistent actor AssetCanister {
         tags: [Text]
     ) : async Result<AssetId, Text> {
         let caller = msg.caller;
-        if (authorizedUploaders.size() == 0) {
+        let daoUploaders = switch (authorizedUploaders.get(daoId)) {
+            case (?ups) ups;
+            case null [];
+        };
+        if (daoUploaders.size() == 0) {
             if (not allowOpenUploads) {
                 return #err("Uploads are disabled until an uploader is authorized or open uploads are enabled");
             };
-        } else if (not isAuthorized(caller)) {
+        } else if (not isAuthorized(daoId, caller)) {
             return #err("Not authorized to upload assets");
         };
         let dataSize = data.size();
@@ -231,7 +242,7 @@ persistent actor AssetCanister {
         switch (assets.get(key)) {
             case (?asset) {
                 // Check access permissions
-                if (asset.isPublic or asset.uploadedBy == caller or isAuthorized(caller)) {
+                if (asset.isPublic or asset.uploadedBy == caller or isAuthorized(daoId, caller)) {
                     #ok(asset)
                 } else {
                     #err("Not authorized to access this asset")
@@ -347,7 +358,7 @@ persistent actor AssetCanister {
         switch (assets.get(key)) {
             case (?asset) {
                 // Check if user owns the asset or is authorized
-                if (asset.uploadedBy == caller or isAuthorized(caller)) {
+                if (asset.uploadedBy == caller or isAuthorized(daoId, caller)) {
                     assets.delete(key);
                     currentStorageUsed -= asset.size;
 
@@ -383,7 +394,7 @@ persistent actor AssetCanister {
 
         switch (assets.get(key)) {
             case (?asset) {
-                if (asset.uploadedBy == caller or isAuthorized(caller)) {
+                if (asset.uploadedBy == caller or isAuthorized(daoId, caller)) {
                     let updatedAsset = {
                         id = asset.id;
                         daoId = asset.daoId;
@@ -443,42 +454,52 @@ persistent actor AssetCanister {
     // Administrative functions
 
     // Add authorized uploader
-    public shared(msg) func addAuthorizedUploader(principal: Principal) : async Result<(), Text> {
+    public shared(msg) func addAuthorizedUploader(daoId: DaoId, principal: Principal) : async Result<(), Text> {
+        let caller = msg.caller;
+        let uploaders = switch (authorizedUploaders.get(daoId)) {
+            case (?u) u;
+            case null [];
+        };
         // Allow the first uploader to be added by anyone when the list is empty.
-        if (authorizedUploaders.size() > 0 and not isAuthorized(msg.caller)) {
+        if (uploaders.size() > 0 and not isAuthorized(daoId, caller)) {
             return #err("Not authorized to add uploaders");
         };
 
-        if (isAuthorized(principal)) {
+        if (Array.find<Principal>(uploaders, func(p) = p == principal) != null) {
             return #err("Uploader already authorized");
         };
 
-        let principals = Buffer.fromArray<Principal>(authorizedUploaders);
-        principals.add(principal);
-        authorizedUploaders := Buffer.toArray(principals);
+        let updated = Array.append<Principal>(uploaders, [principal]);
+        authorizedUploaders.put(daoId, updated);
 
         Debug.print("Authorized uploader added: " # Principal.toText(principal));
         #ok()
     };
 
     // Remove authorized uploader
-    public shared(msg) func removeAuthorizedUploader(principal: Principal) : async Result<(), Text> {
-        if (not isAuthorized(msg.caller)) {
+    public shared(msg) func removeAuthorizedUploader(daoId: DaoId, principal: Principal) : async Result<(), Text> {
+        if (not isAuthorized(daoId, msg.caller)) {
             return #err("Not authorized to remove uploaders");
         };
 
-        authorizedUploaders := Array.filter<Principal>(authorizedUploaders, func(p) = p != principal);
-        
+        let uploaders = switch (authorizedUploaders.get(daoId)) {
+            case (?u) u;
+            case null [];
+        };
+        let updated = Array.filter<Principal>(uploaders, func(p) = p != principal);
+        authorizedUploaders.put(daoId, updated);
+
         Debug.print("Authorized uploader removed: " # Principal.toText(principal));
         #ok()
     };
 
     // Update storage limits
     public shared(msg) func updateStorageLimits(
+        daoId: DaoId,
         maxFileSizeNew: ?Nat,
         maxTotalStorageNew: ?Nat
     ) : async Result<(), Text> {
-        if (not isAuthorized(msg.caller)) {
+        if (not isAuthorized(daoId, msg.caller)) {
             return #err("Not authorized to update storage limits");
         };
 
@@ -501,13 +522,19 @@ persistent actor AssetCanister {
     };
 
     // Get authorized uploaders
-    public query func getAuthorizedUploaders() : async [Principal] {
-        authorizedUploaders
+    public query func getAuthorizedUploaders(daoId: DaoId) : async [Principal] {
+        switch (authorizedUploaders.get(daoId)) {
+            case (?u) u;
+            case null [];
+        }
     };
 
     // Helper functions
-    private func isAuthorized(principal: Principal) : Bool {
-        Array.find<Principal>(authorizedUploaders, func(p) = p == principal) != null
+    private func isAuthorized(daoId: DaoId, principal: Principal) : Bool {
+        switch (authorizedUploaders.get(daoId)) {
+            case (?u) { Array.find<Principal>(u, func(p) = p == principal) != null };
+            case null false;
+        }
     };
 
     // Health check

--- a/src/dao_backend/assets/main.test.mo
+++ b/src/dao_backend/assets/main.test.mo
@@ -17,18 +17,18 @@ actor {
         let uploadBefore = await Asset.uploadAsset(daoId, "test", "image/png", data, true, []);
         assert uploadBefore == #err("Uploads are disabled until an uploader is authorized or open uploads are enabled");
 
-        // Anyone can authorize the first uploader.
-        let res = await Asset.addAuthorizedUploader(selfPrincipal);
+        // Anyone can authorize the first uploader for a DAO.
+        let res = await Asset.addAuthorizedUploader(daoId, selfPrincipal);
         assert res == #ok();
 
-        let uploaders = await Asset.getAuthorizedUploaders();
+        let uploaders = await Asset.getAuthorizedUploaders(daoId);
         assert Array.find<Principal>(uploaders, func(p) = p == selfPrincipal) != null;
 
         // After authorization, upload succeeds.
         let uploadAfter = await Asset.uploadAsset(daoId, "test2", "image/png", data, true, []);
         switch uploadAfter { case (#ok(_)) {}; case (_) { assert false } };
 
-        let duplicateRes = await Asset.addAuthorizedUploader(selfPrincipal);
+        let duplicateRes = await Asset.addAuthorizedUploader(daoId, selfPrincipal);
         assert duplicateRes == #err("Uploader already authorized");
 
         Debug.print("initial uploader configuration and upload permission test passed");

--- a/src/dao_frontend/src/components/management/ManagementAssetsAdmin.tsx
+++ b/src/dao_frontend/src/components/management/ManagementAssetsAdmin.tsx
@@ -27,7 +27,7 @@ const ManagementAssetsAdmin: React.FC = () => {
   const loadData = async () => {
     try {
       const [uploaderList, storageStats] = await Promise.all([
-        getAuthorizedUploaders(),
+        getAuthorizedUploaders(daoId),
         getStorageStats(daoId),
       ]);
       setUploaders(uploaderList);
@@ -46,7 +46,7 @@ const ManagementAssetsAdmin: React.FC = () => {
     setMessage('');
     setError('');
     try {
-      await addAuthorizedUploader(newUploader);
+      await addAuthorizedUploader(daoId, newUploader);
       setMessage('Uploader added successfully');
       setNewUploader('');
       await loadData();
@@ -59,7 +59,7 @@ const ManagementAssetsAdmin: React.FC = () => {
     setMessage('');
     setError('');
     try {
-      await removeAuthorizedUploader(principal);
+      await removeAuthorizedUploader(daoId, principal);
       setMessage('Uploader removed successfully');
       await loadData();
     } catch (err: any) {
@@ -73,7 +73,7 @@ const ManagementAssetsAdmin: React.FC = () => {
     try {
       const maxFile = maxFileSize ? parseInt(maxFileSize, 10) : null;
       const maxTotal = maxTotalStorage ? parseInt(maxTotalStorage, 10) : null;
-      await updateStorageLimits(maxFile, maxTotal);
+      await updateStorageLimits(daoId, maxFile, maxTotal);
       setMessage('Storage limits updated');
       setMaxFileSize('');
       setMaxTotalStorage('');

--- a/src/dao_frontend/src/declarations/assets/assets.did
+++ b/src/dao_frontend/src/declarations/assets/assets.did
@@ -43,7 +43,7 @@ type Asset =
    uploadedBy: principal;
  };
 service : {
- addAuthorizedUploader: ("principal": principal) -> (Result_1);
+ addAuthorizedUploader: (daoId: DaoId, "principal": principal) -> (Result_1);
  batchUploadAssets: (daoId: DaoId, assets_data:
   vec record {
         text;
@@ -56,7 +56,7 @@ service : {
  getAsset: (daoId: DaoId, assetId: AssetId) -> (Result_2);
  getAssetByName: (daoId: DaoId, name: text) -> (opt AssetMetadata) query;
  getAssetMetadata: (daoId: DaoId, assetId: AssetId) -> (opt AssetMetadata) query;
- getAuthorizedUploaders: () -> (vec principal) query;
+ getAuthorizedUploaders: (daoId: DaoId) -> (vec principal) query;
  getPublicAssets: (daoId: DaoId) -> (vec AssetMetadata) query;
  getStorageStats: (daoId: DaoId) ->
   (record {
@@ -75,11 +75,11 @@ service : {
      timestamp: Time;
    }) query;
  init: (initialUploader: opt principal, openUploads: bool) -> ();
- removeAuthorizedUploader: ("principal": principal) -> (Result_1);
+ removeAuthorizedUploader: (daoId: DaoId, "principal": principal) -> (Result_1);
  searchAssetsByTag: (daoId: DaoId, tag: text) -> (vec AssetMetadata) query;
  updateAssetMetadata: (daoId: DaoId, assetId: AssetId, name: opt text, isPublic: opt bool,
   tags: opt vec text) -> (Result_1);
- updateStorageLimits: (maxFileSizeNew: opt nat, maxTotalStorageNew:
+ updateStorageLimits: (daoId: DaoId, maxFileSizeNew: opt nat, maxTotalStorageNew:
   opt nat) -> (Result_1);
  uploadAsset: (daoId: DaoId, name: text, contentType: text, data: AssetData, isPublic:
   bool, tags: vec text) -> (Result);

--- a/src/dao_frontend/src/declarations/assets/assets.did.d.ts
+++ b/src/dao_frontend/src/declarations/assets/assets.did.d.ts
@@ -35,7 +35,7 @@ export type Result_2 = { 'ok' : Asset } |
   { 'err' : string };
 export type Time = bigint;
 export interface _SERVICE {
-  'addAuthorizedUploader' : ActorMethod<[Principal], Result_1>,
+  'addAuthorizedUploader' : ActorMethod<[string, Principal], Result_1>,
   'batchUploadAssets' : ActorMethod<
     [string, Array<[string, string, AssetData, boolean, Array<string>]>],
     Array<Result>
@@ -44,7 +44,7 @@ export interface _SERVICE {
   'getAsset' : ActorMethod<[string, AssetId], Result_2>,
   'getAssetByName' : ActorMethod<[string, string], [] | [AssetMetadata]>,
   'getAssetMetadata' : ActorMethod<[string, AssetId], [] | [AssetMetadata]>,
-  'getAuthorizedUploaders' : ActorMethod<[], Array<Principal>>,
+  'getAuthorizedUploaders' : ActorMethod<[string], Array<Principal>>,
   'getPublicAssets' : ActorMethod<[string], Array<AssetMetadata>>,
   'getStorageStats' : ActorMethod<
     [string],
@@ -63,7 +63,7 @@ export interface _SERVICE {
     { 'status' : string, 'storageUsed' : bigint, 'timestamp' : Time }
   >,
   'init' : ActorMethod<[[] | [Principal], boolean], undefined>,
-  'removeAuthorizedUploader' : ActorMethod<[Principal], Result_1>,
+  'removeAuthorizedUploader' : ActorMethod<[string, Principal], Result_1>,
   'searchAssetsByTag' : ActorMethod<[string, string], Array<AssetMetadata>>,
   'updateAssetMetadata' : ActorMethod<
     [
@@ -75,7 +75,7 @@ export interface _SERVICE {
     ],
     Result_1
   >,
-  'updateStorageLimits' : ActorMethod<[[] | [bigint], [] | [bigint]], Result_1>,
+  'updateStorageLimits' : ActorMethod<[string, [] | [bigint], [] | [bigint]], Result_1>,
   'uploadAsset' : ActorMethod<
     [string, string, string, AssetData, boolean, Array<string>],
     Result

--- a/src/dao_frontend/src/declarations/assets/assets.did.js
+++ b/src/dao_frontend/src/declarations/assets/assets.did.js
@@ -29,7 +29,7 @@ export const idlFactory = ({ IDL }) => {
     'tags' : IDL.Vec(IDL.Text),
   });
   return IDL.Service({
-    'addAuthorizedUploader' : IDL.Func([IDL.Principal], [Result_1], []),
+    'addAuthorizedUploader' : IDL.Func([IDL.Text, IDL.Principal], [Result_1], []),
     'batchUploadAssets' : IDL.Func(
         [
           IDL.Text,
@@ -59,7 +59,7 @@ export const idlFactory = ({ IDL }) => {
         ['query'],
       ),
     'getAuthorizedUploaders' : IDL.Func(
-        [],
+        [IDL.Text],
         [IDL.Vec(IDL.Principal)],
         ['query'],
       ),
@@ -91,7 +91,7 @@ export const idlFactory = ({ IDL }) => {
         ['query'],
       ),
     'init' : IDL.Func([IDL.Opt(IDL.Principal), IDL.Bool], [], []),
-    'removeAuthorizedUploader' : IDL.Func([IDL.Principal], [Result_1], []),
+    'removeAuthorizedUploader' : IDL.Func([IDL.Text, IDL.Principal], [Result_1], []),
     'searchAssetsByTag' : IDL.Func(
         [IDL.Text, IDL.Text],
         [IDL.Vec(AssetMetadata)],
@@ -109,7 +109,7 @@ export const idlFactory = ({ IDL }) => {
         [],
       ),
     'updateStorageLimits' : IDL.Func(
-        [IDL.Opt(IDL.Nat), IDL.Opt(IDL.Nat)],
+        [IDL.Text, IDL.Opt(IDL.Nat), IDL.Opt(IDL.Nat)],
         [Result_1],
         [],
       ),

--- a/src/dao_frontend/src/hooks/useAssets.js
+++ b/src/dao_frontend/src/hooks/useAssets.js
@@ -167,11 +167,11 @@ export const useAssets = () => {
     }
   };
 
-  const getAuthorizedUploaders = async () => {
+  const getAuthorizedUploaders = async (daoId) => {
     setLoading(true);
     setError(null);
     try {
-      const res = await actors.assets.getAuthorizedUploaders();
+      const res = await actors.assets.getAuthorizedUploaders(daoId);
       return res.map((p) => (typeof p.toText === 'function' ? p.toText() : p));
     } catch (err) {
       setError(err.message);
@@ -181,11 +181,12 @@ export const useAssets = () => {
     }
   };
 
-  const addAuthorizedUploader = async (principal) => {
+  const addAuthorizedUploader = async (daoId, principal) => {
     setLoading(true);
     setError(null);
     try {
       const res = await actors.assets.addAuthorizedUploader(
+        daoId,
         Principal.fromText(principal)
       );
       if (res.err) {
@@ -200,11 +201,12 @@ export const useAssets = () => {
     }
   };
 
-  const removeAuthorizedUploader = async (principal) => {
+  const removeAuthorizedUploader = async (daoId, principal) => {
     setLoading(true);
     setError(null);
     try {
       const res = await actors.assets.removeAuthorizedUploader(
+        daoId,
         Principal.fromText(principal)
       );
       if (res.err) {
@@ -220,6 +222,7 @@ export const useAssets = () => {
   };
 
   const updateStorageLimits = async (
+    daoId,
     maxFileSizeNew = null,
     maxTotalStorageNew = null
   ) => {
@@ -227,6 +230,7 @@ export const useAssets = () => {
     setError(null);
     try {
       const res = await actors.assets.updateStorageLimits(
+        daoId,
         maxFileSizeNew === null ? [] : [BigInt(maxFileSizeNew)],
         maxTotalStorageNew === null ? [] : [BigInt(maxTotalStorageNew)]
       );


### PR DESCRIPTION
## Summary
- store authorized uploaders in a per-DAO HashMap
- persist uploader map across upgrades
- expose DAO-aware uploader admin APIs and update frontend hooks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a20f6fedb88320b14e1b701e724043